### PR TITLE
added Consent Flow to demo for iOS

### DIFF
--- a/example/ios/AppLovinMAXExample/Info.plist
+++ b/example/ios/AppLovinMAXExample/Info.plist
@@ -39,6 +39,8 @@
 	</dict>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string></string>
+	<key>NSUserTrackingUsageDescription</key>
+	<string>This only uses device info for more interesting and relevant ads</string>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIRequiredDeviceCapabilities</key>

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -51,13 +51,10 @@ const App = () => {
   const [isNativeUIMRecShowing, setIsNativeUIMRecShowing] = useState(false);
   const [statusText, setStatusText] = useState('Initializing SDK...');
 
-  // Enable the consent flow programmatically, also add
-  // NSUserTrackingUsageDescription to Info.plist
+  // Enable the iOS consent flow programmatically - NSUserTrackingUsageDescription must be added to the Info.plist
   AppLovinMAX.setConsentFlowEnabled(true);
-  // url of private policy - mandatory
-  AppLovinMAX.setPrivacyPolicyUrl('https://your_company_name.com/privacy/');
-  // optional url of terms of service
-  AppLovinMAX.setTermsOfServiceUrl('https://your_company_name.com/terms/');
+  AppLovinMAX.setPrivacyPolicyUrl('https://your_company_name.com/privacy/'); // mandatory
+  AppLovinMAX.setTermsOfServiceUrl('https://your_company_name.com/terms/'); // optional
 
   AppLovinMAX.setTestDeviceAdvertisingIds([]);
   AppLovinMAX.initialize(SDK_KEY, () => {

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -51,6 +51,14 @@ const App = () => {
   const [isNativeUIMRecShowing, setIsNativeUIMRecShowing] = useState(false);
   const [statusText, setStatusText] = useState('Initializing SDK...');
 
+  // Enable the consent flow programmatically, also add
+  // NSUserTrackingUsageDescription to Info.plist
+  AppLovinMAX.setConsentFlowEnabled(true);
+  // url of private policy - mandatory
+  AppLovinMAX.setPrivacyPolicyUrl('https://your_company_name.com/privacy/');
+  // optional url of terms of service
+  AppLovinMAX.setTermsOfServiceUrl('https://your_company_name.com/terms/');
+
   AppLovinMAX.setTestDeviceAdvertisingIds([]);
   AppLovinMAX.initialize(SDK_KEY, () => {
     setIsInitialized(true);


### PR DESCRIPTION
added Consent Flow to demo only for iOS

- verified the consent dialog on start only for the first time
- verified all items checked in the Max Consent Flow section in Mediation Debugger
- verified true or false on 'Has User Consent' in Mediation Debugger depending on selecting allow/not allow in the consent dialog