### PR TITLE
added support for native ad

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Versions
 
 ## x.x.x
+    * Add support for native ads via `<AppLovinMAX.NativeAdView adUnitId={...}/>`.
     * Add autorefresh support for banner and MREC native UI components: `<AppLovinMAX.AdView autoRefresh={true/false} .../>`
     * Fix `java.lang.ClassCastException` in Android when ad is loaded due to processing `ad.waterfall` object.
 ## 3.2.2

--- a/android/src/main/java/com/applovin/reactnative/AppLovinMAXModule.java
+++ b/android/src/main/java/com/applovin/reactnative/AppLovinMAXModule.java
@@ -855,6 +855,13 @@ public class AppLovinMAXModule
         rewardedAd.setExtraParameter( key, value );
     }
 
+    @ReactMethod()
+    public void preLoadNativeAd(final String adUnitId, @Nullable final String placement, @Nullable final String customData, @Nullable final ReadableMap extraParameter)
+    {
+        Map extraParameterMap = ( extraParameter != null ) ? extraParameter.toHashMap() : null;
+        AppLovinMAXNativeAdLoader.getInstance().preLoadAd( getReactApplicationContext(), adUnitId, placement, customData, extraParameterMap );
+    }
+
     // AD CALLBACKS
 
     @Override
@@ -895,6 +902,10 @@ public class AppLovinMAXModule
         {
             name = "OnRewardedAdLoadedEvent";
         }
+        else if ( MaxAdFormat.NATIVE == adFormat )
+        {
+            name = "OnNativeAdLoadedEvent";
+        }
         else
         {
             logInvalidAdFormat( adFormat );
@@ -928,8 +939,15 @@ public class AppLovinMAXModule
         }
         else
         {
-            logStackTrace( new IllegalStateException( "invalid adUnitId: " + adUnitId ) );
-            return;
+            if ( AppLovinMAXNativeAdLoader.getInstance().errorAdUnitId.equals( adUnitId ) )
+            {
+                name = "OnNativeAdLoadFailedEvent";
+            }
+            else
+            {
+                logStackTrace( new IllegalStateException( "invalid adUnitId: " + adUnitId ) );
+                return;
+            }
         }
 
         sendReactNativeEventForAdLoadFailed( name, adUnitId, error );
