### PR TITLE
feat/custom_data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Versions
 
+## x.x.x
+    * Add support for custom data.
 ## 3.1.0
     * Add support for data passing.
     * Add API for Android to provide a built-in consent flow that sets the user consent flag.

--- a/android/src/main/java/com/applovin/reactnative/AppLovinMAXAdView.java
+++ b/android/src/main/java/com/applovin/reactnative/AppLovinMAXAdView.java
@@ -74,7 +74,7 @@ class AppLovinMAXAdView
         return adView;
     }
 
-    public void maybeAttachAdView(final String placement, final String adaptiveBannerEnabledStr, final String adUnitId, final MaxAdFormat adFormat)
+    public void maybeAttachAdView(final String placement, final String customData, final String adaptiveBannerEnabledStr, final String adUnitId, final MaxAdFormat adFormat)
     {
         final Activity currentActivity = reactContext.getCurrentActivity();
         if ( currentActivity == null )
@@ -98,6 +98,11 @@ class AppLovinMAXAdView
                     if ( placement != null )
                     {
                         adView.setPlacement( placement );
+                    }
+
+                    if ( customData != null )
+                    {
+                        adView.setCustomData( customData );
                     }
 
                     if ( adaptiveBannerEnabledStr != null )

--- a/android/src/main/java/com/applovin/reactnative/AppLovinMAXModule.java
+++ b/android/src/main/java/com/applovin/reactnative/AppLovinMAXModule.java
@@ -657,6 +657,12 @@ public class AppLovinMAXModule
     }
 
     @ReactMethod()
+    public void setBannerCustomData(final String adUnitId, final String customData)
+    {
+        setAdViewCustomData( adUnitId, getDeviceSpecificBannerAdViewAdFormat(), customData );
+    }
+
+    @ReactMethod()
     public void setBannerWidth(final String adUnitId, final int widthDp)
     {
         setAdViewWidth( adUnitId, widthDp, getDeviceSpecificBannerAdViewAdFormat() );
@@ -719,6 +725,12 @@ public class AppLovinMAXModule
     }
 
     @ReactMethod()
+    public void setMRecCustomData(final String adUnitId, final String customData)
+    {
+        setAdViewCustomData( adUnitId, MaxAdFormat.MREC, customData );
+    }
+
+    @ReactMethod()
     public void updateMRecPosition(final String adUnitId, final String mrecPosition)
     {
         updateAdViewPosition( adUnitId, mrecPosition, DEFAULT_AD_VIEW_OFFSET, MaxAdFormat.MREC );
@@ -765,9 +777,10 @@ public class AppLovinMAXModule
     }
 
     @ReactMethod()
-    public void showInterstitial(final String adUnitId)
+    public void showInterstitial(final String adUnitId, final String placement, final String customData)
     {
-        showInterstitialWithPlacement( adUnitId, null );
+        MaxInterstitialAd interstitial = retrieveInterstitial( adUnitId );
+        interstitial.showAd( placement, customData );
     }
 
     @ReactMethod()
@@ -807,9 +820,10 @@ public class AppLovinMAXModule
     }
 
     @ReactMethod()
-    public void showRewardedAd(final String adUnitId)
+    public void showRewardedAd(final String adUnitId, final String placement, final String customData)
     {
-        showRewardedAdWithPlacement( adUnitId, null );
+        MaxRewardedAd rewardedAd = retrieveRewardedAd( adUnitId );
+        rewardedAd.showAd( placement, customData );
     }
 
     @ReactMethod()
@@ -1140,6 +1154,27 @@ public class AppLovinMAXModule
                 }
 
                 adView.setPlacement( placement );
+            }
+        } );
+    }
+
+    private void setAdViewCustomData(final String adUnitId, final MaxAdFormat adFormat, final String customData)
+    {
+        getReactApplicationContext().runOnUiQueueThread( new Runnable()
+        {
+            @Override
+            public void run()
+            {
+                d( "Setting customData \"" + customData + "\" for " + adFormat.getLabel() + " with ad unit id \"" + adUnitId + "\"" );
+
+                final MaxAdView adView = retrieveAdView( adUnitId, adFormat, "", DEFAULT_AD_VIEW_OFFSET );
+                if ( adView == null )
+                {
+                    e( adFormat.getLabel() + " does not exist" );
+                    return;
+                }
+
+                adView.setCustomData( customData );
             }
         } );
     }

--- a/android/src/main/java/com/applovin/reactnative/AppLovinMAXModule.java
+++ b/android/src/main/java/com/applovin/reactnative/AppLovinMAXModule.java
@@ -784,13 +784,6 @@ public class AppLovinMAXModule
     }
 
     @ReactMethod()
