### PR TITLE
bug/android_waterfall_exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Versions
 
+## x.x.x
+    * Fix an exception in Android waterfall.
 ## 3.2.2
     * Lock to Android SDK 11.4.4 and iOS SDK 11.4.3.
 ## 3.2.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Versions
 
 ## x.x.x
-    * Fix an exception in Android waterfall.
+    * Fix `java.lang.ClassCastException` in Android when ad is loaded due to processing `ad.waterfall` object.
 ## 3.2.2
     * Lock to Android SDK 11.4.4 and iOS SDK 11.4.3.
 ## 3.2.1

--- a/android/src/main/java/com/applovin/reactnative/AppLovinMAXModule.java
+++ b/android/src/main/java/com/applovin/reactnative/AppLovinMAXModule.java
@@ -1770,8 +1770,12 @@ public class AppLovinMAXModule
         WritableMap credentials = Arguments.createMap();
         for ( String key : credentialBundle.keySet() )
         {
-            String value = credentialBundle.getString( key, "" );
-            credentials.putString( key, value );
+            Object obj = credentialBundle.get( key );
+            if ( obj != null )
+            {
+                String value = obj.toString();
+                credentials.putString( key, value );
+            }
         }
         networkResponseObject.putMap( "credentials", credentials );
 

--- a/android/src/main/java/com/applovin/reactnative/AppLovinMAXModule.java
+++ b/android/src/main/java/com/applovin/reactnative/AppLovinMAXModule.java
@@ -1771,10 +1771,9 @@ public class AppLovinMAXModule
         for ( String key : credentialBundle.keySet() )
         {
             Object obj = credentialBundle.get( key );
-            if ( obj != null )
+            if ( obj instanceof String )
             {
-                String value = obj.toString();
-                credentials.putString( key, value );
+                credentials.putString( key, (String) obj );
             }
         }
         networkResponseObject.putMap( "credentials", credentials );


### PR DESCRIPTION
Fixed a ClassCastException in the waterfall credential to cast non-string Bundle objects:

com.applovin.enterprise.apps.demoapp W/Bundle: Attempt to cast generated internal exception:
    java.lang.ClassCastException: java.lang.Boolean cannot be cast to java.lang.String
        at android.os.BaseBundle.getString(BaseBundle.java:1199)
        at android.os.BaseBundle.getString(BaseBundle.java:1218)
        at com.applovin.reactnative.AppLovinMAXModule.createNetworkResponseInfo(AppLovinMAXModule.java:1798)
        at com.applovin.reactnative.AppLovinMAXModule.createAdWaterfallInfo(AppLovinMAXModule.java:1768)
        at com.applovin.reactnative.AppLovinMAXModule.getAdInfo(AppLovinMAXModule.java:1749)
        at com.applovin.reactnative.AppLovinMAXModule.onAdLoaded(AppLovinMAXModule.java:914)
