### PR TITLE
ref/update_build_and_example

### DIFF
--- a/android/src/main/java/com/applovin/reactnative/AppLovinMAXModule.java
+++ b/android/src/main/java/com/applovin/reactnative/AppLovinMAXModule.java
@@ -1933,6 +1933,18 @@ public class AppLovinMAXModule
         mRewardedAds.clear();
     }
 
+    // Required methods introduced React Native 0.65
+    //
+    // Without these methods, the following warnings are generated.
+    //
+    // WARN new NativeEventEmitter() was called with a non-null argument without the required addListener method.
+    // WARN new NativeEventEmitter() was called with a non-null argument without the required removeListeners method.
+    @ReactMethod
+    public void addListener(String eventName) { }
+
+    @ReactMethod
+    public void removeListeners(Integer count) { }
+
     // React Native Bridge
 
     private void sendReactNativeEvent(final String name, @Nullable final WritableMap params)

--- a/example/android/app/src/main/java/com/applovin/enterprise/apps/demoapp/MainApplication.java
+++ b/example/android/app/src/main/java/com/applovin/enterprise/apps/demoapp/MainApplication.java
@@ -32,7 +32,6 @@ public class MainApplication
                     List<ReactPackage> packages = new PackageList( this ).getPackages();
                     // Packages that cannot be autolinked yet can be added manually here, for AppLovinMAXExample:
                     // packages.add(new MyReactNativePackage());
-                    packages.add( new AppLovinMAXPackage() );
 
                     return packages;
                 }

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -3,12 +3,12 @@
 buildscript {
     ext {
         buildToolsVersion = "28.0.3"
-        minSdkVersion = 16
+        minSdkVersion = 21
         compileSdkVersion = 28
         targetSdkVersion = 28
     }
     ext.versions = [
-            'minSdk'                : 16,
+            'minSdk'                : 21,
             'compileSdk'            : 29,
             'targetSdk'             : 29,
             'playServicesIdentifier': "16.0.0",

--- a/example/package.json
+++ b/example/package.json
@@ -13,16 +13,9 @@
     "android:bundle:release": "react-native bundle --platform android --dev false --entry-file index.tsx --bundle-output android/app/src/main/assets/index.android.bundle --assets-dest android/app/build/intermediates/res/merged/release/"
   },
   "dependencies": {
-    "@react-native-community/masked-view": "^0.1.10",
-    "@react-navigation/native": "^5.9.3",
-    "@react-navigation/stack": "^5.14.3",
     "react": "^16.13.1",
     "react-native": "^0.63.1",
-    "react-native-applovin-max": "^2.3.1",
-    "react-native-gesture-handler": "^1.10.3",
-    "react-native-reanimated": "^2.0.0",
-    "react-native-safe-area-context": "^3.2.0",
-    "react-native-screens": "^2.18.1"
+    "react-native-applovin-max": "^2.3.1"
   },
   "devDependencies": {
     "@babel/core": "^7.9.6",

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -370,7 +370,7 @@ const App = () => {
 const styles = StyleSheet.create({
   container: {
     height: Platform.select({
-      ios: Dimensions.get('window').height-44, // For top safe area
+      ios: Dimensions.get('window').height - 44, // For top safe area
       android: Dimensions.get('window').height,
     }),
   },

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,10 +1,8 @@
 import React, {useState, useEffect} from 'react';
-import {Platform, StyleSheet, Text, View} from 'react-native';
+import {Platform, StyleSheet, Text, View, SafeAreaView, Dimensions} from 'react-native';
 import AppLovinMAX from '../../src/index';
 import AppLogo from './components/AppLogo';
 import AppButton from './components/AppButton';
-import 'react-native-gesture-handler';
-import {NavigationContainer} from "@react-navigation/native";
 
 const adLoadState = {
   notLoaded: 'NOT_LOADED',
@@ -243,7 +241,7 @@ const App = () => {
   }
 
   return (
-    <NavigationContainer>
+    <SafeAreaView>
       <View style={styles.container}>
         <AppLogo/>
         <Text style={styles.statusText}>
@@ -365,14 +363,16 @@ const App = () => {
           }}
         />
       </View>
-    </NavigationContainer>
+    </SafeAreaView>
   );
 };
 
 const styles = StyleSheet.create({
   container: {
-    paddingTop: 80,
-    flex: 1, // Enables flexbox column layout
+    height: Platform.select({
+      ios: Dimensions.get('window').height-44, // For top safe area
+      android: Dimensions.get('window').height,
+    }),
   },
   statusText: {
     marginBottom: 10,

--- a/example/src/components/AppLogo.js
+++ b/example/src/components/AppLogo.js
@@ -20,8 +20,6 @@ const styles = StyleSheet.create({
   },
   container: {
     height: 60,
-    paddingTop: 10,
-    paddingBottom: 50,
     alignItems: 'center', // horizontal-align
     justifyContent: 'center', // vertical-align
   },


### PR DESCRIPTION
Updated build and example:

- Suspend the Android warning messages with RN 0.65 and later by adding addListener and removeListeners.
- Remove to add AppLovinMAXPackage() to package, which will be automatically linked.
- Update the minSdkVersion from 16 to 21 for Android to build the example
- Remove unnecessary pacakges and libraries from the example