-    public void showInterstitialWithPlacement(final String adUnitId, final String placement)
-    {
-        MaxInterstitialAd interstitial = retrieveInterstitial( adUnitId );
-        interstitial.showAd( placement );
-    }
-
-    @ReactMethod()
     public void setInterstitialExtraParameter(final String adUnitId, final String key, final String value)
     {
         MaxInterstitialAd interstitial = retrieveInterstitial( adUnitId );
@@ -824,13 +817,6 @@ public class AppLovinMAXModule
     {
         MaxRewardedAd rewardedAd = retrieveRewardedAd( adUnitId );
         rewardedAd.showAd( placement, customData );
-    }
-
-    @ReactMethod()
-    public void showRewardedAdWithPlacement(final String adUnitId, final String placement)
-    {
-        MaxRewardedAd rewardedAd = retrieveRewardedAd( adUnitId );
-        rewardedAd.showAd( placement );
     }
 
     @ReactMethod()

--- a/android/src/main/java/com/applovin/reactnative/AppLovinMAXModule.java
+++ b/android/src/main/java/com/applovin/reactnative/AppLovinMAXModule.java
@@ -1216,7 +1216,7 @@ public class AppLovinMAXModule
             @Override
             public void run()
             {
-                d( "Setting customData \"" + customData + "\" for " + adFormat.getLabel() + " with ad unit id \"" + adUnitId + "\"" );
+                d( "Setting custom data \"" + customData + "\" for " + adFormat.getLabel() + " with ad unit id \"" + adUnitId + "\"" );
 
                 final MaxAdView adView = retrieveAdView( adUnitId, adFormat, "", DEFAULT_AD_VIEW_OFFSET );
                 if ( adView == null )

--- a/ios/AppLovinMAX.m
+++ b/ios/AppLovinMAX.m
@@ -512,6 +512,11 @@ RCT_EXPORT_METHOD(setBannerPlacement:(NSString *)adUnitIdentifier :(nullable NSS
     [self setAdViewPlacement: placement forAdUnitIdentifier: adUnitIdentifier adFormat: DEVICE_SPECIFIC_ADVIEW_AD_FORMAT];
 }
 
+RCT_EXPORT_METHOD(setBannerCustomData:(NSString *)adUnitIdentifier :(nullable NSString *)customData)
+{
+    [self setAdViewCustomData: customData forAdUnitIdentifier: adUnitIdentifier adFormat: DEVICE_SPECIFIC_ADVIEW_AD_FORMAT];
+}
+
 RCT_EXPORT_METHOD(updateBannerPosition:(NSString *)adUnitIdentifier :(NSString *)bannerPosition)
 {
     [self updateAdViewPosition: bannerPosition withOffset: CGPointZero forAdUnitIdentifier: adUnitIdentifier adFormat: DEVICE_SPECIFIC_ADVIEW_AD_FORMAT];
@@ -564,6 +569,11 @@ RCT_EXPORT_METHOD(setMRecPlacement:(NSString *)adUnitIdentifier :(nullable NSStr
     [self setAdViewPlacement: placement forAdUnitIdentifier: adUnitIdentifier adFormat: MAAdFormat.mrec];
 }
 
+RCT_EXPORT_METHOD(setMRecCustomData:(NSString *)adUnitIdentifier :(nullable NSString *)customData)
+{
+    [self setAdViewCustomData: customData forAdUnitIdentifier: adUnitIdentifier adFormat: MAAdFormat.mrec];
+}
+
 RCT_EXPORT_METHOD(updateMRecPosition:(NSString *)mrecPosition :(NSString *)adUnitIdentifier)
 {
     [self updateAdViewPosition: mrecPosition withOffset: CGPointZero forAdUnitIdentifier: adUnitIdentifier adFormat: MAAdFormat.mrec];
@@ -598,9 +608,10 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(isInterstitialReady:(NSString *)adUnitIde
     return @([interstitial isReady]);
 }
 
-RCT_EXPORT_METHOD(showInterstitial:(NSString *)adUnitIdentifier)
+RCT_EXPORT_METHOD(showInterstitial:(NSString *)adUnitIdentifier :(nullable NSString *)placement :(nullable NSString *)customData)
 {
-    [self showInterstitialWithPlacement: adUnitIdentifier : nil];
+    MAInterstitialAd *interstitial = [self retrieveInterstitialForAdUnitIdentifier: adUnitIdentifier];
+    [interstitial showAdForPlacement: placement customData: customData];
 }
 
 RCT_EXPORT_METHOD(showInterstitialWithPlacement:(NSString *)adUnitIdentifier :(NSString *)placement)
@@ -629,9 +640,10 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(isRewardedAdReady:(NSString *)adUnitIdent
     return @([rewardedAd isReady]);
 }
 
-RCT_EXPORT_METHOD(showRewardedAd:(NSString *)adUnitIdentifier)
+RCT_EXPORT_METHOD(showRewardedAd:(NSString *)adUnitIdentifier :(nullable NSString *)placement :(nullable NSString *)customData)
 {
-    [self showRewardedAdWithPlacement: adUnitIdentifier : nil];
+    MARewardedAd *rewardedAd = [self retrieveRewardedAdForAdUnitIdentifier: adUnitIdentifier];
+    [rewardedAd showAdForPlacement: placement customData: customData];
 }
 
 RCT_EXPORT_METHOD(showRewardedAdWithPlacement:(NSString *)adUnitIdentifier :(NSString *)placement)
@@ -923,6 +935,17 @@ RCT_EXPORT_METHOD(setRewardedAdExtraParameter:(NSString *)adUnitIdentifier :(NSS
         
         MAAdView *adView = [self retrieveAdViewForAdUnitIdentifier: adUnitIdentifier adFormat: adFormat atPosition: @"" withOffset: CGPointZero];
         adView.placement = placement;
+    });
+}
+
+- (void)setAdViewCustomData:(nullable NSString *)customData forAdUnitIdentifier:(NSString *)adUnitIdentifier adFormat:(MAAdFormat *)adFormat
+{
+    dispatch_async(dispatch_get_main_queue(), ^{
+
+        [self log: @"Setting customData \"%@\" for \"%@\" with ad unit identifier \"%@\"", customData, adFormat, adUnitIdentifier];
+
+        MAAdView *adView = [self retrieveAdViewForAdUnitIdentifier: adUnitIdentifier adFormat: adFormat atPosition: @"" withOffset: CGPointZero];
+        adView.customData = customData;
     });
 }
 

--- a/ios/AppLovinMAX.m
+++ b/ios/AppLovinMAX.m
@@ -976,7 +976,7 @@ RCT_EXPORT_METHOD(setRewardedAdExtraParameter:(NSString *)adUnitIdentifier :(NSS
 {
     dispatch_async(dispatch_get_main_queue(), ^{
 
-        [self log: @"Setting customData \"%@\" for \"%@\" with ad unit identifier \"%@\"", customData, adFormat, adUnitIdentifier];
+        [self log: @"Setting custom data \"%@\" for \"%@\" with ad unit identifier \"%@\"", customData, adFormat, adUnitIdentifier];
 
         MAAdView *adView = [self retrieveAdViewForAdUnitIdentifier: adUnitIdentifier adFormat: adFormat atPosition: @"" withOffset: CGPointZero];
         adView.customData = customData;

--- a/ios/AppLovinMAX.m
+++ b/ios/AppLovinMAX.m
@@ -614,12 +614,6 @@ RCT_EXPORT_METHOD(showInterstitial:(NSString *)adUnitIdentifier :(nullable NSStr
     [interstitial showAdForPlacement: placement customData: customData];
 }
 
-RCT_EXPORT_METHOD(showInterstitialWithPlacement:(NSString *)adUnitIdentifier :(NSString *)placement)
-{
-    MAInterstitialAd *interstitial = [self retrieveInterstitialForAdUnitIdentifier: adUnitIdentifier];
-    [interstitial showAdForPlacement: placement];
-}
-
 RCT_EXPORT_METHOD(setInterstitialExtraParameter:(NSString *)adUnitIdentifier :(NSString *)key :(nullable NSString *)value)
 {
     MAInterstitialAd *interstitial = [self retrieveInterstitialForAdUnitIdentifier: adUnitIdentifier];
@@ -644,12 +638,6 @@ RCT_EXPORT_METHOD(showRewardedAd:(NSString *)adUnitIdentifier :(nullable NSStrin
 {
     MARewardedAd *rewardedAd = [self retrieveRewardedAdForAdUnitIdentifier: adUnitIdentifier];
     [rewardedAd showAdForPlacement: placement customData: customData];
-}
-
-RCT_EXPORT_METHOD(showRewardedAdWithPlacement:(NSString *)adUnitIdentifier :(NSString *)placement)
-{
-    MARewardedAd *rewardedAd = [self retrieveRewardedAdForAdUnitIdentifier: adUnitIdentifier];
-    [rewardedAd showAdForPlacement: placement];
 }
 
 RCT_EXPORT_METHOD(setRewardedAdExtraParameter:(NSString *)adUnitIdentifier :(NSString *)key :(nullable NSString *)value)

--- a/src/AppLovinMAXAdView.js
+++ b/src/AppLovinMAXAdView.js
@@ -13,6 +13,7 @@ class AdView extends React.Component {
     this.setAdUnitId(this.props.adUnitId);
     this.setAdFormat(this.props.adFormat);
     this.setPlacement(this.props.placement);
+    this.setCustomData(this.props.customData);
     this.setAdaptiveBannerEnabled(this.props.adaptiveBannerEnabled);
   }
 
@@ -28,6 +29,10 @@ class AdView extends React.Component {
 
     if (prevProps.placement !== this.props.placement) {
       this.setPlacement(this.props.placement);
+    }
+
+    if (prevProps.customData !== this.props.customData) {
+      this.setCustomData(this.props.customData);
     }
 
     if (prevProps.adaptiveBannerEnabled !== this.props.adaptiveBannerEnabled) {
@@ -94,6 +99,20 @@ class AdView extends React.Component {
     );
   }
 
+  setCustomData(customData) {
+    var adUnitId = this.props.adUnitId;
+    var adFormat = this.props.adFormat;
+
+    // If the ad unit id or ad format are unset, we can't set the customData.
+    if (adUnitId == null || adFormat == null) return;
+
+    UIManager.dispatchViewManagerCommand(
+        findNodeHandle(this),
+        Platform.OS === 'android' ? "setCustomData" : UIManager.getViewManagerConfig("AppLovinMAXAdView").Commands.setCustomData,
+        [customData]
+    );
+  }
+
   setAdaptiveBannerEnabled(enabled) {
     var adUnitId = this.props.adUnitId;
     var adFormat = this.props.adFormat;
@@ -128,6 +147,11 @@ AdView.propTypes = {
    * A string value representing the placement name that you assign when you integrate each ad format, for granular reporting in ad events.
    */
   placement: PropTypes.string,
+
+  /**
+   * A string value representing the customData name that you assign when you integrate each ad format, for granular reporting in ad events.
+   */
+  customData: PropTypes.string,
 
   /**
    * A boolean value representing whether or not to enable adaptive banners. Note that adaptive banners are enabled by default as of v2.3.0.

--- a/src/index.js
+++ b/src/index.js
@@ -65,6 +65,40 @@ const removeEventListener = (event) => {
   }
 };
 
+const showInterstitial = (adUnitId, ...args) => {
+  switch (args.length) {
+  case 0:
+    AppLovinMAX.showInterstitial(adUnitId, null, null);
+    break;
+  case 1:
+    AppLovinMAX.showInterstitial(adUnitId, args[0], null);
+    break;
+  case 2:
+    AppLovinMAX.showInterstitial(adUnitId, args[0], args[1]);
+    break;
+  default:
+    // do nothing - unexpected number of arguments
+    break;
+  }
+};
+
+const showRewardedAd = (adUnitId, ...args) => {
+  switch (args.length) {
+  case 0:
+    AppLovinMAX.showRewardedAd(adUnitId, null, null);
+    break;
+  case 1:
+    AppLovinMAX.showRewardedAd(adUnitId, args[0], null);
+    break;
+  case 2:
+    AppLovinMAX.showRewardedAd(adUnitId, args[0], args[1]);
+    break;
+  default:
+    // do nothing - unexpected number of arguments
+    break;
+  }
+};
+
 export default {
   ...AppLovinMAX,
   AdView,
@@ -80,6 +114,8 @@ export default {
   initialize(sdkKey, callback) {
     AppLovinMAX.initialize(VERSION, sdkKey, callback); // Inject VERSION into native code
   },
+  showInterstitial,
+  showRewardedAd,
 
   /*----------------------*/
   /** AUTO-DECLARED APIs **/


### PR DESCRIPTION
Added support for custom data.   The APIs are:

```
AppLovinMAX.showInterstitial(adUnitId, placement, customData)
AppLovinMAX.showRewardedAd(adUnitId, placement, customData)
AppLovinMAX.setBannerCustomData(adUnitId, customData)
AppLovinMAX.setMRecCustomData(adUnitId, customData)
```

The native API is:

```
 <AppLovinMAX.AdView adUnitId={BANNER_AD_UNIT_ID}
                                   adFormat={AppLovinMAX.AdFormat.BANNER} 
                                   customData='banner_native_customdata'
                                   style={styles.banner}/>
```

Verified in the app logs on both platforms.