### PR TITLE
bug/fix_cycle_ref_warning

### DIFF
--- a/src/AppLovinMAXAdView.js
+++ b/src/AppLovinMAXAdView.js
@@ -1,7 +1,25 @@
-import { requireNativeComponent, UIManager, findNodeHandle } from "react-native";
+import { NativeModules, requireNativeComponent, UIManager, findNodeHandle } from "react-native";
 import PropTypes from "prop-types";
 import React from "react";
-import AppLovinMAX from "./index.js";
+
+const { AppLovinMAX } = NativeModules;
+
+export const AdFormat = {
+  BANNER: "banner",
+  MREC: "mrec",
+};
+
+export const AdViewPosition = {
+  TOP_CENTER: "top_center",
+  TOP_LEFT: "top_left",
+  TOP_RIGHT: "top_right",
+  CENTERED: "centered",
+  CENTER_LEFT: "center_left",
+  CENTER_RIGHT: "center_right",
+  BOTTOM_LEFT: "bottom_left",
+  BOTTOM_CENTER: "bottom_center",
+  BOTTOM_RIGHT: "bottom_right",
+};
 
 class AdView extends React.Component {
 
@@ -52,7 +70,7 @@ class AdView extends React.Component {
   // Helper Functions
 
   sizeForAdFormat(adFormat) {
-    if (adFormat === AppLovinMAX.AdFormat.BANNER) {
+    if (adFormat === AdFormat.BANNER) {
 
       var width = AppLovinMAX.isTablet() ? 728 : 320;
       var height;
@@ -120,7 +138,7 @@ class AdView extends React.Component {
     // If the ad unit id or ad format are unset, we can't set the value
     if (adUnitId == null || adFormat == null) return;
 
-    if (adFormat === AppLovinMAX.AdFormat.BANNER) {
+    if (adFormat === AdFormat.BANNER) {
       if (enabled === true || enabled === false) {
         UIManager.dispatchViewManagerCommand(
             findNodeHandle(this),

--- a/src/TargetingData.js
+++ b/src/TargetingData.js
@@ -1,4 +1,6 @@
-import AppLovinMAX from "./index.js";
+import { NativeModules } from "react-native";
+
+const { AppLovinMAX } = NativeModules;
 
 const AdContentRating = {
   None:               0,

--- a/src/UserSegment.js
+++ b/src/UserSegment.js
@@ -1,4 +1,6 @@
-import AppLovinMAX from "./index.js";
+import { NativeModules } from "react-native";
+
+const { AppLovinMAX } = NativeModules;
 
 let UserSegment = {
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 import { NativeModules, NativeEventEmitter } from "react-native";
-import AdView from "./AppLovinMAXAdView";
+import AdView, { AdFormat, AdViewPosition } from "./AppLovinMAXAdView";
 import { TargetingData as targetingData, AdContentRating, UserGender } from "./TargetingData";
 import { UserSegment as userSegment } from "./UserSegment";
 
@@ -27,25 +27,6 @@ const ConsentDialogState = {
    */
   DOES_NOT_APPLY: 2,
 };
-
-const AdFormat = {
-  BANNER: "banner",
-  MREC: "mrec",
-};
-
-const AdViewPosition = {
-  TOP_CENTER: "top_center",
-  TOP_LEFT: "top_left",
-  TOP_RIGHT: "top_right",
-  CENTERED: "centered",
-  CENTER_LEFT: "center_left",
-  CENTER_RIGHT: "center_right",
-  BOTTOM_LEFT: "bottom_left",
-  BOTTOM_CENTER: "bottom_center",
-  BOTTOM_RIGHT: "bottom_right",
-};
-
-// const AdView = AppLovinMAXAdView;
 
 const emitter = new NativeEventEmitter(AppLovinMAX);
 const subscriptions = {};


### PR DESCRIPTION
Fixed the following warnings from the cycle reference.

```
[Tue Jul 05 2022 16:29:10.526]  WARN     Require cycle: ../src/index.js -> ../src/AppLovinMAXAdView.js -> ../src/index.js

Require cycles are allowed, but can result in uninitialized values. Consider refactoring to remove the need for a cycle.
[Tue Jul 05 2022 16:29:10.528]  WARN     Require cycle: ../src/index.js -> ../src/UserSegment.js -> ../src/index.js

Require cycles are allowed, but can result in uninitialized values. Consider refactoring to remove the need for a cycle.
[Tue Jul 05 2022 16:29:10.528]  WARN     Require cycle: ../src/index.js -> ../src/TargetingData.js -> ../src/index.js
```

This is a bit annoying while in development since it is displayed every restart, and probably not a good impression for the first time user.
