### PR TITLE
feat/adview_autorefresh_property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Versions
 
 ## x.x.x
+    * Add autoRefresh to native AdView - <AppLovinMAX.AdView autoRefresh={true/false} .../>
     * Fix `java.lang.ClassCastException` in Android when ad is loaded due to processing `ad.waterfall` object.
 ## 3.2.2
     * Lock to Android SDK 11.4.4 and iOS SDK 11.4.3.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Versions
 
 ## x.x.x
-    * Add autorefresh support to banner and MREC native UI components: `<AppLovinMAX.AdView autoRefresh={true/false} .../>`
+    * Add autorefresh support for banner and MREC native UI components: `<AppLovinMAX.AdView autoRefresh={true/false} .../>`
     * Fix `java.lang.ClassCastException` in Android when ad is loaded due to processing `ad.waterfall` object.
 ## 3.2.2
     * Lock to Android SDK 11.4.4 and iOS SDK 11.4.3.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Versions
 
 ## x.x.x
-    * Add autoRefresh to native AdView - <AppLovinMAX.AdView autoRefresh={true/false} .../>
+    * Add autorefresh support to banner and MREC native UI components: `<AppLovinMAX.AdView autoRefresh={true/false} .../>`
     * Fix `java.lang.ClassCastException` in Android when ad is loaded due to processing `ad.waterfall` object.
 ## 3.2.2
     * Lock to Android SDK 11.4.4 and iOS SDK 11.4.3.

--- a/android/src/main/java/com/applovin/reactnative/AppLovinMAXAdView.java
+++ b/android/src/main/java/com/applovin/reactnative/AppLovinMAXAdView.java
@@ -74,7 +74,7 @@ class AppLovinMAXAdView
         return adView;
     }
 
-    public void maybeAttachAdView(final String placement, final String customData, final String adaptiveBannerEnabledStr, final String adUnitId, final MaxAdFormat adFormat)
+    public void maybeAttachAdView(final String placement, final String customData, final String adaptiveBannerEnabledStr, final Boolean autoRefreshEnabled, final String adUnitId, final MaxAdFormat adFormat)
     {
         final Activity currentActivity = reactContext.getCurrentActivity();
         if ( currentActivity == null )
@@ -109,6 +109,21 @@ class AppLovinMAXAdView
                     if ( adaptiveBannerEnabledStr != null )
                     {
                         adView.setExtraParameter( "adaptive_banner", adaptiveBannerEnabledStr );
+                    }
+
+                    // Set this extra parameter to work around a SDK bug that ignores calls to stopAutoRefresh()
+                    adView.setExtraParameter( "allow_pause_auto_refresh_immediately", "true" );
+
+                    if ( autoRefreshEnabled != null )
+                    {
+                        if ( autoRefreshEnabled.booleanValue() )
+                        {
+                            adView.startAutoRefresh();
+                        }
+                        else
+                        {
+                            adView.stopAutoRefresh();
+                        }
                     }
 
                     adView.loadAd();

--- a/android/src/main/java/com/applovin/reactnative/AppLovinMAXAdViewManager.java
+++ b/android/src/main/java/com/applovin/reactnative/AppLovinMAXAdViewManager.java
@@ -30,9 +30,10 @@ class AppLovinMAXAdViewManager
     private final Map<AppLovinMAXAdView, MaxAdFormat> adFormatRegistry = new HashMap<>();
 
     // Storage for placement and extra parameters if set before the MAAdView is created
-    private final Map<AppLovinMAXAdView, String> placementRegistry             = new HashMap<>();
-    private final Map<AppLovinMAXAdView, String> customDataRegistry            = new HashMap<>();
-    private final Map<AppLovinMAXAdView, String> adaptiveBannerEnabledRegistry = new HashMap<>();
+    private final Map<AppLovinMAXAdView, String>  placementRegistry             = new HashMap<>();
+    private final Map<AppLovinMAXAdView, String>  customDataRegistry            = new HashMap<>();
+    private final Map<AppLovinMAXAdView, String>  adaptiveBannerEnabledRegistry = new HashMap<>();
+    private final Map<AppLovinMAXAdView, Boolean> autoRefreshEnabledRegistry    = new HashMap<>();
 
     public AppLovinMAXAdViewManager(final ReactApplicationContext reactApplicationContext)
     {
@@ -56,6 +57,12 @@ class AppLovinMAXAdViewManager
     public void receiveCommand(@NonNull AppLovinMAXAdView view, String commandId, @Nullable ReadableArray args)
     {
         if ( args == null ) return;
+
+        if ( "setAutoRefresh".equals( commandId ) )
+        {
+            setAutoRefresh( view, args.getBoolean( 0 ) );
+            return;
+        }
 
         String arg = args.getString( 0 );
         if ( arg == null ) return;
@@ -137,6 +144,30 @@ class AppLovinMAXAdViewManager
         } );
     }
 
