### PR TITLE
feat/guard_consent_flow_logic_to_run_on_ios_14.5_only

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -51,10 +51,13 @@ const App = () => {
   const [isNativeUIMRecShowing, setIsNativeUIMRecShowing] = useState(false);
   const [statusText, setStatusText] = useState('Initializing SDK...');
 
-  // Enable the iOS consent flow programmatically - NSUserTrackingUsageDescription must be added to the Info.plist
-  AppLovinMAX.setConsentFlowEnabled(true);
-  AppLovinMAX.setPrivacyPolicyUrl('https://your_company_name.com/privacy/'); // mandatory
-  AppLovinMAX.setTermsOfServiceUrl('https://your_company_name.com/terms/'); // optional
+  // MAX Conset Flow for iOS 14.5+
+  if (Platform.OS === 'ios' && parseFloat(Platform.Version) >= 14.5) {
+    // Enable the iOS consent flow programmatically - NSUserTrackingUsageDescription must be added to the Info.plist
+    AppLovinMAX.setConsentFlowEnabled(true);
+    AppLovinMAX.setPrivacyPolicyUrl('https://your_company_name.com/privacy/'); // mandatory
+    AppLovinMAX.setTermsOfServiceUrl('https://your_company_name.com/terms/'); // optional
+  }
 
   AppLovinMAX.setTestDeviceAdvertisingIds([]);
   AppLovinMAX.initialize(SDK_KEY, () => {


### PR DESCRIPTION
- verified Consent Flow to run only on iOS 14.5+
- verified with Android not to run
- verified the platform version works as expected