@@ -975,6 +993,10 @@ public class AppLovinMAXModule
         else if ( MaxAdFormat.REWARDED == adFormat )
         {
             name = "OnRewardedAdClickedEvent";
+        }
+        else if ( MaxAdFormat.NATIVE == adFormat )
+        {
+            name = "OnNativeAdClickedEvent";
         }
         else
         {
@@ -1095,6 +1117,10 @@ public class AppLovinMAXModule
         else if ( MaxAdFormat.REWARDED == adFormat )
         {
             name = "OnRewardedAdRevenuePaid";
+        }
+        else if ( MaxAdFormat.NATIVE == adFormat )
+        {
+            name = "OnNativeAdRevenuePaid";
         }
         else
         {

--- a/android/src/main/java/com/applovin/reactnative/AppLovinMAXNativeAdLoader.java
+++ b/android/src/main/java/com/applovin/reactnative/AppLovinMAXNativeAdLoader.java
@@ -1,0 +1,162 @@
+package com.applovin.reactnative;
+
+import android.content.Context;
+
+import com.applovin.mediation.MaxAd;
+import com.applovin.mediation.MaxError;
+import com.applovin.mediation.nativeAds.MaxNativeAdListener;
+import com.applovin.mediation.nativeAds.MaxNativeAdLoader;
+import com.applovin.mediation.nativeAds.MaxNativeAdView;
+
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+import androidx.annotation.Nullable;
+
+public class AppLovinMAXNativeAdLoader
+{
+    interface Listener
+    {
+        void onAdLoaded(MaxAd ad);
+    }
+
+    private static final int MAX_PRELOADED_ADS = 2;
+
+    private static AppLovinMAXNativeAdLoader instance;
+
+    Map<String, List<MaxAd>>       nativeAds;
+    Map<String, MaxNativeAdLoader> loaders;
+
+    public String errorAdUnitId;
+
+    public static AppLovinMAXNativeAdLoader getInstance()
+    {
+        if ( instance == null )
+        {
+            instance = new AppLovinMAXNativeAdLoader();
+        }
+        return instance;
+    }
+
+    private AppLovinMAXNativeAdLoader()
+    {
+        nativeAds = new HashMap<String, List<MaxAd>>();
+        loaders = new HashMap<String, MaxNativeAdLoader>();
+    }
+
+    MaxNativeAdLoader getNativeAdLoader(Context context, String adUnitId)
+    {
+        MaxNativeAdLoader loader = loaders.get( adUnitId );
+        if ( loader == null )
+        {
+            loader = new MaxNativeAdLoader( adUnitId, AppLovinMAXModule.getInstance().getSdk(), context );
+            loaders.put( adUnitId, loader );
+        }
+        return loader;
+    }
+
+    MaxAd getNativeAd(Context context, String adUnitId, String placement, String customData, Map extraParameter, Listener listener)
+    {
+        List<MaxAd> queue = nativeAds.get( adUnitId );
+        if ( queue != null && queue.size() > 0 )
+        {
+            MaxAd ad = queue.get( 0 );
+            if ( ad != null )
+            {
+                queue.remove( 0 );
+            }
+            return ad;
+        }
+
+        load( context, adUnitId, placement, customData, extraParameter, listener );
+
+        return null;
+    }
+
+    void load(Context context, String adUnitId, String placement, String customData, Map<String, Object> extraParameter, Listener listener)
+    {
+        MaxNativeAdLoader loader = getNativeAdLoader( context, adUnitId );
+        loader.setRevenueListener( AppLovinMAXModule.getInstance() );
+        loader.setNativeAdListener( new NativeAdListener( adUnitId, listener ) );
+        loader.setPlacement( placement );
+        loader.setCustomData( customData );
+        if ( extraParameter != null )
+        {
+            for ( Map.Entry<String, Object> entry : extraParameter.entrySet() )
+            {
+                Object value = entry.getValue();
+                if ( value instanceof String )
+                {
+                    loader.setExtraParameter( entry.getKey(), (String) value );
+                }
+            }
+        }
+        loader.loadAd();
+    }
+
+    void preLoadAd(Context context, String adUnitId, String placement, String customData, Map extraParameter)
+    {
+        List<MaxAd> list = nativeAds.get( adUnitId );
+        if ( list != null && list.size() > MAX_PRELOADED_ADS )
+        {
+            return;
+        }
+        load( context, adUnitId, placement, customData, extraParameter, null );
+    }
+
+    class NativeAdListener
+            extends MaxNativeAdListener
+    {
+        String   adUnitId;
+        Listener listener;
+
+        NativeAdListener(String adUnitId, Listener listener)
+        {
+            this.adUnitId = adUnitId;
+            this.listener = listener;
+        }
+
+        @Override
+        public void onNativeAdLoaded(@Nullable final MaxNativeAdView nativeAdView, final MaxAd ad)
+        {
+            AppLovinMAXModule.getInstance().onAdLoaded( ad );
+
+            if ( listener == null )
+            {
+                List<MaxAd> queue = nativeAds.get( ad.getAdUnitId() );
+                if ( queue == null )
+                {
+                    queue = new LinkedList<MaxAd>();
+                    nativeAds.put( ad.getAdUnitId(), queue );
+                }
+                queue.add( ad );
+            }
+            else
+            {
+                listener.onAdLoaded( ad );
+            }
+        }
+
+        @Override
+        public void onNativeAdLoadFailed(final String s, final MaxError error)
+        {
+            errorAdUnitId = adUnitId;
+            AppLovinMAXModule.getInstance().onAdLoadFailed( adUnitId, error );
+            // TODO: should retry
+        }
+
+        @Override
+        public void onNativeAdClicked(final MaxAd ad)
+        {
+            AppLovinMAXModule.getInstance().onAdClicked( ad );
+        }
+    }
+
+    void destroyAd(String adUnitId, MaxAd ad)
+    {
+        MaxNativeAdLoader loader = loaders.get( adUnitId );
+        loader.destroy( ad );
+    }
+}

--- a/android/src/main/java/com/applovin/reactnative/AppLovinMAXNativeAdView.java
+++ b/android/src/main/java/com/applovin/reactnative/AppLovinMAXNativeAdView.java
@@ -1,0 +1,246 @@
+package com.applovin.reactnative;
+
+import android.content.Context;
+import android.view.View;
+import android.view.ViewGroup;
+
+import com.applovin.mediation.MaxAd;
+import com.applovin.mediation.nativeAds.MaxNativeAd;
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.ReactContext;
+import com.facebook.react.bridge.ReadableMap;
+import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.uimanager.RootView;
+import com.facebook.react.uimanager.RootViewUtil;
+import com.facebook.react.uimanager.events.RCTEventEmitter;
+import com.facebook.react.uimanager.util.ReactFindViewUtil;
+import com.facebook.react.views.image.ReactImageView;
+import com.facebook.react.views.view.ReactViewGroup;
+
+import java.util.Map;
+
+import androidx.annotation.Nullable;
+
+public class AppLovinMAXNativeAdView
+        extends ReactViewGroup
+        implements AppLovinMAXNativeAdLoader.Listener
+{
+    ReactContext reactContext;
+
+    String adUnitId;
+    String placement;
+    String customData;
+    Map    extraParameter;
+
+    MaxAd currentAd;
+
+    public AppLovinMAXNativeAdView(final Context context)
+    {
+        super( context );
+        reactContext = (ReactContext) context;
+    }
+
+    void setAdUnitId(final String value)
+    {
+        if ( adUnitId != null && !value.equals( adUnitId ) )
+        {
+            destroyCurrentAd();
+        }
+
+        adUnitId = value;
+
+        loadAd();
+    }
+
+    void setPlacement(@Nullable final String value)
+    {
+        placement = value;
+    }
+
+    void setCustomData(@Nullable final String value)
+    {
+        customData = value;
+    }
+
+    void setExtraParameter(@Nullable final ReadableMap readableMap)
+    {
+        extraParameter = readableMap.toHashMap();
+    }
+
+    void setAdvertiser(final int id)
+    {
+        sendCurrentAd();
+    }
+
+    void setBody(final int id)
+    {
+        sendCurrentAd();
+    }
+
+    void setCallToAction(final int id)
+    {
+        sendCurrentAd();
+    }
+
+    void setIcon(final int id)
+    {
+        sendCurrentAd();
+    }
+
+    void setMedia(final int id)
+    {
+        sendCurrentAd();
+    }
+
+    void setOptions(final int id)
+    {
+        sendCurrentAd();
+    }
+
+    void setTitle(final int id)
+    {
+        sendCurrentAd();
+    }
+
+    void sendCurrentAd()
+    {
+        if ( currentAd != null )
+        {
+            convertNativeAd();
+        }
+    }
+
+    void loadAd()
+    {
+        // returns an ad immediately if it is preloaded, otherwise loads on the fly and returns in the listener
+        MaxAd ad = AppLovinMAXNativeAdLoader.getInstance().getNativeAd( reactContext, adUnitId, placement, customData, extraParameter, this );
+        if ( ad != null )
+        {
+            AppLovinMAXModule.d( "ad loaded from cache" );
+            destroyCurrentAd();
+            currentAd = ad;
+            convertNativeAd();
+        }
+    }
+
+    public void onAdLoaded(MaxAd ad)
+    {
+        AppLovinMAXModule.d( "ad loaded from net" );
+        destroyCurrentAd();
+        currentAd = ad;
+        convertNativeAd();
+    }
+
+    void convertNativeAd()
+    {
+        RootView rootView = RootViewUtil.getRootView( this );
+        if ( rootView == null )
+        {
+            AppLovinMAXModule.e( "View not attached yet" );
+            return;
+        }
+
+        MaxNativeAd nativeAd = currentAd.getNativeAd();
+        if ( nativeAd == null )
+        {
+            AppLovinMAXModule.e( "Empty nativeAd from MaxNativeAd" );
+            return;
+        }
+
+        WritableMap event = Arguments.createMap();
+        event.putString( "title", nativeAd.getTitle() );
+        event.putString( "advertiser", nativeAd.getAdvertiser() );
+        event.putString( "body", nativeAd.getBody() );
+        event.putString( "callToAction", nativeAd.getCallToAction() );
+        event.putString( "aspectRatio", String.valueOf( nativeAd.getMediaContentAspectRatio() ) );
+
+        MaxNativeAd.MaxNativeAdImage icon = nativeAd.getIcon();
+        if ( icon.getUri() != null )
+        {
+            event.putString( "icon", icon.getUri().toString() );
+        }
+        else if ( icon.getDrawable() != null )
+        {
+            ReactImageView imageView = getImageView();
+            if ( imageView != null )
+            {
+                // FIXME: this is deprecated
+                imageView.setImageDrawable( icon.getDrawable() );
+            }
+        }
+
+        addStretchView( nativeAd.getMediaView(), getMediaView() );
+
+        addStretchView( nativeAd.getOptionsView(), getOptionsView() );
+
+        reactContext.getJSModule( RCTEventEmitter.class ).receiveEvent( getId(), "onNativeAdLoaded", event );
+    }
+
+    void addStretchView(View view, ViewGroup toItem)
+    {
+        if ( toItem == null ) return;
+
+        toItem.removeAllViews();
+
+        // toItem (ReactView) doesn't have a layout policy,
+        // so it needs an exact size for the child to add
+        if ( view != null )
+        {
+            view.measure(
+                    MeasureSpec.makeMeasureSpec( toItem.getWidth(), MeasureSpec.EXACTLY ),
+                    MeasureSpec.makeMeasureSpec( toItem.getHeight(), MeasureSpec.EXACTLY )
+            );
+
+            view.layout( toItem.getLeft(), 0, toItem.getRight(), toItem.getBottom() - toItem.getTop() );
+
+            toItem.addView( view );
+        }
+    }
+
+    void performCallToAction()
+    {
+        if ( currentAd != null )
+        {
+            // FIXME: mostly not working
+            currentAd.getNativeAd().performClick();
+        }
+    }
+
+    ReactViewGroup getMediaView()
+    {
+        RootView rootView = RootViewUtil.getRootView( this );
+        if ( rootView == null )
+        {
+            return null;
+        }
+        return (ReactViewGroup) ReactFindViewUtil.findView( (View) rootView, "almMediaView" );
+    }
+
+    ReactViewGroup getOptionsView()
+    {
+        RootView rootView = RootViewUtil.getRootView( this );
+        if ( rootView == null )
+        {
+            return null;
+        }
+        return (ReactViewGroup) ReactFindViewUtil.findView( (View) rootView, "almOptionsView" );
+    }
+
+    ReactImageView getImageView()
+    {
+        RootView rootView = RootViewUtil.getRootView( this );
+        if ( rootView == null )
+        {
+            return null;
+        }
+        return (ReactImageView) ReactFindViewUtil.findView( (View) rootView, "almIconView" );
+    }
+
+    void destroyCurrentAd()
+    {
+        if ( adUnitId != null && currentAd != null )
+        {
+            AppLovinMAXNativeAdLoader.getInstance().destroyAd( adUnitId, currentAd );
+        }
+    }
+}

--- a/android/src/main/java/com/applovin/reactnative/AppLovinMAXNativeAdViewManager.java
+++ b/android/src/main/java/com/applovin/reactnative/AppLovinMAXNativeAdViewManager.java
@@ -1,0 +1,161 @@
+package com.applovin.reactnative;
+
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReadableArray;
+import com.facebook.react.bridge.ReadableMap;
+import com.facebook.react.common.MapBuilder;
+import com.facebook.react.uimanager.ThemedReactContext;
+import com.facebook.react.uimanager.ViewGroupManager;
+import com.facebook.react.uimanager.annotations.ReactProp;
+
+import java.util.Map;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+public class AppLovinMAXNativeAdViewManager
+        extends ViewGroupManager<AppLovinMAXNativeAdView>
+{
+    public static final String REACT_CLASS = "AppLovinMAXNativeAdView";
+
+    public final int COMMAND_LOAD_AD                = 1;
+    public final int COMMAND_PERFORM_CALL_TO_ACTION = 2;
+
+    ReactApplicationContext mCallerContext;
+
+    public AppLovinMAXNativeAdViewManager(final ReactApplicationContext mCallerContext)
+    {
+        this.mCallerContext = mCallerContext;
+    }
+
+    @NonNull
+    @Override
+    protected AppLovinMAXNativeAdView createViewInstance(@NonNull final ThemedReactContext reactContext)
+    {
+        return new AppLovinMAXNativeAdView( reactContext );
+    }
+
+    @NonNull
+    @Override
+    public String getName()
+    {
+        return REACT_CLASS;
+    }
+
+    /// Callback to JS
+
+    @Nullable
+    @Override
+    public Map<String, Object> getExportedCustomDirectEventTypeConstants()
+    {
+        return MapBuilder.<String, Object>builder()
+                .put( "onNativeAdLoaded", MapBuilder.of( "registrationName", "onNativeAdLoaded" ) )
+                .build();
+    }
+
+
+    /// Call from JS
+
+    @Nullable
+    @Override
+    public Map<String, Integer> getCommandsMap()
+    {
+        return MapBuilder.of(
+                "loadAd", COMMAND_LOAD_AD,
+                "performCallToAction", COMMAND_PERFORM_CALL_TO_ACTION
+        );
+    }
+
+    // NOTE: the method is deprecated but the new version won't work
+    @Override
+    public void receiveCommand(@NonNull final AppLovinMAXNativeAdView root, final int commandId, @Nullable final ReadableArray args)
+    {
+        switch ( commandId )
+        {
+            case COMMAND_LOAD_AD:
+                root.loadAd();
+                break;
+            case COMMAND_PERFORM_CALL_TO_ACTION:
+                root.performCallToAction();
+                break;
+        }
+    }
+
+    /// Property Setters
+
+    @ReactProp(name = "adUnitId")
+    public void setAdUnitId(final AppLovinMAXNativeAdView view, final String value)
+    {
+        view.setAdUnitId( value );
+    }
+
+    @ReactProp(name = "placement")
+    public void setPlacement(final AppLovinMAXNativeAdView view, @Nullable final String value)
+    {
+        view.setPlacement( value );
+    }
+
+    @ReactProp(name = "customData")
+    public void setCustomData(final AppLovinMAXNativeAdView view, @Nullable final String value)
+    {
+        view.setCustomData( value );
+    }
+
+    @ReactProp(name = "extraParameter")
+    public void setExtraParameter(final AppLovinMAXNativeAdView view, @Nullable final ReadableMap value)
+    {
+        view.setExtraParameter( value );
+    }
+
+    @ReactProp(name = "advertiser")
+    public void setAdvertiser(final AppLovinMAXNativeAdView view, final int value)
+    {
+        view.setAdvertiser( value );
+    }
+
+    @ReactProp(name = "body")
+    public void setBody(final AppLovinMAXNativeAdView view, final int value)
+    {
+        view.setBody( value );
+    }
+
+    @ReactProp(name = "callToAction")
+    public void setCallToAction(final AppLovinMAXNativeAdView view, final int value)
+    {
+        view.setCallToAction( value );
+    }
+
+    @ReactProp(name = "icon")
+    public void setIcon(final AppLovinMAXNativeAdView view, final int value)
+    {
+        view.setIcon( value );
+    }
+
+    @ReactProp(name = "media")
+    public void setMedia(final AppLovinMAXNativeAdView view, final int value)
+    {
+        view.setMedia( value );
+    }
+
+    @ReactProp(name = "options")
+    public void setOptions(final AppLovinMAXNativeAdView view, final int value)
+    {
+        view.setOptions( value );
+    }
+
+    @ReactProp(name = "title")
+    public void setTitle(final AppLovinMAXNativeAdView view, final int value)
+    {
+        view.setTitle( value );
+    }
+
+    ///
+
+    @Override
+    public void onDropViewInstance(@NonNull final AppLovinMAXNativeAdView view)
+    {
+        super.onDropViewInstance( view );
+
+        view.destroyCurrentAd();
+    }
+}

--- a/android/src/main/java/com/applovin/reactnative/AppLovinMAXPackage.java
+++ b/android/src/main/java/com/applovin/reactnative/AppLovinMAXPackage.java
@@ -27,8 +27,9 @@ public class AppLovinMAXPackage
     @Override
     public @NonNull List<ViewManager> createViewManagers(@NonNull final ReactApplicationContext reactContext)
     {
-        List<ViewManager> viewManagers = new ArrayList<>( 1 );
+        List<ViewManager> viewManagers = new ArrayList<>( 2 );
         viewManagers.add( new AppLovinMAXAdViewManager( reactContext ) );
+        viewManagers.add( new AppLovinMAXNativeAdViewManager( reactContext ) );
         return viewManagers;
     }
 }

--- a/example/src/components/AppButton.js
+++ b/example/src/components/AppButton.js
@@ -2,8 +2,9 @@ import React from 'react';
 import { View, TouchableOpacity, Text, StyleSheet } from 'react-native';
 
 const AppButton = (props) => {
+  const {style, ...rest} = props;
   return (
-    <View style={styles.container}>
+    <View style={[styles.container, style]}>
       <TouchableOpacity
         disabled={!props.enabled}
         style={[
@@ -11,6 +12,7 @@ const AppButton = (props) => {
           props.enabled
             ? { backgroundColor: '#DDDDDD' }
             : { backgroundColor: '#EEEEEE' },
+          style,
         ]}
         onPress={props.onPress}
       >
@@ -18,6 +20,7 @@ const AppButton = (props) => {
           style={[
             styles.text,
             props.enabled ? { color: 'black' } : { color: 'gray' },
+            style,
           ]}
         >
           {props.title}
@@ -30,12 +33,12 @@ const AppButton = (props) => {
 const styles = StyleSheet.create({
   container: {
     justifyContent: 'center',
-    paddingTop: 10,
+    paddingTop: 8,
     paddingHorizontal: 40,
   },
   button: {
     borderRadius: 8,
-    height: 50,
+    height: 40,
     justifyContent: 'center', // vertical-align
     alignItems: 'center', // horizontal-align
   },

--- a/ios/AppLovinMAX.m
+++ b/ios/AppLovinMAX.m
@@ -7,6 +7,7 @@
 //
 
 #import "AppLovinMAX.h"
+#import "AppLovinMaxNativeAdLoader.h"
 
 #define ROOT_VIEW_CONTROLLER (UIApplication.sharedApplication.keyWindow.rootViewController)
 
@@ -657,6 +658,13 @@ RCT_EXPORT_METHOD(setRewardedAdExtraParameter:(NSString *)adUnitIdentifier :(NSS
     [rewardedAd setExtraParameterForKey: key value: value];
 }
 
+#pragma mark - Native
+
+RCT_EXPORT_METHOD(preLoadNativeAd:(NSString *)adUnitIdentifier :(NSString *)placement :(NSString *)customData :(NSDictionary *)extraParameter)
+{
+    [[AppLovinMaxNativeAdLoader shared] preLoadAd: adUnitIdentifier :placement :customData :extraParameter];
+}
+
 #pragma mark - Ad Callbacks
 
 - (void)didLoadAd:(MAAd *)ad
@@ -686,6 +694,10 @@ RCT_EXPORT_METHOD(setRewardedAdExtraParameter:(NSString *)adUnitIdentifier :(NSS
     else if ( MAAdFormat.rewarded == adFormat )
     {
         name = @"OnRewardedAdLoadedEvent";
+    }
+    else if ( MAAdFormat.native == adFormat )
+    {
+        name = @"OnNativeAdLoadedEvent";
     }
     else
     {
@@ -719,8 +731,15 @@ RCT_EXPORT_METHOD(setRewardedAdExtraParameter:(NSString *)adUnitIdentifier :(NSS
     }
     else
     {
-        [self log: @"invalid adUnitId from %@", [NSThread callStackSymbols]];
-        return;
+        if ([adUnitIdentifier isEqualToString: [AppLovinMaxNativeAdLoader shared].errorAdUnitIdentifier] )
+        {
+            name = @"OnNativeAdLoadFailedEvent";
+        }
+        else
+        {
+            [self log: @"invalid adUnitId from %@", [NSThread callStackSymbols]];
+            return;
+        }
     }
     
     [self sendReactNativeEventWithName: name body: @{@"adUnitId" : adUnitIdentifier,
@@ -749,6 +768,10 @@ RCT_EXPORT_METHOD(setRewardedAdExtraParameter:(NSString *)adUnitIdentifier :(NSS
     else if ( MAAdFormat.rewarded == adFormat )
     {
         name = @"OnRewardedAdClickedEvent";
+    }
+    else if ( MAAdFormat.native == adFormat )
+    {
+        name = @"OnNativeAdClickedEvent";
     }
     else
     {
@@ -865,6 +888,10 @@ RCT_EXPORT_METHOD(setRewardedAdExtraParameter:(NSString *)adUnitIdentifier :(NSS
     else if ( MAAdFormat.rewarded == adFormat )
     {
         name = @"OnRewardedAdRevenuePaid";
+    }
+    else if ( MAAdFormat.native == adFormat )
+    {
+        name = @"OnNativeAdRevenuePaid";
     }
     else
     {
@@ -1493,7 +1520,12 @@ RCT_EXPORT_METHOD(setRewardedAdExtraParameter:(NSString *)adUnitIdentifier :(NSS
              @"OnRewardedAdFailedToDisplayEvent",
              @"OnRewardedAdHiddenEvent",
              @"OnRewardedAdReceivedRewardEvent",
-             @"OnRewardedAdRevenuePaid"];
+             @"OnRewardedAdRevenuePaid",
+             
+             @"OnNativeAdLoadedEvent",
+             @"OnNativeAdLoadFailedEvent",
+             @"OnNativeAdClickedEvent",
+             @"OnNativeAdRevenuePaid"];
 }
 
 - (void)startObserving

--- a/ios/AppLovinMAXNativeAdLoader.h
+++ b/ios/AppLovinMAXNativeAdLoader.h
@@ -1,0 +1,45 @@
+#import <Foundation/Foundation.h>
+#import <AppLovinSDK/AppLovinSDK.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@class AppLovinMaxNativeAdLoader;
+
+@protocol AppLovinMAXNativeAdLoaderDelegate <NSObject>
+- (void)didLoadAd:(MAAd *)ad;
+@end
+
+@interface AppLovinMaxNativeAdLoader : NSObject
+
+/**
+ * Returns an instance of this object.
+ */
++ (AppLovinMaxNativeAdLoader*)shared;
+
+/**
+ * Loads a native ad and saves in the cache.
+ */
+- (void)preLoadAd:(NSString *)adUnitIdentifier :(NSString *)placement :(NSString *)customData :(NSDictionary *)extraParameter;
+
+/**
+ * Returns a native ad from the cache if it is available in the cache. Otherwise, loads a native ad and returns in the listner.
+ */
+- (MAAd *)getNativeAd:(NSString *)adUnitIdentifier
+                     :(NSString *)placement
+                     :(NSString *)customData
+                     :(NSDictionary *)extraParameter
+                     :(id<AppLovinMAXNativeAdLoaderDelegate>)delegate;
+
+/**
+ * destroys the ad.
+ */
+- (void)destroyAd:(NSString *)adUnitIdentifier :(MAAd *)ad;
+
+/**
+ * Keeps an ad unit identifier for the current error
+ */
+@property (nonatomic, strong, readonly) NSString *errorAdUnitIdentifier;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/AppLovinMAXNativeAdLoader.m
+++ b/ios/AppLovinMAXNativeAdLoader.m
@@ -1,0 +1,140 @@
+#import "AppLovinMAXNativeAdLoader.h"
+#import <AppLovinSDK/AppLovinSDK.h>
+#import "AppLovinMAX.h"
+
+@interface AppLovinMaxNativeAdLoader ()  <MANativeAdDelegate>
+
+@property (nonatomic, strong) NSMutableDictionary<NSString *, NSMutableArray<MAAd *> *> *nativeAds;
+@property (nonatomic, strong) NSMutableDictionary<NSString *, MANativeAdLoader *> *loaders;
+@property (nonatomic, strong) NSMutableDictionary<NSString *, id<AppLovinMAXNativeAdLoaderDelegate>> *delegates;
+
+@end
+
+@implementation AppLovinMaxNativeAdLoader
+
+static const int MAX_PRELOADED_ADS = 2;
+
++ (AppLovinMaxNativeAdLoader*)shared
+{
+    static AppLovinMaxNativeAdLoader *_sharedInstance = nil;
+    static dispatch_once_t oncePredecate;
+    
+    dispatch_once(&oncePredecate,^{
+        _sharedInstance = [[AppLovinMaxNativeAdLoader alloc] init];
+    });
+    
+    return _sharedInstance;
+}
+
+- (instancetype)init
+{
+    self = [super init];
+    if ( self )
+    {
+        self.nativeAds = [NSMutableDictionary dictionaryWithCapacity: 2];
+        self.loaders = [NSMutableDictionary dictionaryWithCapacity: 2];
+        self.delegates = [NSMutableDictionary dictionaryWithCapacity: 2];
+    }
+    return self;
+}
+
+- (MANativeAdLoader *)getNativeAdLoader:(NSString *)adUnitIdentifier
+{
+    MANativeAdLoader *loader = self.loaders[adUnitIdentifier];
+    if ( !loader )
+    {
+        loader = [[MANativeAdLoader alloc] initWithAdUnitIdentifier: adUnitIdentifier
+                                                                sdk: AppLovinMAX.shared.sdk];
+        self.loaders[adUnitIdentifier] = loader;
+    }
+    return loader;
+}
+
+- (MAAd *)getNativeAd:(NSString *)adUnitIdentifier :(NSString *)placement :(NSString *)customData :(NSDictionary *)extraParameter :(id<AppLovinMAXNativeAdLoaderDelegate>)delegate
+{
+    NSMutableArray *list = self.nativeAds[adUnitIdentifier];
+    if ( list && list.count > 0 )
+    {
+        MAAd* ad = [list objectAtIndex: 0];
+        if (ad) {
+            [list removeObjectAtIndex: 0];
+            return ad;
+        }
+    }
+    
+    [self load: adUnitIdentifier : placement : customData : extraParameter : delegate];
+    
+    return nil;
+}
+
+- (void)load:(NSString *)adUnitIdentifier :(NSString *)placement :(NSString *)customData :(NSDictionary *)extraParameter :(id<AppLovinMAXNativeAdLoaderDelegate>)delegate
+{
+    MANativeAdLoader * loader = [self getNativeAdLoader: adUnitIdentifier];
+    
+    loader.nativeAdDelegate = self;
+    // FIXME: revenueDelegate not working
+    loader.revenueDelegate = AppLovinMAX.shared;
+    loader.placement = placement;
+    loader.customData = customData;
+    for ( NSString* key in extraParameter )
+    {
+        [loader setExtraParameterForKey: key value: extraParameter[key]];
+    }
+    
+    self.delegates[adUnitIdentifier] = delegate;
+    
+    [loader loadAd];
+}
+
+- (void)preLoadAd:(NSString *)adUnitIdentifier :(NSString *)placement :(NSString *)customData :(NSDictionary *)extraParameter
+{
+    NSMutableArray *queue = self.nativeAds[adUnitIdentifier];
+    if ( queue && queue.count > MAX_PRELOADED_ADS )
+    {
+        return;
+    }
+    [self load: adUnitIdentifier : placement : customData : extraParameter : nil];
+}
+
+- (void)didLoadNativeAd:(MANativeAdView *)nativeAdView forAd:(MAAd *)ad
+{
+    [AppLovinMAX.shared didLoadAd: ad];
+    
+    id<AppLovinMAXNativeAdLoaderDelegate> delegate = self.delegates[ad.adUnitIdentifier];
+    
+    if ( delegate )
+    {
+        [delegate didLoadAd: ad];
+    }
+    else
+    {
+        NSMutableArray *list = self.nativeAds[ad.adUnitIdentifier];
+        if ( !list )
+        {
+            list = [NSMutableArray array];
+            self.nativeAds[ad.adUnitIdentifier] = list;
+        }
+        [list addObject: ad];
+    }
+}
+
+- (void)didFailToLoadNativeAdForAdUnitIdentifier:(NSString *)adUnitIdentifier withError:(MAError *)error
+{
+    _errorAdUnitIdentifier = adUnitIdentifier;
+    [AppLovinMAX.shared didFailToLoadAdForAdUnitIdentifier: adUnitIdentifier withError: error];
+    // should retry
+}
+
+- (void)didClickNativeAd:(MAAd *)ad
+{
+    [AppLovinMAX.shared didClickAd: ad];
+}
+
+- (void)destroyAd:(NSString *)adUnitIdentifier :(MAAd *)ad
+{
+    MANativeAdLoader * loader = [self getNativeAdLoader: adUnitIdentifier];
+    
+    [loader destroyAd: ad];
+}
+
+@end

--- a/ios/AppLovinMAXNativeAdView.h
+++ b/ios/AppLovinMAXNativeAdView.h
@@ -1,0 +1,15 @@
+#import <React/RCTUIManager.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface AppLovinMAXNativeAdView : UIView
+
+- (instancetype)initWithBridge:(RCTBridge *)bridge;
+
+- (void)loadAd;
+
+- (void)performCallToAction;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/AppLovinMAXNativeAdView.m
+++ b/ios/AppLovinMAXNativeAdView.m
@@ -1,0 +1,209 @@
+#import "AppLovinMAXNativeAdView.h"
+#import "AppLovinMaxNativeAdLoader.h"
+#import <AppLovinSDK/AppLovinSDK.h>
+#import "AppLovinMAX.h"
+#import <React/RCTUIManagerUtils.h>
+
+@interface AppLovinMAXNativeAdView () <AppLovinMAXNativeAdLoaderDelegate>
+
+// properties
+@property (nonatomic, copy) NSString *adUnitIdentifier;
+@property (nonatomic, copy) NSString *placement;
+@property (nonatomic, copy) NSString *customData;
+@property (nonatomic, copy) NSDictionary *extraParameter;
+@property (nonatomic, copy) RCTDirectEventBlock onNativeAdLoaded;
+
+// applovin native objects
+@property (nonatomic, strong, nullable) MAAd *currentAd;
+
+@end
+
+@implementation AppLovinMAXNativeAdView {
+    __weak RCTBridge *bridge;
+}
+
+- (instancetype)initWithBridge:(RCTBridge *)_bridge
+{
+    if ( self = [super init] )
+    {
+        bridge = _bridge;
+    }
+    return self;
+}
+
+- (void)dealloc
+{
+    [self destroyCurrentAd];
+}
+
+- (void)setAdUnitId:(NSString *)adUnitId
+{
+    if ( self.adUnitIdentifier && [adUnitId isEqualToString: self.adUnitIdentifier] )
+    {
+        [self destroyCurrentAd];
+    }
+    
+    self.adUnitIdentifier = adUnitId;
+    
+    [self loadAd];
+}
+
+- (void)setAdvertiser:(NSNumber *)advertiser
+{
+    [self sendCurrentAd];
+}
+
+- (void)setBody:(NSNumber *)body
+{
+    [self sendCurrentAd];
+}
+
+- (void)setCallToAction:(NSNumber *)callToAction
+{
+    [self sendCurrentAd];
+}
+
+- (void)setIcon:(NSNumber *)icon
+{
+    [self sendCurrentAd];
+}
+
+- (void)setMedia:(NSNumber *)media
+{
+    [self sendCurrentAd];
+}
+
+- (void)setOptions:(NSNumber *)options
+{
+    [self sendCurrentAd];
+}
+
+- (void)setTitle:(NSNumber *)title
+{
+    [self sendCurrentAd];
+}
+
+- (void)sendCurrentAd
+{
+    if ( self.currentAd )
+    {
+        [self convertNativeAd];
+    }
+}
+
+- (void)loadAd
+{
+    MAAd *ad = [[AppLovinMaxNativeAdLoader shared] getNativeAd: self.adUnitIdentifier : self.placement : self.customData : self.extraParameter : self];
+    if ( ad )
+    {
+        [self destroyCurrentAd];
+        self.currentAd = ad;
+        [self convertNativeAd];
+    }
+}
+
+- (void)didLoadAd:(MAAd *)ad
+{
+    [self destroyCurrentAd];
+    self.currentAd = ad;
+    [self convertNativeAd];
+}
+
+- (void)convertNativeAd
+{
+    MANativeAd *nativeAd = self.currentAd.nativeAd;
+    if ( !nativeAd )
+    {
+        return;
+    }
+    
+    // make sure that the view is attached before sending nativeAd up to JS
+    if ( ![self rootTag] )
+    {
+        return;
+    }
+    
+    NSMutableDictionary *event = [NSMutableDictionary dictionary];
+    event[@"title"] = nativeAd.title;
+    event[@"advertiser"] = nativeAd.advertiser;
+    event[@"body"] = nativeAd.body;
+    event[@"callToAction"] = nativeAd.callToAction;
+    event[@"aspectRatio"] = @(nativeAd.mediaContentAspectRatio).stringValue;
+    
+    if ( nativeAd.icon.URL )
+    {
+        event[@"icon"] = [nativeAd.icon.URL absoluteString];
+    }
+    else if ( nativeAd.icon.image )
+    {
+        UIImageView *iconImageView = [self getImageView];
+        if ( iconImageView )
+        {
+            [iconImageView setImage: nativeAd.icon.image];
+        }
+    }
+    
+    UIView *mediaContentView = [self getMediaView];
+    if ( mediaContentView )
+    {
+        [self addStretchView: nativeAd.mediaView toItem: mediaContentView];
+    }
+    
+    UIView *optionsContentView = [self getOptionsView];
+    if ( optionsContentView )
+    {
+        [self addStretchView: nativeAd.mediaView toItem: optionsContentView];
+    }
+    
+    // notify React for a new native ad
+    self.onNativeAdLoaded(event);
+}
+
+- (void)addStretchView:(UIView *)view toItem:(UIView *)toItem
+{
+    view.translatesAutoresizingMaskIntoConstraints = NO;
+    [toItem addSubview: view];
+    [view.widthAnchor constraintEqualToAnchor: toItem.widthAnchor].active = YES;
+    [view.heightAnchor constraintEqualToAnchor: toItem.heightAnchor].active = YES;
+    [view.centerXAnchor constraintEqualToAnchor: toItem.centerXAnchor].active = YES;
+    [view.centerYAnchor constraintEqualToAnchor: toItem.centerYAnchor].active = YES;
+}
+
+- (void)performCallToAction
+{
+    if ( self.currentAd )
+    {
+        // FIXME: not working
+        [self.currentAd.nativeAd performClick];
+    }
+}
+
+- (UIView *)getMediaView
+{
+    return [bridge.uiManager viewForNativeID: @"almMediaView" withRootTag: [self rootTag]];
+}
+
+- (UIView *)getOptionsView
+{
+    return [bridge.uiManager viewForNativeID: @"almOptionsView" withRootTag: [self rootTag]];
+}
+
+- (UIImageView *)getImageView
+{
+    return (UIImageView *) [bridge.uiManager viewForNativeID: @"almIconView" withRootTag: [self rootTag]];
+}
+
+- (void)destroyCurrentAd
+{
+    if ( self.currentAd )
+    {
+        if (self.currentAd.nativeAd)
+        {
+            [self.currentAd.nativeAd.mediaView removeFromSuperview];
+            [self.currentAd.nativeAd.optionsView removeFromSuperview];
+        }
+        [[AppLovinMaxNativeAdLoader shared] destroyAd:self.adUnitIdentifier :self.currentAd];
+    }
+}
+
+@end

--- a/ios/AppLovinMAXNativeAdViewManager.h
+++ b/ios/AppLovinMAXNativeAdViewManager.h
@@ -1,0 +1,9 @@
+#import <React/RCTViewManager.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface AppLovinMAXNativeAdViewManager : RCTViewManager
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/AppLovinMAXNativeAdViewManager.m
+++ b/ios/AppLovinMAXNativeAdViewManager.m
@@ -1,0 +1,76 @@
+#import "AppLovinMAXNativeAdViewManager.h"
+#import "AppLovinMAXNativeAdView.h"
+#import <React/RCTUIManager.h>
+
+@implementation AppLovinMAXNativeAdViewManager
+
+RCT_EXPORT_MODULE(AppLovinMAXNativeAdView)
+
+RCT_EXPORT_VIEW_PROPERTY(adUnitId, NSString)
+RCT_EXPORT_VIEW_PROPERTY(placement, NSString)
+RCT_EXPORT_VIEW_PROPERTY(customData, NSString)
+RCT_EXPORT_VIEW_PROPERTY(extraParameter, NSDictionary)
+RCT_EXPORT_VIEW_PROPERTY(advertiser, NSNumber)
+RCT_EXPORT_VIEW_PROPERTY(body, NSNumber)
+RCT_EXPORT_VIEW_PROPERTY(callToAction, NSNumber)
+RCT_EXPORT_VIEW_PROPERTY(icon, NSNumber)
+RCT_EXPORT_VIEW_PROPERTY(media, NSNumber)
+RCT_EXPORT_VIEW_PROPERTY(options, NSNumber)
+RCT_EXPORT_VIEW_PROPERTY(title, NSNumber)
+RCT_EXPORT_VIEW_PROPERTY(onNativeAdLoaded, RCTDirectEventBlock)
+
++ (BOOL)requiresMainQueueSetup
+{
+    return YES;
+}
+
+- (UIView *)view
+{
+    return [[AppLovinMAXNativeAdView alloc] initWithBridge: self.bridge];
+}
+
+RCT_EXPORT_METHOD(loadAd:(nonnull NSNumber *)viewTag)
+{
+    [self.bridge.uiManager addUIBlock:^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, UIView *> *viewRegistry) {
+        UIView *view = viewRegistry[viewTag];
+        if ( !view )
+        {
+            RCTLogError(@"Cannot find UIView with tag %@", viewTag);
+            return;
+        }
+        
+        if ( ![view isKindOfClass:[AppLovinMAXNativeAdView class]] )
+        {
+            RCTLogError(@"Cannot find AppLovinMAXNativeAdView with tag %@", viewTag);
+        }
+        else
+        {
+            AppLovinMAXNativeAdView *nativeAdView = (AppLovinMAXNativeAdView *) view;
+            [nativeAdView loadAd];
+        }
+    }];
+}
+
+RCT_EXPORT_METHOD(performCallToAction:(nonnull NSNumber *)viewTag)
+{
+    [self.bridge.uiManager addUIBlock:^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, UIView *> *viewRegistry) {
+        UIView *view = viewRegistry[viewTag];
+        if ( !view )
+        {
+            RCTLogError(@"Cannot find UIView with tag %@", viewTag);
+            return;
+        }
+        
+        if ( ![view isKindOfClass:[AppLovinMAXNativeAdView class]] )
+        {
+            RCTLogError(@"Cannot find AppLovinMAXNativeAdView with tag %@", viewTag);
+        }
+        else
+        {
+            AppLovinMAXNativeAdView *nativeAdView = (AppLovinMAXNativeAdView *) view;
+            [nativeAdView performCallToAction];
+        }
+    }];
+}
+
+@end

--- a/src/NativeAdComponents.js
+++ b/src/NativeAdComponents.js
@@ -1,0 +1,154 @@
+import React, { useContext, useRef, useCallback } from "react";
+import { findNodeHandle, UIManager, Text, Image, View, TouchableOpacity } from "react-native";
+import { NativeAdViewContext } from "./NativeAdViewProvider";
+
+export const AdvertiserView = (props) => {
+
+  const ref = useRef();
+
+  const {nativeAd, nativeAdView} = useContext(NativeAdViewContext);
+
+  const _onLayout = useCallback(() => {
+    if (nativeAdView) {
+      nativeAdView.setNativeProps({
+        advertiser: findNodeHandle(ref.current),
+      });
+    }
+  }, [nativeAdView, ref]);
+
+  return (
+    <Text {...props} nativeID="almAdvertiserView" ref={ref} onLayout={_onLayout}>
+      {nativeAd ? nativeAd.advertiser : null}
+    </Text>
+  );
+};
+
+export const BodyView = (props) => {
+
+  const ref = useRef();
+
+  const {nativeAd, nativeAdView} = useContext(NativeAdViewContext);
+
+  const _onLayout = useCallback(() => {
+    if (nativeAdView) {
+      nativeAdView.setNativeProps({
+        body: findNodeHandle(ref.current),
+      });
+    }
+  }, [nativeAdView, ref]);
+
+  return (
+    <Text {...props} nativeID="almBodyView" ref={ref} onLayout={_onLayout}>
+      {nativeAd ? nativeAd.body : null}
+    </Text>
+  );
+};
+
+export const CallToActionView = (props) => {
+
+  const ref = useRef();
+
+  const {nativeAd, nativeAdView} = useContext(NativeAdViewContext);
+
+  const _onLayout = useCallback(() => {
+    if (nativeAdView) {
+      nativeAdView.setNativeProps({
+        callToAction: findNodeHandle(ref.current),
+      });
+    }
+  }, [nativeAdView, ref]);
+
+  const _onPressButton = () => {
+    UIManager.dispatchViewManagerCommand(
+      findNodeHandle(nativeAdView),
+      UIManager.getViewManagerConfig("AppLovinMAXNativeAdView").Commands.performCallToAction,
+      undefined
+    );
+  };
+
+  return (
+    <TouchableOpacity {...props} nativeID="almCallToActionView" ref={ref} onPress={_onPressButton} onLayout={_onLayout}>
+      <Text {...props}>
+        {nativeAd ? nativeAd.callToAction : null}
+      </Text>
+    </TouchableOpacity>
+  );
+};
+
+export const IconView = (props) => {
+
+  const ref = useRef();
+
+  const {nativeAd, nativeAdView} = useContext(NativeAdViewContext);
+
+  const _onLayout = useCallback(() => {
+    if (nativeAdView) {
+      nativeAdView.setNativeProps({
+        icon: findNodeHandle(ref.current),
+      });
+    }
+  }, [nativeAdView, ref]);
+
+  return (
+    <Image {...props} nativeID="almIconView" ref={ref} source={{ uri: nativeAd.icon || null }} onLayout={_onLayout}/>
+  );
+};
+
+export const MediaView = (props) => {
+
+  const ref = useRef();
+
+  const {nativeAd, nativeAdView} = useContext(NativeAdViewContext);
+
+  const _onLayout = useCallback(() => {
+    if (nativeAdView) {
+      nativeAdView.setNativeProps({
+        media: findNodeHandle(ref.current),
+      });
+    }
+  }, [nativeAdView, ref]);
+
+  return (
+    <View {...props} nativeID="almMediaView" ref={ref} onLayout={_onLayout}/>
+  );
+};
+
+export const OptionsView = (props) => {
+
+  const ref = useRef();
+
+  const {nativeAd, nativeAdView} = useContext(NativeAdViewContext);
+
+  const _onLayout = useCallback(() => {
+    if (nativeAdView) {
+      nativeAdView.setNativeProps({
+        options: findNodeHandle(ref.current),
+      });
+    }
+  }, [nativeAdView, ref]);
+
+  return (
+    <View {...props} nativeID="almOptionsView" ref={ref} onLayout={_onLayout}/>
+  );
+};
+
+export const TitleView = (props) => {
+
+  const ref = useRef();
+
+  const {nativeAd, nativeAdView} = useContext(NativeAdViewContext);
+
+  const _onLayout = useCallback(() => {
+    if (nativeAdView) {
+      nativeAdView.setNativeProps({
+        title: findNodeHandle(ref.current),
+      });
+    }
+  }, [nativeAdView, ref]);
+
+  return (
+    <Text {...props} nativeID="almTitleView" ref={ref} onLayout={_onLayout}>
+      {nativeAd ? nativeAd.title : null}
+    </Text>
+  );
+};

--- a/src/NativeAdView.js
+++ b/src/NativeAdView.js
@@ -1,0 +1,67 @@
+import React, {
+  forwardRef,
+  useContext,
+  useEffect,
+  useCallback,
+  useRef,
+  useImperativeHandle,
+} from "react";
+import { requireNativeComponent, UIManager, findNodeHandle } from "react-native";
+import { NativeAdViewContext, NativeAdViewProvider } from "./NativeAdViewProvider";
+
+export const NativeAdViewWrapper = forwardRef((props, ref) => {
+  return (
+    <NativeAdViewProvider>
+      <NativeAdView {...props} ref={ref}/>
+    </NativeAdViewProvider>
+  );
+});
+
+const NativeAdView = forwardRef((props, ref) => {
+
+  // keep the current ref
+  const thisRef = useRef();
+
+  // context setters work here, but values can be seen only inside the children
+  const {nativeAd, nativeAdView, setNativeAd, setNativeAdView} = useContext(NativeAdViewContext);
+
+  // invoke the native ad loader
+  const loadAd = () => {
+    if (!thisRef) {
+      console.log('NativeAdView: loadAd: thisRef is null');
+    }
+    UIManager.dispatchViewManagerCommand(
+      findNodeHandle(thisRef.current),
+      UIManager.getViewManagerConfig("AppLovinMAXNativeAdView").Commands.loadAd,
+      undefined
+    );
+  };
+
+  // expose functions to outside
+  useImperativeHandle(ref, () => ({ loadAd }), []);
+
+  // save ref to this function and the context
+  const _saveRef = (ref) => {
+    if (ref) {
+      thisRef.current = ref;
+      setNativeAdView(ref);
+    }
+  };
+
+  // callback from the native module to set a loaded ad
+  const _onNativeAdLoaded = (event) => {
+    let ad = event.nativeEvent;
+    setNativeAd(ad);
+  };
+
+  return (
+    <AppLovinMAXNativeAdView {...props} ref={_saveRef} onNativeAdLoaded={_onNativeAdLoaded}>
+        {props.children}
+    </AppLovinMAXNativeAdView>
+  );
+});
+
+export const AppLovinMAXNativeAdView = requireNativeComponent('AppLovinMAXNativeAdView');
+
+export default NativeAdViewWrapper;
+

--- a/src/NativeAdViewProvider.js
+++ b/src/NativeAdViewProvider.js
@@ -1,0 +1,19 @@
+import React, { useState, createContext, useMemo } from "react";
+
+export const NativeAdViewContext = createContext();
+
+export const NativeAdViewProvider = props => {
+
+  const [nativeAd, setNativeAd] = useState({});
+  const [nativeAdView, setNativeAdView] = useState();
+
+  const providerValue = useMemo(() => ({
+    nativeAd, nativeAdView, setNativeAd, setNativeAdView,
+  }), [nativeAd, nativeAdView]);
+
+  return (
+    <NativeAdViewContext.Provider value={providerValue}>
+      {props.children}
+    </NativeAdViewContext.Provider>
+  );
+};

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,8 @@ import { NativeModules, NativeEventEmitter } from "react-native";
 import AdView, { AdFormat, AdViewPosition } from "./AppLovinMAXAdView";
 import { TargetingData as targetingData, AdContentRating, UserGender } from "./TargetingData";
 import { UserSegment as userSegment } from "./UserSegment";
+import { NativeAdViewWrapper as NativeAdView } from "./NativeAdView";
+import { AdvertiserView, BodyView, CallToActionView, IconView, MediaView, OptionsView, TitleView } from "./NativeAdComponents";
 
 const { AppLovinMAX } = NativeModules;
 
@@ -82,6 +84,30 @@ const showRewardedAd = (adUnitId, ...args) => {
   }
 };
 
+const preLoadNativeAd = (adUnitId, ...args) => {
+  switch (args.length) {
+  case 0:
+    // adUnitId
+    AppLovinMAX.preLoadNativeAd(adUnitId, null, null, null);
+    break;
+  case 1:
+    // adUnitId, placement
+    AppLovinMAX.preLoadNativeAd(adUnitId, args[0], null, null);
+    break;
+  case 2:
+    // adUnitId, placement, customData
+    AppLovinMAX.preLoadNativeAd(adUnitId, args[0], args[1], null);
+    break;
+  case 3:
+    // adUnitId, placement, customData, extraParameters
+    AppLovinMAX.preLoadNativeAd(adUnitId, args[0], args[1], args[2]);
+    break;
+  default:
+    // do nothing - unexpected number of arguments
+    break;
+  }
+};
+
 export default {
   ...AppLovinMAX,
   AdView,
@@ -92,6 +118,14 @@ export default {
   ConsentDialogState,
   AdViewPosition,
   AdFormat,
+  NativeAdView,
+  AdvertiserView,
+  TitleView,
+  BodyView,
+  CallToActionView,
+  MediaView,
+  OptionsView,
+  IconView,
   addEventListener,
   removeEventListener,
   // Use callback to avoid need for attaching listeners at top level on each re-render
@@ -100,6 +134,7 @@ export default {
   },
   showInterstitial,
   showRewardedAd,
+  preLoadNativeAd,
 
   /*----------------------*/
   /** AUTO-DECLARED APIs **/


### PR DESCRIPTION
### Initial review for supporting Native ads in RN

NativeAdView is a container view that can contain the native ad components in conjunction with your own components.   NativeAdView loads native ads and applies them for the native ad components to render.

```
    <AppLovinMAX.NativeAdView adUnitId={NATIVE_AD_UNIT_ID}
                              placement='myplacement'
                              customData='mycustomdata'
                              extraParameter={{'key1':'value1', 'key2':'value2',}}
                              ref={nativeAdRef}
                              style={styles.nativeadview}>
```

The native ad components include IconView, TitleVIew, AdvertiserView, BodyView, MediaView, OptionsView, and CallToActionView.    The standard RN properties are applicable to both NativeAdView and the native ad components so that you can layout and change colors and fonts normally as the regular RN components.
```
    <AppLovinMAX.NativeAdView adUnitId={NATIVE_AD_UNIT_ID} style={style.nativeadview} ...>
        <AppLovinMAX.IconView style={styles.icon}/>
        <AppLovinMAX.TitleView style={styles.title}/>
        <AppLovinMAX.AdvertiserView style={styles.advertiser}/>
        <AppLovinMAX.BodyView style={styles.body}/>
        <AppLovinMAX.MediaView style={styles.mediaView}/>
        <AppLovinMAX.CallToActionView style={styles.callToAction}/>
    </AppLovinMAX.NativeAdView>
```

NativeAdView loads a native ad as soon as it is about to be mounted.   Also, you can preload a native ad.

```
    AppLovinMAX.preLoadNativeAd(final String adUnitId, final String placement, final String customData, final ReadableMap extraParameter)
```

You can reload native ads in the particular AppLovinMAX.NativeAdView.

```
    nativeAdRef.current?.loadAd();
```

**Internal Architecture:**


NativeAdView extends UIView for iOS and ReactViewGroup for Android.  RN takes care of managing everything about the components including layout and properties.   The native ad components extend a standard RN component.

```
IconView => <Image/>
TitleVIew, AdvertiserView, BodyView, CallToActionView => <Text/>
MediaView, OptionsView => <View/>
```

NativeAdView loads a native ad in the native layer, then send it up to the JS layer, so the JS layer renders the content.   But, only for MediaView, the native layer directly attaches an AppLovin's native media view to the corresponding RN native view.

**Usage:**

```
const NativeAd = () => {
  const nativeAdRef = useRef();

  const _onPress = () => {
    nativeAdRef.current?.loadAd();
  };

  return (
    <AppLovinMAX.NativeAdView adUnitId={NATIVE_AD_UNIT_ID}
                              placement='myplacement'
                              customData='mycustomdata'
                              extraParameter={{
                                'key1':'value1',
                                'key2':'value2',
                              }}
                              ref={nativeAdViewRef}
                              style={styles.nativead}>
      <View style={{flex: 1, flexDirection: 'column'}}>
        <View style={{flexDirection: 'row'}}>
          <AppLovinMAX.IconView style={styles.icon}/>
          <View style={{flexDirection: 'column', flexGrow: 1}}>
            <AppLovinMAX.TitleView style={styles.title}/>
            <View style={{flexDirection: 'row', justifyContent: 'space-between', paddingHorizontal:10}}>
              <AppLovinMAX.AdvertiserView style={styles.advertiser}/>
              <Text style={styles.admark}>AD</Text>
            </View>
          </View>
        </View>
        <AppLovinMAX.BodyView style={styles.body}/>
        <AppLovinMAX.MediaView style={styles.mediaView}/>
        <AppLovinMAX.CallToActionView style={styles.callToAction}/>
      </View>
    </AppLovinMAX.NativeAdView>
  );
};
```

Android             |  iOS
:-------------------------:|:-------------------------:
<img src="https://user-images.githubusercontent.com/100324169/177079543-f4efb297-ef48-482c-8af2-88519309928b.png" width="200" height="450">  | <img src="https://user-images.githubusercontent.com/100324169/177079567-6b299282-e044-4310-bdb7-d7e6f3c16a18.png" width="200" height="450">