+    public void setAutoRefresh(final AppLovinMAXAdView view, final boolean enabled)
+    {
+        // Post to main thread to avoid race condition with actual creation of MaxAdView in maybeAttachAdView()
+        view.post( () -> {
+
+            MaxAdView adView = view.getAdView();
+            if ( adView != null )
+            {
+                if ( enabled )
+                {
+                    adView.startAutoRefresh();
+                }
+                else
+                {
+                    adView.stopAutoRefresh();
+                }
+            }
+            else
+            {
+                autoRefreshEnabledRegistry.put( view, enabled );
+            }
+        } );
+    }
+
     public void setAdUnitId(final AppLovinMAXAdView view, final String adUnitId)
     {
         adUnitIdRegistry.put( view, adUnitId );
@@ -162,10 +193,12 @@ class AppLovinMAXAdViewManager
         String placement = placementRegistry.remove( view );
         String customData = customDataRegistry.remove( view );
         String adaptiveBannerEnabledStr = adaptiveBannerEnabledRegistry.remove( view );
+        Boolean autoRefreshEnabled = autoRefreshEnabledRegistry.remove( view );
 
         view.maybeAttachAdView( placement,
                                 customData,
                                 adaptiveBannerEnabledStr,
+                                autoRefreshEnabled,
                                 adUnitIdRegistry.get( view ),
                                 adFormatRegistry.get( view ) );
     }

--- a/ios/AppLovinMAXAdViewManager.m
+++ b/ios/AppLovinMAXAdViewManager.m
@@ -27,6 +27,7 @@
 @property (nonatomic, strong) NSMutableDictionary<NSNumber *, NSString *> *placementRegistry;
 @property (nonatomic, strong) NSMutableDictionary<NSNumber *, NSString *> *customDataRegistry;
 @property (nonatomic, strong) NSMutableDictionary<NSNumber *, NSString *> *adaptiveBannerEnabledRegistry;
+@property (nonatomic, strong) NSMutableDictionary<NSNumber *, NSNumber *> *autoRefreshEnabledRegistry;
 
 @end
 
@@ -49,6 +50,7 @@ RCT_EXPORT_MODULE(AppLovinMAXAdView)
         self.placementRegistry = [NSMutableDictionary dictionary];
         self.customDataRegistry = [NSMutableDictionary dictionary];
         self.adaptiveBannerEnabledRegistry = [NSMutableDictionary dictionary];
+        self.autoRefreshEnabledRegistry = [NSMutableDictionary dictionary];
     }
     return self;
 }
@@ -130,6 +132,38 @@ RCT_EXPORT_METHOD(setAdaptiveBannerEnabled:(nonnull NSNumber *)viewTag toEnabled
         else
         {
             self.adaptiveBannerEnabledRegistry[viewTag] = enabledStr;
+        }
+    }];
+}
+
+// NOTE: `nonnull` must be annotated here for this RN export to work at runtime
+RCT_EXPORT_METHOD(setAutoRefresh:(nonnull NSNumber *)viewTag toEnabled:(BOOL)enabled)
+{
+    [self.bridge.uiManager addUIBlock:^(RCTUIManager *uiManager, NSDictionary<NSNumber *, UIView *> *viewRegistry) {
+        
+        // NOTE: iOS caches the native view via `viewTag` when you remove it from screen (unlike Android)
+        UIView *view = viewRegistry[viewTag];
+        if ( !view )
+        {
+            RCTLogError(@"Cannot find UIView with tag %@", viewTag);
+            return;
+        }
+        
+        MAAdView *adView = [self adViewFromContainerView: view];
+        if ( adView )
+        {
+            if ( enabled )
+            {
+                [adView startAutoRefresh];
+            }
+            else
+            {
+                [adView stopAutoRefresh];
+            }
+        }
+        else
+        {
+            self.autoRefreshEnabledRegistry[viewTag] = [NSNumber numberWithBool: enabled];
         }
     }];
 }
