### PR TITLE
feat/adview_autorefresh_property

### DIFF
--- a/android/src/main/java/com/applovin/reactnative/AppLovinMAXAdView.java
+++ b/android/src/main/java/com/applovin/reactnative/AppLovinMAXAdView.java
@@ -74,7 +74,7 @@ class AppLovinMAXAdView
         return adView;
     }
 
-    public void maybeAttachAdView(final String placement, final String customData, final String adaptiveBannerEnabledStr, final String adUnitId, final MaxAdFormat adFormat)
+    public void maybeAttachAdView(final String placement, final String customData, final String adaptiveBannerEnabledStr, final boolean autoRefreshEnabled, final String adUnitId, final MaxAdFormat adFormat)
     {
         final Activity currentActivity = reactContext.getCurrentActivity();
         if ( currentActivity == null )
@@ -109,6 +109,15 @@ class AppLovinMAXAdView
                     if ( adaptiveBannerEnabledStr != null )
                     {
                         adView.setExtraParameter( "adaptive_banner", adaptiveBannerEnabledStr );
+                    }
+
+                    if ( autoRefreshEnabled )
+                    {
+                        adView.startAutoRefresh();
+                    }
+                    else
+                    {
+                        adView.stopAutoRefresh();
                     }
 
                     adView.loadAd();

--- a/src/AppLovinMAXAdView.js
+++ b/src/AppLovinMAXAdView.js
@@ -15,6 +15,7 @@ class AdView extends React.Component {
     this.setPlacement(this.props.placement);
     this.setCustomData(this.props.customData);
     this.setAdaptiveBannerEnabled(this.props.adaptiveBannerEnabled);
+    this.setAutoRefresh(this.props.autoRefresh);
   }
 
   componentDidUpdate(prevProps) {
@@ -37,6 +38,10 @@ class AdView extends React.Component {
 
     if (prevProps.adaptiveBannerEnabled !== this.props.adaptiveBannerEnabled) {
       this.setAdaptiveBannerEnabled(this.props.adaptiveBannerEnabled);
+    }
+
+    if (prevProps.autoRefresh !== this.props.autoRefresh) {
+      this.setAutoRefresh(this.props.autoRefresh);
     }
   }
 
@@ -130,6 +135,22 @@ class AdView extends React.Component {
       }
     }
   }
+
+  setAutoRefresh(enabled) {
+    var adUnitId = this.props.adUnitId;
+    var adFormat = this.props.adFormat;
+
+    // If the ad unit id or ad format are unset, we can't set the autorefresh.
+    if (adUnitId == null || adFormat == null) return;
+
+    if (enabled === true || enabled === false) {
+      UIManager.dispatchViewManagerCommand(
+        findNodeHandle(this),
+        Platform.OS === 'android' ? "setAutoRefresh" : UIManager.getViewManagerConfig("AppLovinMAXAdView").Commands.setAutoRefresh,
+        [enabled]
+      );
+    }
+  }
 }
 
 AdView.propTypes = {
@@ -157,6 +178,11 @@ AdView.propTypes = {
    * A boolean value representing whether or not to enable adaptive banners. Note that adaptive banners are enabled by default as of v2.3.0.
    */
   adaptiveBannerEnabled: PropTypes.bool,
+
+  /**
+   * A boolean value representing whether or not to enable auto refresh. Note that auto refresh is enabled by default.
+   */
+  autoRefresh: PropTypes.bool,
 };
 
 // requireNativeComponent automatically resolves 'AppLovinMAXAdView' to 'AppLovinMAXAdViewManager'


### PR DESCRIPTION
### Added ‘autoRefresh’ property to the native AdView interface

**The change doesn’t work with the ‘false’ initial value.**

I tried many things but I was not able to get it to work.  I'm wondering if this might be expected behaviour.

Here is the testing I did.

```
const [bannerAutoRefresh, setBannerAutoRefresh] = useState(false); 

<AppLovinMAX.AdView adUnitId={BANNER_AD_UNIT_ID}
                    adFormat={AppLovinMAX.AdFormat.BANNER}
                    autoRefresh={bannerAutoRefresh}
                    style={styles.banner}/>

<AppButton
     title={bannerAutoRefresh ? 'Disable Banner AutoRefresh' : 'Enable Banner AutoRefresh'}
     onPress={() => {
        setBannerAutoRefresh(!bannerAutoRefresh);
     }}
 />
```


