### PR TITLE
feat/reuse_native_adview

### DIFF
--- a/android/src/main/java/com/applovin/reactnative/AppLovinMAXAdViewManager.java
+++ b/android/src/main/java/com/applovin/reactnative/AppLovinMAXAdViewManager.java
@@ -73,8 +73,6 @@ class AppLovinMAXAdViewManager
     {
         view.destroy();
 
-        view.destroy();
-
         super.onDropViewInstance( view );
     }
 }

--- a/android/src/main/java/com/applovin/reactnative/AppLovinMAXAdViewManager.java
+++ b/android/src/main/java/com/applovin/reactnative/AppLovinMAXAdViewManager.java
@@ -73,6 +73,8 @@ class AppLovinMAXAdViewManager
     {
         view.destroy();
 
+        view.destroy();
+
         super.onDropViewInstance( view );
     }
 }

--- a/ios/AppLovinMAX.m
+++ b/ios/AppLovinMAX.m
@@ -7,6 +7,7 @@
 //
 
 #import "AppLovinMAX.h"
+#import "AppLovinMAXAdView.h"
 
 #define ROOT_VIEW_CONTROLLER (UIApplication.sharedApplication.keyWindow.rootViewController)
 
@@ -699,6 +700,23 @@ RCT_EXPORT_METHOD(setRewardedAdExtraParameter:(NSString *)adUnitIdentifier :(NSS
 {
     MARewardedAd *rewardedAd = [self retrieveRewardedAdForAdUnitIdentifier: adUnitIdentifier];
     [rewardedAd setExtraParameterForKey: key value: value];
+}
+
+#pragma mark - Preloading
+
+RCT_EXPORT_METHOD(preloadAdView:(nonnull NSNumber *)count :(NSString *)adUnitIdentifier :(NSString *)adFormatStr :(nullable NSString *)placement :(nullable NSString *)customData :(BOOL)adaptiveBannerEnabled :(BOOL)autoRefresh)
+{
+    MAAdFormat *adFormat;
+    if ( [@"banner" isEqualToString: adFormatStr] )
+    {
+        adFormat = DEVICE_SPECIFIC_ADVIEW_AD_FORMAT;
+    }
+    else if ( [@"mrec" isEqualToString: adFormatStr] )
+    {
+        adFormat = MAAdFormat.mrec;
+    }
+
+    [AppLovinMAXAdView preloadAdView: count adUnitId: adUnitIdentifier adFormat: adFormat placement: placement customData: customData adaptiveBannerEnabled: adaptiveBannerEnabled autoRefresh: autoRefresh];
 }
 
 #pragma mark - Ad Callbacks

--- a/ios/AppLovinMAXAdView.h
+++ b/ios/AppLovinMAXAdView.h
@@ -1,12 +1,17 @@
 #import <React/RCTUIManager.h>
+#import <AppLovinSDK/AppLovinSDK.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
 @interface AppLovinMAXAdView : UIView
 
-@property (nonatomic, strong) MAAdView *adView;
-
-- (MAAdView *)retrieveAdView:(NSString *)adUnitIdentifier adFormat:(MAAdFormat *)adFormat;
++ (void)preloadAdView:(NSNumber *)count
+             adUnitId:(NSString *)adUnitIdentifier
+             adFormat:(MAAdFormat *)adFormat
+            placement:(nullable NSString *)placement
+           customData:(nullable NSString *)customData
+adaptiveBannerEnabled:(BOOL)adaptiveBannerEnabled
+          autoRefresh:(BOOL)autoRefresh;
 
 @end
 

--- a/ios/AppLovinMAXAdView.h
+++ b/ios/AppLovinMAXAdView.h
@@ -4,6 +4,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface AppLovinMAXAdView : UIView
 
+@property (nonatomic, strong) MAAdView *adView;
+
+- (MAAdView *)retrieveAdView:(NSString *)adUnitIdentifier adFormat:(MAAdFormat *)adFormat;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ios/AppLovinMAXAdView.m
+++ b/ios/AppLovinMAXAdView.m
@@ -13,6 +13,10 @@
 @property (nonatomic, copy, nullable) NSString *customData;
 @property (nonatomic, assign, readonly, getter=isAdaptiveBannerEnabled) BOOL adaptiveBannerEnabled;
 @property (nonatomic, assign, readonly, getter=isAutoRefresh) BOOL autoRefresh;
+=======
+#import "AppLovinMAXAdView.h"
+
+@interface AppLovinMAXAdView ()
 
 @end
 
@@ -164,12 +168,26 @@
                                                    [self.adView.centerXAnchor constraintEqualToAnchor: self.centerXAnchor],
                                                    [self.adView.centerYAnchor constraintEqualToAnchor: self.centerYAnchor]]];
     });
+=======
+@synthesize adView;
+
+static NSMutableDictionary<NSString *, NSMutableDictionary<MAAdFormat *, NSMutableSet<MAAdView *> *> *> *mAdViews;
+
+- (instancetype)init
+{
+    if( !mAdViews )
+    {
+        mAdViews = [NSMutableDictionary dictionaryWithCapacity: 2];
+    }
+    
+    return [super init];
 }
 
 - (void)didMoveToWindow
 {
     [super didMoveToWindow];
     
+    /*
     // This view is unmounted
     if ( !self.window )
     {
@@ -183,7 +201,62 @@
             [self.adView removeFromSuperview];
             
             self.adView = nil;
+    */
+
+    // Removed from its superview
+    if ( !self.window )
+    {
+        if ( adView )
+        {
+            [self storeAdView: adView];
         }
+    }
+}
+
+- (MAAdView *)retrieveAdView:(NSString *)adUnitIdentifier adFormat:(MAAdFormat *)adFormat
+{
+    NSMutableDictionary *adFormatListDic = mAdViews[adUnitIdentifier];
+    if ( adFormatListDic )
+    {
+        NSMutableSet *adViewList = adFormatListDic[adFormat];
+        if ( adViewList )
+        {
+            MAAdView *adView = [adViewList anyObject];
+            if ( adView )
+            {
+                [adViewList removeObject: adView];
+            }
+            return adView;
+        }
+    }
+    return nil;
+}
+
+- (void)storeAdView:(MAAdView *)adView
+{
+    NSMutableDictionary *adFormatListDic = mAdViews[adView.adUnitIdentifier];
+    if ( !adFormatListDic )
+    {
+        adFormatListDic = [NSMutableDictionary dictionaryWithCapacity: 2];
+        mAdViews[adView.adUnitIdentifier] = adFormatListDic;
+        
+        NSMutableSet *adViewList = [NSMutableSet setWithCapacity: 2];
+        adFormatListDic[adView.adFormat] = adViewList;
+        
+        [adViewList addObject: adView];
+    }
+    
+    NSMutableSet *adViewList = adFormatListDic[adView.adFormat];
+    if ( !adViewList )
+    {
+        NSMutableSet *adViewList = [NSMutableSet setWithCapacity: 2];
+        adFormatListDic[adView.adFormat] = adViewList;
+        
+        [adViewList addObject: adView];
+    }
+    else
+    {
+        [adViewList addObject: adView];
     }
 }
 


### PR DESCRIPTION
### Add support for re-using AdViews after mount & un-mounts

The original request comes from https://github.com/AppLovin/AppLovin-MAX-React-Native/issues/50.

This will allow reusing native AdViews after un-mounts by caching, and will not reload a new ad upon re-mounts unless auto-refresh is set to true.

It ended up that the amount of changes is more than expected especially on iOS, so please review.