@@ -230,6 +264,22 @@ RCT_EXPORT_METHOD(setAdFormat:(nonnull NSNumber *)viewTag toAdFormat:(NSString *
                 [adView setExtraParameterForKey: @"adaptive_banner" value: adaptiveBannerEnabledStr];
             }
             
+            // Set this extra parameter to work around a SDK bug that ignores calls to stopAutoRefresh()
+            [adView setExtraParameterForKey: @"allow_pause_auto_refresh_immediately" value: @"true"];
+
+            NSNumber *autoRefreshEnabled = self.autoRefreshEnabledRegistry[viewTag];
+            if ( autoRefreshEnabled )
+            {
+                if ( [autoRefreshEnabled boolValue] )
+                {
+                    [adView startAutoRefresh];
+                }
+                else
+                {
+                    [adView stopAutoRefresh];
+                }
+            }
+
             [adView loadAd];
             
             [containerView addSubview: adView];

--- a/ios/AppLovinMAXAdViewManager.m
+++ b/ios/AppLovinMAXAdViewManager.m
@@ -163,7 +163,7 @@ RCT_EXPORT_METHOD(setAutoRefresh:(nonnull NSNumber *)viewTag toEnabled:(BOOL)ena
         }
         else
         {
-            self.autoRefreshEnabledRegistry[viewTag] = [NSNumber numberWithBool: enabled];
+            self.autoRefreshEnabledRegistry[viewTag] = @(enabled);
         }
     }];
 }

--- a/src/AppLovinMAXAdView.js
+++ b/src/AppLovinMAXAdView.js
@@ -33,6 +33,7 @@ class AdView extends React.Component {
     this.setPlacement(this.props.placement);
     this.setCustomData(this.props.customData);
     this.setAdaptiveBannerEnabled(this.props.adaptiveBannerEnabled);
+    this.setAutoRefresh(this.props.autoRefresh);
   }
 
   componentDidUpdate(prevProps) {
@@ -55,6 +56,10 @@ class AdView extends React.Component {
 
     if (prevProps.adaptiveBannerEnabled !== this.props.adaptiveBannerEnabled) {
       this.setAdaptiveBannerEnabled(this.props.adaptiveBannerEnabled);
+    }
+
+    if (prevProps.autoRefresh !== this.props.autoRefresh) {
+      this.setAutoRefresh(this.props.autoRefresh);
     }
   }
 
@@ -148,6 +153,22 @@ class AdView extends React.Component {
       }
     }
   }
+
+  setAutoRefresh(enabled) {
+    var adUnitId = this.props.adUnitId;
+    var adFormat = this.props.adFormat;
+
+    // If the ad unit id or ad format are unset, we can't set the autorefresh.
+    if (adUnitId == null || adFormat == null) return;
+
+    if (enabled === true || enabled === false) {
+      UIManager.dispatchViewManagerCommand(
+        findNodeHandle(this),
+        Platform.OS === 'android' ? "setAutoRefresh" : UIManager.getViewManagerConfig("AppLovinMAXAdView").Commands.setAutoRefresh,
+        [enabled]
+      );
+    }
+  }
 }
 
 AdView.propTypes = {
@@ -175,6 +196,11 @@ AdView.propTypes = {
    * A boolean value representing whether or not to enable adaptive banners. Note that adaptive banners are enabled by default as of v2.3.0.
    */
   adaptiveBannerEnabled: PropTypes.bool,
+
+  /**
+   * A boolean value representing whether or not to enable auto refresh. Note that auto refresh is enabled by default.
+   */
+  autoRefresh: PropTypes.bool,
 };
 
 // requireNativeComponent automatically resolves 'AppLovinMAXAdView' to 'AppLovinMAXAdViewManager'

--- a/src/AppLovinMAXAdView.js
+++ b/src/AppLovinMAXAdView.js
@@ -198,7 +198,7 @@ AdView.propTypes = {
   adaptiveBannerEnabled: PropTypes.bool,
 
   /**
-   * A boolean value representing whether or not to enable auto refresh. Note that auto-refresh is enabled by default.
+   * A boolean value representing whether or not to enable auto-refresh. Note that auto-refresh is enabled by default.
    */
   autoRefresh: PropTypes.bool,
 };

--- a/src/AppLovinMAXAdView.js
+++ b/src/AppLovinMAXAdView.js
@@ -198,7 +198,7 @@ AdView.propTypes = {
   adaptiveBannerEnabled: PropTypes.bool,
 
   /**
-   * A boolean value representing whether or not to enable auto refresh. Note that auto refresh is enabled by default.
+   * A boolean value representing whether or not to enable auto refresh. Note that auto-refresh is enabled by default.
    */
   autoRefresh: PropTypes.bool,
 };


### PR DESCRIPTION
### Add autoRefresh to native AdView

```
            <AppLovinMAX.AdView adUnitId={MREC_AD_UNIT_ID}
                                adFormat={AppLovinMAX.AdFormat.MREC}
                                autoRefresh={isNativeUIMRecAutoRefresh}
                                style={styles.mrec}/>
```

autoRefresh can be dynamically updated to start or stop autoRefresh.

Now it starts with stopAutoRefresh.    The behavior are:

- true: start with startAutoRefresh
- false: start with stopAutoRefresh
- No value:  start with startAutoRefresh by default
