### PR TITLE
feat/advanced_placement_apis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Versions
 
+## x.x.x
+    * Add support for segment name.
+    * Add support for impression-level user revenue api.
+    * Add support for waterfall information api.
+    * Add support for custom data.
 ## 3.1.0
     * Add support for data passing.
     * Add API for Android to provide a built-in consent flow that sets the user consent flag.

--- a/android/src/main/java/com/applovin/reactnative/AppLovinMAXAdView.java
+++ b/android/src/main/java/com/applovin/reactnative/AppLovinMAXAdView.java
@@ -74,7 +74,7 @@ class AppLovinMAXAdView
         return adView;
     }
 
-    public void maybeAttachAdView(final String placement, final String adaptiveBannerEnabledStr, final String adUnitId, final MaxAdFormat adFormat)
+    public void maybeAttachAdView(final String placement, final String customData, final String adaptiveBannerEnabledStr, final String adUnitId, final MaxAdFormat adFormat)
     {
         final Activity currentActivity = reactContext.getCurrentActivity();
         if ( currentActivity == null )
@@ -94,10 +94,16 @@ class AppLovinMAXAdView
                 {
                     adView = new MaxAdView( adUnitId, adFormat, AppLovinMAXModule.getInstance().getSdk(), currentActivity );
                     adView.setListener( AppLovinMAXModule.getInstance() );
+                    adView.setRevenueListener( AppLovinMAXModule.getInstance() );
 
                     if ( placement != null )
                     {
                         adView.setPlacement( placement );
+                    }
+
+                    if ( customData != null )
+                    {
+                        adView.setCustomData( customData );
                     }
 
                     if ( adaptiveBannerEnabledStr != null )

--- a/android/src/main/java/com/applovin/reactnative/AppLovinMAXAdViewManager.java
+++ b/android/src/main/java/com/applovin/reactnative/AppLovinMAXAdViewManager.java
@@ -31,6 +31,7 @@ class AppLovinMAXAdViewManager
 
     // Storage for placement and extra parameters if set before the MAAdView is created
     private final Map<AppLovinMAXAdView, String> placementRegistry             = new HashMap<>();
+    private final Map<AppLovinMAXAdView, String> customDataRegistry            = new HashMap<>();
     private final Map<AppLovinMAXAdView, String> adaptiveBannerEnabledRegistry = new HashMap<>();
 
     public AppLovinMAXAdViewManager(final ReactApplicationContext reactApplicationContext)
@@ -63,6 +64,10 @@ class AppLovinMAXAdViewManager
         {
             setPlacement( view, arg );
         }
+        else if ( "setCustomData".equals( commandId ) )
+        {
+            setCustomData( view, arg );
+        }
         else if ( "setAdaptiveBannerEnabled".equals( commandId ) )
         {
             setAdaptiveBannerEnabled( view, arg );
@@ -94,6 +99,23 @@ class AppLovinMAXAdViewManager
             else
             {
                 placementRegistry.put( view, placement );
+            }
+        } );
+    }
+
+    public void setCustomData(final AppLovinMAXAdView view, final String customData)
+    {
+        // Post to main thread to avoid race condition with actual creation of MaxAdView in maybeAttachAdView()
+        view.post( () -> {
+
+            MaxAdView adView = view.getAdView();
+            if ( adView != null )
+            {
+                adView.setCustomData( customData );
+            }
+            else
+            {
+                customDataRegistry.put( view, customData );
             }
         } );
     }
@@ -138,9 +160,11 @@ class AppLovinMAXAdViewManager
     private void maybeAttachAdView(final AppLovinMAXAdView view)
     {
         String placement = placementRegistry.remove( view );
+        String customData = customDataRegistry.remove( view );
         String adaptiveBannerEnabledStr = adaptiveBannerEnabledRegistry.remove( view );
 
         view.maybeAttachAdView( placement,
+                                customData,
                                 adaptiveBannerEnabledStr,
                                 adUnitIdRegistry.get( view ),
                                 adFormatRegistry.get( view ) );

--- a/android/src/main/java/com/applovin/reactnative/AppLovinMAXModule.java
+++ b/android/src/main/java/com/applovin/reactnative/AppLovinMAXModule.java
@@ -1117,9 +1117,9 @@ public class AppLovinMAXModule
         }
 
         WritableMap adInfo = getAdInfo( ad );
