### PR TITLE
feat/segment_name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Versions
 
 ## x.x.x
-    * Add support for segment name.
+    * Add support for setting user segment via `AppLovinMAX.userSegment.name`.
 ## 3.1.0
     * Add support for data passing.
     * Add API for Android to provide a built-in consent flow that sets the user consent flag.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Versions
 
+## x.x.x
+    * Add support for segment name.
 ## 3.1.0
     * Add support for data passing.
     * Add API for Android to provide a built-in consent flow that sets the user consent flag.

--- a/android/src/main/java/com/applovin/reactnative/AppLovinMAXModule.java
+++ b/android/src/main/java/com/applovin/reactnative/AppLovinMAXModule.java
@@ -452,6 +452,18 @@ public class AppLovinMAXModule
      // Data Passing
 
     @ReactMethod()
+    public void setUserSegmentField(final String name)
+    {
+        if ( sdk == null )
+        {
+            logUninitializedAccessError( "setUserSegmentField" );
+            return;
+        }
+
+        sdk.getUserSegment().setName( name );
+    }
+
+    @ReactMethod()
     public void setTargetingDataYearOfBirth(final int yearOfBirth)
     {
         if ( sdk == null )

--- a/android/src/main/java/com/applovin/reactnative/AppLovinMAXModule.java
+++ b/android/src/main/java/com/applovin/reactnative/AppLovinMAXModule.java
@@ -452,11 +452,11 @@ public class AppLovinMAXModule
      // Data Passing
 
     @ReactMethod()
-    public void setUserSegmentField(final String name)
+    public void setUserSegment(final String name)
     {
         if ( sdk == null )
         {
-            logUninitializedAccessError( "setUserSegmentField" );
+            logUninitializedAccessError( "setUserSegment" );
             return;
         }
 

--- a/ios/AppLovinMAX.m
+++ b/ios/AppLovinMAX.m
@@ -351,11 +351,11 @@ RCT_EXPORT_METHOD(setTermsOfServiceUrl:(NSString *)urlString)
 
 #pragma mark - Data Passing
 
-RCT_EXPORT_METHOD(setUserSegmentField:(nullable NSString *)name)
+RCT_EXPORT_METHOD(setUserSegment:(nullable NSString *)name)
 {
     if ( !_sdk )
     {
-        [self logUninitializedAccessError: @"setUserSegmentField"];
+        [self logUninitializedAccessError: @"setUserSegment"];
         return;
     }
 

--- a/ios/AppLovinMAX.m
+++ b/ios/AppLovinMAX.m
@@ -351,6 +351,17 @@ RCT_EXPORT_METHOD(setTermsOfServiceUrl:(NSString *)urlString)
 
 #pragma mark - Data Passing
 
+RCT_EXPORT_METHOD(setUserSegmentField:(nullable NSString *)name)
+{
+    if ( !_sdk )
+    {
+        [self logUninitializedAccessError: @"setUserSegmentField"];
+        return;
+    }
+
+    self.sdk.userSegment.name = name;
+}
+
 RCT_EXPORT_METHOD(setTargetingDataYearOfBirth:(nonnull NSNumber *)yearOfBirth)
 {
     if ( !_sdk )

--- a/src/UserSegment.js
+++ b/src/UserSegment.js
@@ -1,0 +1,12 @@
+import AppLovinMAX from "./index.js";
+
+let UserSegment = {
+
+  set name(value) {
+    AppLovinMAX.setUserSegmentField(value);
+  },
+};
+
+export {
+  UserSegment,
+};

--- a/src/UserSegment.js
+++ b/src/UserSegment.js
@@ -3,7 +3,7 @@ import AppLovinMAX from "./index.js";
 let UserSegment = {
 
   set name(value) {
-    AppLovinMAX.setUserSegmentField(value);
+    AppLovinMAX.setUserSegment(value);
   },
 };
 

--- a/src/index.js
+++ b/src/index.js
@@ -124,7 +124,6 @@ export default {
   /*----------------*/
   /* DATA PASSING */
   /*----------------*/
-  /* setUserSegmentField(name) */
   /* setTargetingDataYearOfBirth(yearOfBirth) */
   /* setTargetingDataGender(gender) */
   /* setTargetingDataMaximumAdContentRating(maximumAdContentRating) */

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 import { NativeModules, NativeEventEmitter } from "react-native";
 import AdView from "./AppLovinMAXAdView";
 import { TargetingData as targetingData, AdContentRating, UserGender } from "./TargetingData";
+import { UserSegment as userSegment } from "./UserSegment";
 
 const { AppLovinMAX } = NativeModules;
 
@@ -68,6 +69,7 @@ const removeEventListener = (event) => {
 export default {
   ...AppLovinMAX,
   AdView,
+  userSegment,
   targetingData,
   AdContentRating,
   UserGender,
@@ -118,6 +120,19 @@ export default {
   /* setPrivacyPolicyUrl(urlString) */
   /* setTermsOfServiceUrl(urlString) */
   /* setLocationCollectionEnabled(locationCollectionEnabled) */
+
+  /*----------------*/
+  /* DATA PASSING */
+  /*----------------*/
+  /* setUserSegmentField(name) */
+  /* setTargetingDataYearOfBirth(yearOfBirth) */
+  /* setTargetingDataGender(gender) */
+  /* setTargetingDataMaximumAdContentRating(maximumAdContentRating) */
+  /* setTargetingDataEmail(email) */
+  /* setTargetingDataPhoneNumber(phoneNumber) */
+  /* setTargetingDataKeywords(keywords) */
+  /* setTargetingDataInterests(interests) */
+  /* clearAllTargetingData() */
 
   /*----------------*/
   /* EVENT TRACKING */


### PR DESCRIPTION
Added support for segment name.   The api is:

```
AppLovinMAX.userSegment.name = 'myusersegment';
```

Verified in the mediate request for both iOS and android

```
"app_info": {
  "user_segment_name": "myusersegment",
},
```
