### PR TITLE
feat/user_revenue_api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Versions
 
+## x.x.x
+    * Add support for impression-level user revenue api.
 ## 3.1.0
     * Add support for data passing.
     * Add API for Android to provide a built-in consent flow that sets the user consent flag.

--- a/android/src/main/java/com/applovin/reactnative/AppLovinMAXAdView.java
+++ b/android/src/main/java/com/applovin/reactnative/AppLovinMAXAdView.java
@@ -94,6 +94,7 @@ class AppLovinMAXAdView
                 {
                     adView = new MaxAdView( adUnitId, adFormat, AppLovinMAXModule.getInstance().getSdk(), currentActivity );
                     adView.setListener( AppLovinMAXModule.getInstance() );
+                    adView.setRevenueListener( AppLovinMAXModule.getInstance() );
 
                     if ( placement != null )
                     {

--- a/android/src/main/java/com/applovin/reactnative/AppLovinMAXModule.java
+++ b/android/src/main/java/com/applovin/reactnative/AppLovinMAXModule.java
@@ -21,6 +21,7 @@ import android.widget.RelativeLayout;
 import com.applovin.mediation.MaxAd;
 import com.applovin.mediation.MaxAdFormat;
 import com.applovin.mediation.MaxAdListener;
+import com.applovin.mediation.MaxAdRevenueListener;
 import com.applovin.mediation.MaxAdViewAdListener;
 import com.applovin.mediation.MaxError;
 import com.applovin.mediation.MaxErrorCode;
@@ -66,7 +67,7 @@ import static com.facebook.react.modules.core.DeviceEventManagerModule.RCTDevice
  */
 public class AppLovinMAXModule
         extends ReactContextBaseJavaModule
-        implements MaxAdListener, MaxAdViewAdListener, MaxRewardedAdListener
+        implements MaxAdListener, MaxAdViewAdListener, MaxRewardedAdListener, MaxAdRevenueListener
 {
     private static final String SDK_TAG = "AppLovinSdk";
     private static final String TAG     = "AppLovinMAXModule";
@@ -1045,6 +1046,41 @@ public class AppLovinMAXModule
         sendReactNativeEvent( ( MaxAdFormat.MREC == adFormat ) ? "OnMRecAdCollapsedEvent" : "OnBannerAdCollapsedEvent", getAdInfo( ad ) );
     }
 
+ @Override
+    public void onAdRevenuePaid(final MaxAd ad)
+    {
+        final MaxAdFormat adFormat = ad.getFormat();
+        final String name;
+        if ( MaxAdFormat.BANNER == adFormat || MaxAdFormat.LEADER == adFormat )
+        {
+            name = "OnBannerAdRevenuePaid";
+        }
+        else if ( MaxAdFormat.MREC == adFormat )
+        {
+            name = "OnMRecAdRevenuePaid";
+        }
+        else if ( MaxAdFormat.INTERSTITIAL == adFormat )
+        {
+            name = "OnInterstitialAdRevenuePaid";
+        }
+        else if ( MaxAdFormat.REWARDED == adFormat )
+        {
+            name = "OnRewardedAdRevenuePaid";
+        }
+        else
+        {
+            logInvalidAdFormat( adFormat );
+            return;
+        }
+
+        WritableMap adInfo = getAdInfo( ad );
+        adInfo.putString( "networkPlacement", ad.getNetworkPlacement() );
+        adInfo.putString( "revenuePrecision", ad.getRevenuePrecision() );
+        adInfo.putString( "countryCode", sdkConfiguration.getCountryCode() );
+
+        sendReactNativeEvent( name, adInfo );
+    }
+
     @Override
     public void onRewardedVideoCompleted(final MaxAd ad)
     {
@@ -1260,6 +1296,7 @@ public class AppLovinMAXModule
                 }
 
                 adView.setListener( null );
+                adView.setRevenueListener( null );
                 adView.destroy();
 
                 mAdViews.remove( adUnitId );
@@ -1359,6 +1396,7 @@ public class AppLovinMAXModule
         {
             result = new MaxInterstitialAd( adUnitId, sdk, currentActivity );
             result.setListener( this );
+            result.setRevenueListener( this );
 
             mInterstitials.put( adUnitId, result );
         }
@@ -1377,6 +1415,7 @@ public class AppLovinMAXModule
         {
             result = MaxRewardedAd.getInstance( adUnitId, sdk, currentActivity );
             result.setListener( this );
+            result.setRevenueListener( this );
 
             mRewardedAds.put( adUnitId, result );
         }
@@ -1396,6 +1435,7 @@ public class AppLovinMAXModule
         {
             result = new MaxAdView( adUnitId, adFormat, sdk, maybeGetCurrentActivity() );
             result.setListener( this );
+            result.setRevenueListener( this );
 
             mAdViews.put( adUnitId, result );
             mAdViewPositions.put( adUnitId, adViewPosition );

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -121,6 +121,9 @@ const App = () => {
       setInterstitialAdLoadState(adLoadState.notLoaded);
       logStatus('Interstitial ad hidden');
     });
+    AppLovinMAX.addEventListener('OnInterstitialAdRevenuePaid', (adInfo) => {
+      logStatus('Interstitial ad revenue paid: ' + adInfo.revenue);
+    });
 
     // Rewarded Ad Listeners
     AppLovinMAX.addEventListener('OnRewardedAdLoadedEvent', (adInfo) => {
@@ -163,6 +166,9 @@ const App = () => {
     AppLovinMAX.addEventListener('OnRewardedAdReceivedRewardEvent', (adInfo) => {
       logStatus('Rewarded ad granted reward');
     });
+    AppLovinMAX.addEventListener('OnRewardedAdRevenuePaid', (adInfo) => {
+      logStatus('Rewarded ad revenue paid: ' + adInfo.revenue);
+    });
 
     // Banner Ad Listeners
     AppLovinMAX.addEventListener('OnBannerAdLoadedEvent', (adInfo) => {
@@ -180,6 +186,9 @@ const App = () => {
     AppLovinMAX.addEventListener('OnBannerAdCollapsedEvent', (adInfo) => {
       logStatus('Banner ad collapsed')
     });
+    AppLovinMAX.addEventListener('OnBannerAdRevenuePaid', (adInfo) => {
+      logStatus('Banner ad revenue paid: ' + adInfo.revenue);
+    });
 
     // MREC Ad Listeners
     AppLovinMAX.addEventListener('OnMRecAdLoadedEvent', (adInfo) => {
@@ -196,6 +205,9 @@ const App = () => {
     });
     AppLovinMAX.addEventListener('OnMRecAdCollapsedEvent', (adInfo) => {
       logStatus('MREC ad collapsed')
+    });
+    AppLovinMAX.addEventListener('OnMRecAdRevenuePaid', (adInfo) => {
+      logStatus('MREC ad revenue paid: ' + adInfo.revenue);
     });
   }
 

--- a/ios/AppLovinMAX.h
+++ b/ios/AppLovinMAX.h
@@ -19,7 +19,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * The primary bridge between JS <-> native code for the AppLovin MAX React Native module.
  */
-@interface AppLovinMAX : RCTEventEmitter<RCTBridgeModule, MAAdDelegate, MARewardedAdDelegate, MAAdViewAdDelegate>
+@interface AppLovinMAX : RCTEventEmitter<RCTBridgeModule, MAAdRevenueDelegate, MAAdDelegate, MARewardedAdDelegate, MAAdViewAdDelegate>
 
 /**
  * Shared instance of this bridge module.

--- a/ios/AppLovinMAX.h
+++ b/ios/AppLovinMAX.h
@@ -19,7 +19,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * The primary bridge between JS <-> native code for the AppLovin MAX React Native module.
  */
-@interface AppLovinMAX : RCTEventEmitter<RCTBridgeModule, MAAdRevenueDelegate, MAAdDelegate, MARewardedAdDelegate, MAAdViewAdDelegate>
+@interface AppLovinMAX : RCTEventEmitter<RCTBridgeModule, MAAdDelegate, MARewardedAdDelegate, MAAdViewAdDelegate, MAAdRevenueDelegate>
 
 /**
  * Shared instance of this bridge module.

--- a/ios/AppLovinMAX.m
+++ b/ios/AppLovinMAX.m
@@ -834,6 +834,40 @@ RCT_EXPORT_METHOD(setRewardedAdExtraParameter:(NSString *)adUnitIdentifier :(NSS
                                   body: [self adInfoForAd: ad]];
 }
 
+- (void)didPayRevenueForAd:(MAAd *)ad
+{
+    NSString *name;
+    MAAdFormat *adFormat = ad.format;
+    if ( MAAdFormat.banner == adFormat || MAAdFormat.leader == adFormat )
+    {
+        name = @"OnBannerAdRevenuePaid";
+    }
+    else if ( MAAdFormat.mrec == adFormat )
+    {
+        name = @"OnMRecAdRevenuePaid";
+    }
+    else if ( MAAdFormat.interstitial == adFormat )
+    {
+        name = @"OnInterstitialAdRevenuePaid";
+    }
+    else if ( MAAdFormat.rewarded == adFormat )
+    {
+        name = @"OnRewardedAdRevenuePaid";
+    }
+    else
+    {
+        [self logInvalidAdFormat: adFormat];
+        return;
+    }
+
+    NSMutableDictionary *body = [self adInfoForAd: ad].mutableCopy;
+    body[@"networkPlacement"] = ad.networkPlacement;
+    body[@"revenuePrecision"] = ad.revenuePrecision;
+    body[@"countryCode"] = self.sdk.configuration.countryCode;
+
+    [self sendReactNativeEventWithName: name body: body];
+}
+
 - (void)didCompleteRewardedVideoForAd:(MAAd *)ad
 {
     // This event is not forwarded
@@ -1040,6 +1074,7 @@ RCT_EXPORT_METHOD(setRewardedAdExtraParameter:(NSString *)adUnitIdentifier :(NSS
         
         MAAdView *view = [self retrieveAdViewForAdUnitIdentifier: adUnitIdentifier adFormat: adFormat];
         view.delegate = nil;
+        view.revenueDelegate = nil;
         
         [view removeFromSuperview];
         
@@ -1058,6 +1093,7 @@ RCT_EXPORT_METHOD(setRewardedAdExtraParameter:(NSString *)adUnitIdentifier :(NSS
     {
         result = [[MAInterstitialAd alloc] initWithAdUnitIdentifier: adUnitIdentifier sdk: self.sdk];
         result.delegate = self;
+        result.revenueDelegate = self;
         
         self.interstitials[adUnitIdentifier] = result;
     }
@@ -1072,6 +1108,7 @@ RCT_EXPORT_METHOD(setRewardedAdExtraParameter:(NSString *)adUnitIdentifier :(NSS
     {
         result = [MARewardedAd sharedWithAdUnitIdentifier: adUnitIdentifier sdk: self.sdk];
         result.delegate = self;
+        result.revenueDelegate = self;
         
         self.rewardedAds[adUnitIdentifier] = result;
     }
@@ -1091,6 +1128,7 @@ RCT_EXPORT_METHOD(setRewardedAdExtraParameter:(NSString *)adUnitIdentifier :(NSS
     {
         result = [[MAAdView alloc] initWithAdUnitIdentifier: adUnitIdentifier adFormat: adFormat sdk: self.sdk];
         result.delegate = self;
+        result.revenueDelegate = self;
         result.userInteractionEnabled = NO;
         result.translatesAutoresizingMaskIntoConstraints = NO;
         
@@ -1342,12 +1380,14 @@ RCT_EXPORT_METHOD(setRewardedAdExtraParameter:(NSString *)adUnitIdentifier :(NSS
              @"OnMRecAdClickedEvent",
              @"OnMRecAdCollapsedEvent",
              @"OnMRecAdExpandedEvent",
+             @"OnMRecAdRevenuePaid",
              
              @"OnBannerAdLoadedEvent",
              @"OnBannerAdLoadFailedEvent",
              @"OnBannerAdClickedEvent",
              @"OnBannerAdCollapsedEvent",
              @"OnBannerAdExpandedEvent",
+             @"OnBannerAdRevenuePaid",
              
              @"OnInterstitialLoadedEvent",
              @"OnInterstitialLoadFailedEvent",
@@ -1355,6 +1395,7 @@ RCT_EXPORT_METHOD(setRewardedAdExtraParameter:(NSString *)adUnitIdentifier :(NSS
              @"OnInterstitialDisplayedEvent",
              @"OnInterstitialAdFailedToDisplayEvent",
              @"OnInterstitialHiddenEvent",
+             @"OnInterstitialAdRevenuePaid",
              
              @"OnRewardedAdLoadedEvent",
              @"OnRewardedAdLoadFailedEvent",
@@ -1362,7 +1403,8 @@ RCT_EXPORT_METHOD(setRewardedAdExtraParameter:(NSString *)adUnitIdentifier :(NSS
              @"OnRewardedAdDisplayedEvent",
              @"OnRewardedAdFailedToDisplayEvent",
              @"OnRewardedAdHiddenEvent",
-             @"OnRewardedAdReceivedRewardEvent"];
+             @"OnRewardedAdReceivedRewardEvent",
+             @"OnRewardedAdRevenuePaid"];
 }
 
 - (void)startObserving

--- a/ios/AppLovinMAXAdViewManager.m
+++ b/ios/AppLovinMAXAdViewManager.m
@@ -180,6 +180,7 @@ RCT_EXPORT_METHOD(setAdFormat:(nonnull NSNumber *)viewTag toAdFormat:(NSString *
             adView = [[MAAdView alloc] initWithAdUnitIdentifier: adUnitIdentifier adFormat: adFormat sdk: AppLovinMAX.shared.sdk];
             adView.frame = (CGRect) { CGPointZero, adFormat.size };
             adView.delegate = AppLovinMAX.shared; // Go through core class for callback forwarding to React Native layer
+            adView.revenueDelegate = AppLovinMAX.shared;
             
             NSString *placement = self.placementRegistry[viewTag];
             if ( placement )


### PR DESCRIPTION
Aded support for the user revenue APIs:

```
OnInterstitialAdRevenuePaid
OnRewardedAdRevenuePaid
OnMRecAdLoadedEvent
OnBannerAdRevenuePaid
```

Verified in the app logs on both platforms with all the ad types, also with the native banner and MREC.

```
{
   "networkName":"AppLovin",
   "revenue":0.012777527809143065,
   "placement":"",
   "adUnitId":"072b1be38502cea2",
   "creativeId":"12192278",
   "revenuePrecision":"exact",
   "networkPlacement":"inter_videoa",
   "countryCode":"JP"
}
```