### PR TITLE
added autorefresh apis for the programmatic adview

### DIFF
--- a/android/src/main/java/com/applovin/reactnative/AppLovinMAXModule.java
+++ b/android/src/main/java/com/applovin/reactnative/AppLovinMAXModule.java
@@ -716,6 +716,18 @@ public class AppLovinMAXModule
     }
 
     @ReactMethod()
+    public void startBannerAutoRefresh(final String adUnitId)
+    {
+        startAutoRefresh( adUnitId, getDeviceSpecificBannerAdViewAdFormat() );
+    }
+
+    @ReactMethod()
+    public void stopBannerAutoRefresh(final String adUnitId)
+    {
+        stopAutoRefresh( adUnitId, getDeviceSpecificBannerAdViewAdFormat() );
+    }
+
+    @ReactMethod()
     public void showBanner(final String adUnitId)
     {
         showAdView( adUnitId, getDeviceSpecificBannerAdViewAdFormat() );
@@ -763,6 +775,18 @@ public class AppLovinMAXModule
     public void updateMRecPosition(final String adUnitId, final String mrecPosition)
     {
         updateAdViewPosition( adUnitId, mrecPosition, DEFAULT_AD_VIEW_OFFSET, MaxAdFormat.MREC );
+    }
+
+    @ReactMethod()
+    public void startMRecAutoRefresh(final String adUnitId)
+    {
+        startAutoRefresh( adUnitId, MaxAdFormat.MREC );
+    }
+
+    @ReactMethod()
+    public void stopMRecAutoRefresh(final String adUnitId)
+    {
+        stopAutoRefresh( adUnitId, MaxAdFormat.MREC );
     }
 
     @ReactMethod()
@@ -1434,6 +1458,48 @@ public class AppLovinMAXModule
         } );
     }
 
