### PR TITLE
feat/android_show_consent_dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Versions
 
+## x.x.x
+    * Update the example app to demonstrate iOS' Max Consent Flow.
+    * Add API for Android to provide a built-in consent flow that sets the user consent flag.
 ## 3.0.2
     * Lock to Android SDK 11.3.2 and iOS SDK 11.3.2.
 ## 3.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 ## Versions
 
 ## x.x.x
-    * Update the example app to demonstrate iOS' Max Consent Flow.
     * Add API for Android to provide a built-in consent flow that sets the user consent flag.
 ## 3.0.2
     * Lock to Android SDK 11.3.2 and iOS SDK 11.3.2.

--- a/android/src/main/java/com/applovin/reactnative/AppLovinMAXModule.java
+++ b/android/src/main/java/com/applovin/reactnative/AppLovinMAXModule.java
@@ -295,6 +295,25 @@ public class AppLovinMAXModule
         sdk.showMediationDebugger();
     }
 
+    @ReactMethod()
+    public void showConsentDialog(final Callback callback)
+    {
+        if ( sdk == null )
+        {
+            e( "Failed to show consent dialog - please ensure the AppLovin MAX React Native Plugin has been initialized by calling 'AppLovinMAX.initialize();'!" );
+            return;
+        }
+
+        sdk.getUserService().showConsentDialog( maybeGetCurrentActivity(), new AppLovinUserService.OnConsentDialogDismissListener()
+        {
+            @Override
+            public void onDismiss()
+            {
+                callback.invoke();
+            }
+        } );
+    }
+
     @ReactMethod(isBlockingSynchronousMethod = true)
     public int getConsentDialogState()
     {
@@ -313,24 +332,6 @@ public class AppLovinMAXModule
     public boolean hasUserConsent()
     {
         return AppLovinPrivacySettings.hasUserConsent( maybeGetCurrentActivity() );
-    }
-
-    @ReactMethod()
-    public void showConsentDialog(final Callback callback)
-    {
-        Activity currentActivity = maybeGetCurrentActivity();
-        if ( currentActivity == null ) return;
-
-        if ( sdk == null ) return;
-
-        sdk.getUserService().showConsentDialog( currentActivity, new AppLovinUserService.OnConsentDialogDismissListener()
-        {
-            @Override
-            public void onDismiss()
-            {
-                callback.invoke();
-            }
-        } );
     }
 
     @ReactMethod()

--- a/android/src/main/java/com/applovin/reactnative/AppLovinMAXModule.java
+++ b/android/src/main/java/com/applovin/reactnative/AppLovinMAXModule.java
@@ -35,6 +35,7 @@ import com.applovin.sdk.AppLovinSdk;
 import com.applovin.sdk.AppLovinSdkConfiguration;
 import com.applovin.sdk.AppLovinSdkSettings;
 import com.applovin.sdk.AppLovinSdkUtils;
+import com.applovin.sdk.AppLovinUserService;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.Callback;
 import com.facebook.react.bridge.ReactApplicationContext;
@@ -312,6 +313,24 @@ public class AppLovinMAXModule
     public boolean hasUserConsent()
     {
         return AppLovinPrivacySettings.hasUserConsent( maybeGetCurrentActivity() );
+    }
+
+    @ReactMethod()
+    public void showConsentDialog(final Callback callback)
+    {
+        Activity currentActivity = maybeGetCurrentActivity();
+        if ( currentActivity == null ) return;
+
+        if ( sdk == null ) return;
+
+        sdk.getUserService().showConsentDialog( currentActivity, new AppLovinUserService.OnConsentDialogDismissListener()
+        {
+            @Override
+            public void onDismiss()
+            {
+                callback.invoke();
+            }
+        } );
     }
 
     @ReactMethod()

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -51,7 +51,7 @@ const App = () => {
   const [isNativeUIMRecShowing, setIsNativeUIMRecShowing] = useState(false);
   const [statusText, setStatusText] = useState('Initializing SDK...');
 
-  // MAX Conset Flow for iOS 14.5+
+  // MAX Consent Flow for iOS 14.5+
   if (Platform.OS === 'ios' && parseFloat(Platform.Version) >= 14.5) {
     // Enable the iOS consent flow programmatically - NSUserTrackingUsageDescription must be added to the Info.plist
     AppLovinMAX.setConsentFlowEnabled(true);
@@ -64,6 +64,16 @@ const App = () => {
     setIsInitialized(true);
 
     logStatus('SDK Initialized');
+
+    if (Platform.OS === 'android') {
+      // Show a built-in consent dialog that sets the user consent flag for you on Android.
+      // You should check that you actually need to show this consent dialog
+      // by checking the parameter of 'configuration.consentDialogState'
+      // in the completion block of 'AppLovinMAX.initialize'.
+      AppLovinMAX.showConsentDialog(() => {
+        logStatus('Consent dialog closed');
+      });
+    }
 
     // Attach ad listeners for interstitial ads, rewarded ads, and banner ads
     attachAdListeners();

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -60,19 +60,24 @@ const App = () => {
   }
 
   AppLovinMAX.setTestDeviceAdvertisingIds([]);
-  AppLovinMAX.initialize(SDK_KEY, () => {
+  AppLovinMAX.initialize(SDK_KEY, (configuration) => {
     setIsInitialized(true);
 
     logStatus('SDK Initialized');
 
     if (Platform.OS === 'android') {
-      // Show a built-in consent dialog that sets the user consent flag for you on Android.
-      // You should check that you actually need to show this consent dialog
-      // by checking the parameter of 'configuration.consentDialogState'
-      // in the completion block of 'AppLovinMAX.initialize'.
-      AppLovinMAX.showConsentDialog(() => {
-        logStatus('Consent dialog closed');
-      });
+      if (configuration.consentDialogState == AppLovinMAX.ConsentDialogState.APPLIES) {
+        // Show user consent dialog
+        AppLovinMAX.showConsentDialog(() => {
+          logStatus('Consent dialog closed');
+        });
+      } else if (configuration.consentDialogState == AppLovinMAX.ConsentDialogState.DOES_NOT_APPLY) {
+        // No need to show consent dialog, proceed with initialization
+      } else {
+        // Consent dialog state is unknown. Proceed with initialization, but check if the consent
+        // dialog should be shown on the next application initialization
+        // No need to show consent dialog, proceed with initialization
+      }
     }
 
     // Attach ad listeners for interstitial ads, rewarded ads, and banner ads

--- a/ios/AppLovinMAX.m
+++ b/ios/AppLovinMAX.m
@@ -241,6 +241,13 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(hasUserConsent)
     return @([ALPrivacySettings hasUserConsent]);
 }
 
+RCT_EXPORT_METHOD(showConsentDialog:(RCTResponseSenderBlock)callback)
+{
+    [self log: @"Failed to show consent dialog - Unavailable on iOS, please use the consent flow: https://dash.applovin.com/documentation/mediation/react-native/getting-started/consent-flow"];
+
+    callback(nil);
+}
+
 RCT_EXPORT_METHOD(setIsAgeRestrictedUser:(BOOL)isAgeRestrictedUser)
 {
     [ALPrivacySettings setIsAgeRestrictedUser: isAgeRestrictedUser];

--- a/ios/AppLovinMAX.m
+++ b/ios/AppLovinMAX.m
@@ -224,6 +224,13 @@ RCT_EXPORT_METHOD(showMediationDebugger)
     [self.sdk showMediationDebugger];
 }
 
+RCT_EXPORT_METHOD(showConsentDialog:(RCTResponseSenderBlock)callback)
+{
+    [self log: @"Failed to show consent dialog - Unavailable on iOS, please use the consent flow: https://dash.applovin.com/documentation/mediation/react-native/getting-started/consent-flow"];
+
+    callback(nil);
+}
+
 RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(getConsentDialogState)
 {
     if ( ![self isInitialized] ) return @(ALConsentDialogStateUnknown);
@@ -239,13 +246,6 @@ RCT_EXPORT_METHOD(setHasUserConsent:(BOOL)hasUserConsent)
 RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(hasUserConsent)
 {
     return @([ALPrivacySettings hasUserConsent]);
-}
-
-RCT_EXPORT_METHOD(showConsentDialog:(RCTResponseSenderBlock)callback)
-{
-    [self log: @"Failed to show consent dialog - Unavailable on iOS, please use the consent flow: https://dash.applovin.com/documentation/mediation/react-native/getting-started/consent-flow"];
-
-    callback(nil);
 }
 
 RCT_EXPORT_METHOD(setIsAgeRestrictedUser:(BOOL)isAgeRestrictedUser)

--- a/src/index.js
+++ b/src/index.js
@@ -94,6 +94,7 @@ export default {
   /* getConsentDialogState() */
   /* setHasUserConsent(hasUserConsent) */
   /* hasUserConsent() */
+  /* showConsentDialog(callback) */
   /* setIsAgeRestrictedUser(isAgeRestrictedUser) */
   /* isAgeRestrictedUser() */
   /* setDoNotSell(doNotSell) */

--- a/src/index.js
+++ b/src/index.js
@@ -91,10 +91,10 @@ export default {
   /*--------------*/
   /* PRIVACY APIs */
   /*--------------*/
+  /* showConsentDialog(callback) */
   /* getConsentDialogState() */
   /* setHasUserConsent(hasUserConsent) */
   /* hasUserConsent() */
-  /* showConsentDialog(callback) */
   /* setIsAgeRestrictedUser(isAgeRestrictedUser) */
   /* isAgeRestrictedUser() */
   /* setDoNotSell(doNotSell) */


### PR DESCRIPTION
added showConsentDialog() for Android

- Verified to run this on both Android and iOS, on Android, the consent dialog is shown, on iOS, the error message is printed in the log console
- Added a subtask for the doc update