-        adInfo.putString( "networkPlacement", !TextUtils.isEmpty( ad.getNetworkPlacement() ) ? ad.getNetworkPlacement() : "" );
-        adInfo.putString( "revenuePrecision", !TextUtils.isEmpty( ad.getRevenuePrecision() ) ? ad.getRevenuePrecision() : "" );
-        adInfo.putString( "countryCode", !TextUtils.isEmpty( sdkConfiguration.getCountryCode() ) ? sdkConfiguration.getCountryCode() : "" );
+        adInfo.putString( "networkPlacement", ad.getNetworkPlacement() );
+        adInfo.putString( "revenuePrecision", ad.getRevenuePrecision() );
+        adInfo.putString( "countryCode", sdkConfiguration.getCountryCode() );
 
         sendReactNativeEvent( name, adInfo );
     }
@@ -1798,13 +1798,13 @@ public class AppLovinMAXModule
     private WritableMap getWaterfallInfo(final MaxAdWaterfallInfo waterfallInfo)
     {
         WritableMap waterfall = Arguments.createMap();
-        waterfall.putString( "name", !TextUtils.isEmpty( waterfallInfo.getName() ) ? waterfallInfo.getName() : "" );
-        waterfall.putString( "testName", !TextUtils.isEmpty( waterfallInfo.getTestName() ) ? waterfallInfo.getTestName() : "" );
+        waterfall.putString( "name", waterfallInfo.getName() );
+        waterfall.putString( "testName", waterfallInfo.getTestName() );
         // use putDouble since there is no putLong available
         waterfall.putDouble( "latencyMillis", waterfallInfo.getLatencyMillis() );
 
         List<MaxNetworkResponseInfo> responseInfoList = waterfallInfo.getNetworkResponses();
-        if ( responseInfoList != null && !responseInfoList.isEmpty() )
+        if ( !responseInfoList.isEmpty() )
         {
             WritableArray responses = Arguments.createArray();
             for ( MaxNetworkResponseInfo response : responseInfoList )
@@ -1815,10 +1815,10 @@ public class AppLovinMAXModule
                 if ( mediatedNetworkInfo != null )
                 {
                     WritableMap mediatedNetwork = Arguments.createMap();
-                    mediatedNetwork.putString( "name", !TextUtils.isEmpty( mediatedNetworkInfo.getName() ) ? mediatedNetworkInfo.getName() : "" );
-                    mediatedNetwork.putString( "adapterClassName", !TextUtils.isEmpty( mediatedNetworkInfo.getAdapterClassName() ) ? mediatedNetworkInfo.getAdapterClassName() : "" );
-                    mediatedNetwork.putString( "adapterVersion", !TextUtils.isEmpty( mediatedNetworkInfo.getAdapterVersion() ) ? mediatedNetworkInfo.getAdapterVersion() : "" );
-                    mediatedNetwork.putString( "sdkVersion", !TextUtils.isEmpty( mediatedNetworkInfo.getSdkVersion() ) ? mediatedNetworkInfo.getSdkVersion() : "" );
+                    mediatedNetwork.putString( "name", mediatedNetworkInfo.getName() );
+                    mediatedNetwork.putString( "adapterClassName", mediatedNetworkInfo.getAdapterClassName() );
+                    mediatedNetwork.putString( "adapterVersion", mediatedNetworkInfo.getAdapterVersion() );
+                    mediatedNetwork.putString( "sdkVersion", mediatedNetworkInfo.getSdkVersion() );
                     responseInfo.putMap( "mediatedNetwork", mediatedNetwork );
                 }
 
@@ -1827,7 +1827,7 @@ public class AppLovinMAXModule
                 responseInfo.putDouble( "latencyMillis", response.getLatencyMillis() );
 
                 Bundle credentialBundle = response.getCredentials();
-                if ( credentialBundle != null )
+                if ( !credentialBundle.isEmpty() )
                 {
                     WritableMap credentials = Arguments.createMap();
                     for ( String key : credentialBundle.keySet() )
@@ -1843,7 +1843,7 @@ public class AppLovinMAXModule
                 {
                     WritableMap error = Arguments.createMap();
                     error.putInt( "code", maxError.getCode() );
-                    error.putString( "message", !TextUtils.isEmpty( maxError.getMessage() ) ? maxError.getMessage() : "" );
+                    error.putString( "message", maxError.getMessage() );
                     MaxAdWaterfallInfo errorWaterfall = maxError.getWaterfall();
                     if ( errorWaterfall != null )
                     {
@@ -1857,6 +1857,7 @@ public class AppLovinMAXModule
 
             waterfall.putArray( "networkResponses", responses );
         }
+
         return waterfall;
     }
 

--- a/ios/AppLovinMAX.h
+++ b/ios/AppLovinMAX.h
@@ -19,7 +19,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * The primary bridge between JS <-> native code for the AppLovin MAX React Native module.
  */
-@interface AppLovinMAX : RCTEventEmitter<RCTBridgeModule, MAAdDelegate, MARewardedAdDelegate, MAAdViewAdDelegate>
+@interface AppLovinMAX : RCTEventEmitter<RCTBridgeModule, MAAdRevenueDelegate, MAAdDelegate, MARewardedAdDelegate, MAAdViewAdDelegate>
 
 /**
  * Shared instance of this bridge module.

--- a/ios/AppLovinMAX.m
+++ b/ios/AppLovinMAX.m
@@ -902,9 +902,9 @@ RCT_EXPORT_METHOD(setRewardedAdExtraParameter:(NSString *)adUnitIdentifier :(NSS
     }
     
     NSMutableDictionary *body = [self adInfoForAd: ad].mutableCopy;
-    body[@"networkPlacement"] = ad.networkPlacement ?: @"";
-    body[@"revenuePrecision"] = ad.revenuePrecision ?: @"";
-    body[@"countryCode"] = self.sdk.configuration.countryCode ?: @"";
+    body[@"networkPlacement"] = ad.networkPlacement;
+    body[@"revenuePrecision"] = ad.revenuePrecision;
+    body[@"countryCode"] = self.sdk.configuration.countryCode;
 
     [self sendReactNativeEventWithName: name body: body];
 }
@@ -1400,8 +1400,8 @@ RCT_EXPORT_METHOD(setRewardedAdExtraParameter:(NSString *)adUnitIdentifier :(NSS
 - (NSDictionary<NSString *, id> *)getWaterallInfo:(nonnull MAAdWaterfallInfo *)waterfallInfo
 {
     NSMutableDictionary *waterfall = [[NSMutableDictionary alloc] init];
-    waterfall[@"name"] = waterfallInfo.name ?: @"";
-    waterfall[@"testName"] = waterfallInfo.testName ?: @"";
+    waterfall[@"name"] = waterfallInfo.name;
+    waterfall[@"testName"] = waterfallInfo.testName;
     
     // latency is defined as NSTimeInterval, a typealias for double, but
     // since latencyMillis in Android is defined as long(64 bit integer), 
@@ -1410,7 +1410,7 @@ RCT_EXPORT_METHOD(setRewardedAdExtraParameter:(NSString *)adUnitIdentifier :(NSS
     NSNumber* latencyMillis = [NSNumber numberWithDouble: (waterfallInfo.latency * 1000)];
     waterfall[@"latencyMillis"] = (latencyMillis.longLongValue == -1000) ? @(-1) : @(latencyMillis.longLongValue);
 
-    if (waterfallInfo.networkResponses && waterfallInfo.networkResponses.count > 0)
+    if (waterfallInfo.networkResponses.count > 0)
     {
         NSMutableArray *responses = [[NSMutableArray alloc] init];
 
@@ -1418,22 +1418,19 @@ RCT_EXPORT_METHOD(setRewardedAdExtraParameter:(NSString *)adUnitIdentifier :(NSS
         {
             NSMutableDictionary *responseInfo = [[NSMutableDictionary alloc] init];
 
-            if (response.mediatedNetwork)
-            {
-                NSMutableDictionary *mediateNetwork = [[NSMutableDictionary alloc] init];
-                mediateNetwork[@"name"] = response.mediatedNetwork.name ?: @"";
-                mediateNetwork[@"adapterClassName"] = response.mediatedNetwork.adapterClassName ?: @"";
-                mediateNetwork[@"adapterVersion"] = response.mediatedNetwork.adapterVersion ?: @"";
-                mediateNetwork[@"sdkVersion"] = response.mediatedNetwork.sdkVersion ?: @"";
-                responseInfo[@"mediatedNetwork"] = mediateNetwork;
-            }
+            NSMutableDictionary *mediateNetwork = [[NSMutableDictionary alloc] init];
+            mediateNetwork[@"name"] = response.mediatedNetwork.name;
+            mediateNetwork[@"adapterClassName"] = response.mediatedNetwork.adapterClassName;
+            mediateNetwork[@"adapterVersion"] = response.mediatedNetwork.adapterVersion;
+            mediateNetwork[@"sdkVersion"] = response.mediatedNetwork.sdkVersion;
+            responseInfo[@"mediatedNetwork"] = mediateNetwork;
 
             NSNumber* latencyMillis = [NSNumber numberWithDouble: (response.latency * 1000)];
             responseInfo[@"latencyMillis"] = (latencyMillis.longLongValue == -1000) ? @(-1) : @(latencyMillis.longLongValue);
 
             responseInfo[@"adLoadState"] = @((int) response.adLoadState);
 
-            if (response.credentials)
+            if (response.credentials.count > 0)
             {
                 NSMutableDictionary *credentials = [[NSMutableDictionary<NSString *, NSString *> alloc] init];
                 for (NSString *key in response.credentials)
@@ -1448,7 +1445,7 @@ RCT_EXPORT_METHOD(setRewardedAdExtraParameter:(NSString *)adUnitIdentifier :(NSS
             {
                 NSMutableDictionary *error = [[NSMutableDictionary alloc] init];
                 error[@"code"] = @(response.error.code);
-                error[@"message"] = response.error.message ?: @"";
+                error[@"message"] = response.error.message;
                 if (response.error.waterfall)
                 {
                     error[@"waterfall"] = [self getWaterallInfo:response.error.waterfall];

--- a/src/AppLovinMAXAdView.js
+++ b/src/AppLovinMAXAdView.js
@@ -13,6 +13,7 @@ class AdView extends React.Component {
     this.setAdUnitId(this.props.adUnitId);
     this.setAdFormat(this.props.adFormat);
     this.setPlacement(this.props.placement);
+    this.setCustomData(this.props.customData);
     this.setAdaptiveBannerEnabled(this.props.adaptiveBannerEnabled);
   }
 
@@ -28,6 +29,10 @@ class AdView extends React.Component {
 
     if (prevProps.placement !== this.props.placement) {
       this.setPlacement(this.props.placement);
+    }
+
+    if (prevProps.customData !== this.props.customData) {
+      this.setCustomData(this.props.customData);
     }
 
     if (prevProps.adaptiveBannerEnabled !== this.props.adaptiveBannerEnabled) {
@@ -94,6 +99,20 @@ class AdView extends React.Component {
     );
   }
 
+  setCustomData(customData) {
+    var adUnitId = this.props.adUnitId;
+    var adFormat = this.props.adFormat;
+
+    // If the ad unit id or ad format are unset, we can't set the customData.
+    if (adUnitId == null || adFormat == null) return;
+
+    UIManager.dispatchViewManagerCommand(
+        findNodeHandle(this),
+        Platform.OS === 'android' ? "setCustomData" : UIManager.getViewManagerConfig("AppLovinMAXAdView").Commands.setCustomData,
+        [customData]
+    );
+  }
+
   setAdaptiveBannerEnabled(enabled) {
     var adUnitId = this.props.adUnitId;
     var adFormat = this.props.adFormat;
@@ -128,6 +147,11 @@ AdView.propTypes = {
    * A string value representing the placement name that you assign when you integrate each ad format, for granular reporting in ad events.
    */
   placement: PropTypes.string,
+
+  /**
+   * A string value representing the customData name that you assign when you integrate each ad format, for granular reporting in ad events.
+   */
+  customData: PropTypes.string,
 
   /**
    * A boolean value representing whether or not to enable adaptive banners. Note that adaptive banners are enabled by default as of v2.3.0.

--- a/src/UserSegment.js
+++ b/src/UserSegment.js
@@ -1,0 +1,12 @@
+import AppLovinMAX from "./index.js";
+
+let UserSegment = {
+
+  set name(value) {
+    AppLovinMAX.setUserSegmentField(value);
+  },
+};
+
+export {
+  UserSegment,
+};

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 import { NativeModules, NativeEventEmitter } from "react-native";
 import AdView from "./AppLovinMAXAdView";
 import { TargetingData as targetingData, AdContentRating, UserGender } from "./TargetingData";
+import { UserSegment as userSegment } from "./UserSegment";
 
 const { AppLovinMAX } = NativeModules;
 
@@ -65,6 +66,30 @@ const removeEventListener = (event) => {
   }
 };
 
+const showInterstitial = (adUnitIdentifier, placement, customData) => {
+  if (placement !== undefined && customData !== undefined) {
+	AppLovinMAX.showInterstitial(adUnitIdentifier, placement, customData);
+  } else if (placement !== undefined) {
+	AppLovinMAX.showInterstitial(adUnitIdentifier, placement, null);
+  } else if (customData !== undefined) {
+	AppLovinMAX.showInterstitial(adUnitIdentifier, null, customData);
+  } else {
+	AppLovinMAX.showInterstitial(adUnitIdentifier, null, null);
+  }
+};
+
+const showRewardedAd = (adUnitIdentifier, placement, customData) => {
+  if (placement !== undefined && customData !== undefined) {
+	AppLovinMAX.showRewardedAd(adUnitIdentifier, placement, customData);
+  } else if (placement !== undefined) {
+	AppLovinMAX.showRewardedAd(adUnitIdentifier, placement, null);
+  } else if (customData !== undefined) {
+	AppLovinMAX.showRewardedAd(adUnitIdentifier, null, customData);
+  } else {
+	AppLovinMAX.showRewardedAd(adUnitIdentifier, null, null);
+  }
+};
+
 export default {
   ...AppLovinMAX,
   AdView,
@@ -80,6 +105,9 @@ export default {
   initialize(sdkKey, callback) {
     AppLovinMAX.initialize(VERSION, sdkKey, callback); // Inject VERSION into native code
   },
+  userSegment,
+  showInterstitial,
+  showRewardedAd,
 
   /*----------------------*/
   /** AUTO-DECLARED APIs **/

--- a/src/index.js
+++ b/src/index.js
@@ -66,33 +66,44 @@ const removeEventListener = (event) => {
   }
 };
 
-const showInterstitial = (adUnitIdentifier, placement, customData) => {
-  if (placement !== undefined && customData !== undefined) {
-	AppLovinMAX.showInterstitial(adUnitIdentifier, placement, customData);
-  } else if (placement !== undefined) {
-	AppLovinMAX.showInterstitial(adUnitIdentifier, placement, null);
-  } else if (customData !== undefined) {
-	AppLovinMAX.showInterstitial(adUnitIdentifier, null, customData);
-  } else {
-	AppLovinMAX.showInterstitial(adUnitIdentifier, null, null);
+const showInterstitial = (adUnitId, ...args) => {
+  switch (args.length) {
+  case 0:
+    AppLovinMAX.showInterstitial(adUnitId, null, null);
+    break;
+  case 1:
+    AppLovinMAX.showInterstitial(adUnitId, args[0], null);
+    break;
+  case 2:
+    AppLovinMAX.showInterstitial(adUnitId, args[0], args[1]);
+    break;
+  default:
+    // do nothing - unexpected number of arguments
+    break;
   }
 };
 
-const showRewardedAd = (adUnitIdentifier, placement, customData) => {
-  if (placement !== undefined && customData !== undefined) {
-	AppLovinMAX.showRewardedAd(adUnitIdentifier, placement, customData);
-  } else if (placement !== undefined) {
-	AppLovinMAX.showRewardedAd(adUnitIdentifier, placement, null);
-  } else if (customData !== undefined) {
-	AppLovinMAX.showRewardedAd(adUnitIdentifier, null, customData);
-  } else {
-	AppLovinMAX.showRewardedAd(adUnitIdentifier, null, null);
+const showRewardedAd = (adUnitId, ...args) => {
+  switch (args.length) {
+  case 0:
+    AppLovinMAX.showRewardedAd(adUnitId, null, null);
+    break;
+  case 1:
+    AppLovinMAX.showRewardedAd(adUnitId, args[0], null);
+    break;
+  case 2:
+    AppLovinMAX.showRewardedAd(adUnitId, args[0], args[1]);
+    break;
+  default:
+    // do nothing - unexpected number of arguments
+    break;
   }
 };
 
 export default {
   ...AppLovinMAX,
   AdView,
+  userSegment,
   targetingData,
   AdContentRating,
   UserGender,
@@ -105,7 +116,6 @@ export default {
   initialize(sdkKey, callback) {
     AppLovinMAX.initialize(VERSION, sdkKey, callback); // Inject VERSION into native code
   },
-  userSegment,
   showInterstitial,
   showRewardedAd,
 


### PR DESCRIPTION
**Added the advanced placement APIs:**

1. Segment Name
2. Impression-Level User Revenue API
3. Waterfall Information API
4. Custom Data

**Details**

**1. Segment Name**

`AppLovinMAX.userSegment.name = 'myusersegment'`

Verified in the mediate request for both iOS and android

```
"app_info": {
  "user_segment_name": "myusersegment",
},
```

**2. Impression-Level User Revenue API**

```
OnInterstitialAdRevenuePaid
OnRewardedAdRevenuePaid
OnMRecAdLoadedEvent
OnBannerAdRevenuePaid
```

Verified in the app logs on both platforms with all the ad types, also with the native banner and MREC.

```
{
   "networkName":"AppLovin",
   "revenue":0.012777527809143065,
   "placement":"",
   "adUnitId":"072b1be38502cea2",
   "creativeId":"12192278",
   "revenuePrecision":"exact",
   "networkPlacement":"inter_videoa",
   "countryCode":"JP"
}
```

**3. Waterfall Information API**

The DSP name looks renamed or removed.   Is it ‘networkPlacement”? 

The Waterfall info is nice to have, but since I’m not able to test all cases, especially the recursive waterfalls in the error response, I think it’s okay not to have it in RN.

The output of the loaded adInfo in the JSON format:

```
{
   "waterfall":{
      "latencyMillis":2793,
      "testName":"Control",
      "networkResponses":[
         {
            "error":{
               "message":"",
               "code":204
            },
            "credentials":{
               "custom_network_name":"i-mobile_AOS",
               "placement_id":"i-mobile aos banner"
            },
            "latencyMillis":1555,
            "adLoadState":2,
            "mediatedNetwork":{
               "sdkVersion":"11.3.2",
               "adapterVersion":"11.3.2",
               "adapterClassName":"com.applovin.mediation.adapters.AppLovinMediationAdapter",
               "name":"AppLovin"
            }
         },
         {
            "error":{
               "message":"Ad Not Ready",
               "code":-5205
            },
            "credentials":{
               "always_reward_user":"true",
               "placement_id":"381026",
               "app_id":"19502316"
            },
            "latencyMillis":162,
            "adLoadState":2,
            "mediatedNetwork":{
               "sdkVersion":"2.4.20211029",
               "adapterVersion":"2021.10.29.2",
               "adapterClassName":"com.applovin.mediation.adapters.LineMediationAdapter",
               "name":"LINE"
            }
         },
         {
            "error":{
               "message":"Ad Not Ready",
               "code":-5205
            },
            "credentials":{
               "always_reward_user":"true",
               "placement_id":"125130",
               "app_id":"19502316"
            },
            "latencyMillis":140,
            "adLoadState":2,
            "mediatedNetwork":{
               "sdkVersion":"2.4.20211029",
               "adapterVersion":"2021.10.29.2",
               "adapterClassName":"com.applovin.mediation.adapters.LineMediationAdapter",
               "name":"LINE"
            }
         },
         {
            "error":{
               "message":"WebView Error",
               "code":-5212
            },
            "credentials":{
               "placement_id":"BN_0_9",
               "game_id":"3747425"
            },
            "latencyMillis":25,
            "adLoadState":2,
            "mediatedNetwork":{
               "sdkVersion":"4.2.1",
               "adapterVersion":"4.2.1.0",
               "adapterClassName":"com.applovin.mediation.adapters.UnityAdsMediationAdapter",
               "name":"Unity Ads"
            }
         },
         {
            "error":{
               "message":"Ad Not Ready",
               "code":-5205
            },
            "credentials":{
               "always_reward_user":"true",
               "placement_id":"872167",
               "app_id":"19502316"
            },
            "latencyMillis":275,
            "adLoadState":2,
            "mediatedNetwork":{
               "sdkVersion":"2.4.20211029",
               "adapterVersion":"2021.10.29.2",
               "adapterClassName":"com.applovin.mediation.adapters.LineMediationAdapter",
               "name":"LINE"
            }
         },
         {
            "error":{
               "message":"Ad Not Ready",
               "code":-5205
            },
            "credentials":{
               "always_reward_user":"true",
               "placement_id":"630391",
               "app_id":"19502316"
            },
            "latencyMillis":291,
            "adLoadState":2,
            "mediatedNetwork":{
               "sdkVersion":"2.4.20211029",
               "adapterVersion":"2021.10.29.2",
               "adapterClassName":"com.applovin.mediation.adapters.LineMediationAdapter",
               "name":"LINE"
            }
         },
         {
            "credentials":{
               "placement_id":"980034018",
               "app_id":"5098961"
            },
            "latencyMillis":337,
            "adLoadState":1,
            "mediatedNetwork":{
               "sdkVersion":"4.3.0.9",
               "adapterVersion":"4.3.0.9.0",
               "adapterClassName":"com.applovin.mediation.adapters.ByteDanceMediationAdapter",
               "name":"Pangle"
            }
         },
         {
            "credentials":{
               "placement_id":"997708",
               "api_key":"72ec5e53431fca745877589a194e4d4a2884ec07"
            },
            "latencyMillis":-1,
            "adLoadState":0,
            "mediatedNetwork":{
               "sdkVersion":"",
               "adapterVersion":"8.0.1.1",
               "adapterClassName":"com.applovin.mediation.adapters.NendMediationAdapter",
               "name":"Nend"
            }
         },
         {
            "credentials":{
               "placement_id":"340439",
               "app_key":"d0fc76c3fa051e331f0428c552343e9a",
               "app_id":"133990"
            },
            "latencyMillis":-1,
            "adLoadState":0,
            "mediatedNetwork":{
               "sdkVersion":"MAL_16.1.11",
               "adapterVersion":"16.1.11.2",
               "adapterClassName":"com.applovin.mediation.adapters.MintegralMediationAdapter",
               "name":"Mintegral"
            }
         },
         {
            "credentials":{
               "placement_id":"banner_regular"
            },
            "latencyMillis":-1,
            "adLoadState":0,
            "mediatedNetwork":{
               "sdkVersion":"11.3.2",
               "adapterVersion":"11.3.2",
               "adapterClassName":"com.applovin.mediation.adapters.AppLovinMediationAdapter",
               "name":"AppLovin"
            }
         }
      ],
      "name":"Default Waterfall"
   },
   "adUnitId":"0fc2e4b84771d777",
   "placement":"",
   "revenue":0.00012711,
   "networkName":"Pangle",
   "creativeId":"1d6369224f7a2ae964f5d674e77d5bbbb5337d16u8194"
}

```

The output of the error adInfo in the JSON format:

```
{
   "code":204,
   "adLoadFailureInfo":"",
   "message":"MAX returned no eligible ads from any mediated networks for this app/device.",
   "waterfall":{
      "testName":"",
      "latencyMillis":1,
      "name":""
   },
   "adUnitId":"16b9017b667b2d720"
}
```

**4. Custom Data**

The new APIs are:

```
AppLovinMAX.showInterstitial(adUnitId, placement, customData)
AppLovinMAX.showRewardedAd(adUnitId, placement, customData)
AppLovinMAX.setBannerCustomData(adUnitId, customData)
AppLovinMAX.setMRecCustomData(adUnitId, customData)
```

The native API is:

```
 <AppLovinMAX.AdView adUnitId={BANNER_AD_UNIT_ID}
                                   adFormat={AppLovinMAX.AdFormat.BANNER} 
                                   customData='banner_native_customdata'
                                   style={styles.banner}/>
```

The new APIs will deprecate these APIs - 

```
AppLovinMAX.showInterstitialWithPlacement(adUnitId, placement)
AppLovinMAX.showRewardedAdWithPlacement(adUnitId, placement)
```

Verified in the app logs on both platforms with all the ad types, also with the native banner and MREC.