+    private void startAutoRefresh(final String adUnitId, final MaxAdFormat adFormat)
+    {
+        getReactApplicationContext().runOnUiQueueThread( new Runnable()
+        {
+            @Override
+            public void run()
+            {
+                d( "Starting auto refresh " + adFormat.getLabel() + " with ad unit id \"" + adUnitId );
+
+                final MaxAdView adView = retrieveAdView( adUnitId, adFormat );
+                if ( adView == null )
+                {
+                    e( adFormat.getLabel() + " does not exist" );
+                    return;
+                }
+
+                adView.startAutoRefresh();
+            }
+        } );
+    }
+
+    private void stopAutoRefresh(final String adUnitId, final MaxAdFormat adFormat)
+    {
+        getReactApplicationContext().runOnUiQueueThread( new Runnable()
+        {
+            @Override
+            public void run()
+            {
+                d( "Stopping auto refresh " + adFormat.getLabel() + " with ad unit id \"" + adUnitId );
+
+                final MaxAdView adView = retrieveAdView( adUnitId, adFormat );
+                if ( adView == null )
+                {
+                    e( adFormat.getLabel() + " does not exist" );
+                    return;
+                }
+
+                adView.stopAutoRefresh();
+            }
+        } );
+    }
+
     @Nullable
     private MaxInterstitialAd retrieveInterstitial(String adUnitId)
     {
@@ -1485,6 +1551,9 @@ public class AppLovinMAXModule
             result = new MaxAdView( adUnitId, adFormat, sdk, maybeGetCurrentActivity() );
             result.setListener( this );
             result.setRevenueListener( this );
+
+            // Set this extra parameter to work around a SDK bug that ignores calls to stopAutoRefresh()
+            result.setExtraParameter( "allow_pause_auto_refresh_immediately", "true" );
 
             mAdViews.put( adUnitId, result );
             mAdViewPositions.put( adUnitId, adViewPosition );

--- a/android/src/main/java/com/applovin/reactnative/AppLovinMAXModule.java
+++ b/android/src/main/java/com/applovin/reactnative/AppLovinMAXModule.java
@@ -1465,7 +1465,7 @@ public class AppLovinMAXModule
             @Override
             public void run()
             {
-                d( "Starting auto refresh " + adFormat.getLabel() + " with ad unit id \"" + adUnitId );
+                d( "Starting auto refresh " + adFormat.getLabel() + " with ad unit id \"" + adUnitId + "\"" );
 
                 final MaxAdView adView = retrieveAdView( adUnitId, adFormat );
                 if ( adView == null )
@@ -1486,7 +1486,7 @@ public class AppLovinMAXModule
             @Override
             public void run()
             {
-                d( "Stopping auto refresh " + adFormat.getLabel() + " with ad unit id \"" + adUnitId );
+                d( "Stopping auto refresh " + adFormat.getLabel() + " with ad unit id \"" + adUnitId + "\"" );
 
                 final MaxAdView adView = retrieveAdView( adUnitId, adFormat );
                 if ( adView == null )

--- a/ios/AppLovinMAX.m
+++ b/ios/AppLovinMAX.m
@@ -548,6 +548,16 @@ RCT_EXPORT_METHOD(setBannerExtraParameter:(NSString *)adUnitIdentifier :(NSStrin
     [self setAdViewExtraParameterForAdUnitIdentifier: adUnitIdentifier adFormat: DEVICE_SPECIFIC_ADVIEW_AD_FORMAT key: key value: value];
 }
 
+RCT_EXPORT_METHOD(startBannerAutoRefresh:(NSString *)adUnitIdentifier)
+{
+    [self startAutoRefresh: adUnitIdentifier adFormat: DEVICE_SPECIFIC_ADVIEW_AD_FORMAT];
+}
+
+RCT_EXPORT_METHOD(stopBannerAutoRefresh:(NSString *)adUnitIdentifier)
+{
+    [self stopAutoRefresh: adUnitIdentifier adFormat: DEVICE_SPECIFIC_ADVIEW_AD_FORMAT];
+}
+
 RCT_EXPORT_METHOD(showBanner:(NSString *)adUnitIdentifier)
 {
     [self showAdViewWithAdUnitIdentifier: adUnitIdentifier adFormat: DEVICE_SPECIFIC_ADVIEW_AD_FORMAT];
@@ -588,6 +598,16 @@ RCT_EXPORT_METHOD(setMRecCustomData:(NSString *)adUnitIdentifier :(nullable NSSt
 RCT_EXPORT_METHOD(updateMRecPosition:(NSString *)mrecPosition :(NSString *)adUnitIdentifier)
 {
     [self updateAdViewPosition: mrecPosition withOffset: CGPointZero forAdUnitIdentifier: adUnitIdentifier adFormat: MAAdFormat.mrec];
+}
+
+RCT_EXPORT_METHOD(startMRecAutoRefresh:(NSString *)adUnitIdentifier)
+{
+    [self startAutoRefresh: adUnitIdentifier adFormat: MAAdFormat.mrec];
+}
+
+RCT_EXPORT_METHOD(stopMRecAutoRefresh:(NSString *)adUnitIdentifier)
+{
+    [self stopAutoRefresh: adUnitIdentifier adFormat: MAAdFormat.mrec];
 }
 
 RCT_EXPORT_METHOD(showMRec:(NSString *)adUnitIdentifier)
@@ -1052,6 +1072,28 @@ RCT_EXPORT_METHOD(setRewardedAdExtraParameter:(NSString *)adUnitIdentifier :(NSS
     });
 }
 
+- (void)startAutoRefresh:(NSString *)adUnitIdentifier adFormat:(MAAdFormat *)adFormat
+{
+    dispatch_async(dispatch_get_main_queue(), ^{
+        
+        [self log: @"Starting auto refresh \"%@\" with ad unit identifier \"%@\"", adFormat, adUnitIdentifier];
+        
+        MAAdView *view = [self retrieveAdViewForAdUnitIdentifier: adUnitIdentifier adFormat: adFormat];
+        [view startAutoRefresh];
+    });
+}
+
+- (void)stopAutoRefresh:(NSString *)adUnitIdentifier adFormat:(MAAdFormat *)adFormat
+{
+    dispatch_async(dispatch_get_main_queue(), ^{
+        
+        [self log: @"Stopping auto refresh \"%@\" with ad unit identifier \"%@\"", adFormat, adUnitIdentifier];
+        
+        MAAdView *view = [self retrieveAdViewForAdUnitIdentifier: adUnitIdentifier adFormat: adFormat];
+        [view stopAutoRefresh];
+    });
+}
+
 - (void)showAdViewWithAdUnitIdentifier:(NSString *)adUnitIdentifier adFormat:(MAAdFormat *)adFormat
 {
     dispatch_async(dispatch_get_main_queue(), ^{
@@ -1155,6 +1197,9 @@ RCT_EXPORT_METHOD(setRewardedAdExtraParameter:(NSString *)adUnitIdentifier :(NSS
         result.userInteractionEnabled = NO;
         result.translatesAutoresizingMaskIntoConstraints = NO;
         
+        // Set this extra parameter to work around a SDK bug that ignores calls to stopAutoRefresh()
+        [result setExtraParameterForKey: @"allow_pause_auto_refresh_immediately" value: @"true"];
+
         self.adViews[adUnitIdentifier] = result;
         self.adViewPositions[adUnitIdentifier] = adViewPosition;
         self.adViewOffsets[adUnitIdentifier] = [NSValue valueWithCGPoint: offset];


### PR DESCRIPTION
Realized that the programmatic AdView interface needs APIs for controlling autoRefresh.    Here is the proposed APIs:

Banner:
```
                AppLovinMAX.startBannerAutoRefresh(BANNER_AD_UNIT_ID);
                AppLovinMAX.stopBannerAutoRefresh(BANNER_AD_UNIT_ID);
```

MREC:
```
                AppLovinMAX.startMRecAutoRefresh(MREC_AD_UNIT_ID);
                AppLovinMAX.stopMRecAutoRefresh(MREC_AD_UNIT_ID);
```

In order to start AdView with autoRefresh disabled, the API has to be set right after the show method.

```
              AppLovinMAX.showMRec(MREC_AD_UNIT_ID);
              AppLovinMAX.stopMRecAutoRefresh(MREC_AD_UNIT_ID);
```

