### PR TITLE
feat/reuse_native_adview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Versions
 
+## x.x.x
+    * Add support for re-using AdViews after mount & un-mounts
 ## 3.3.1
     * Depend on Android SDK 11.5.1 and iOS SDK 11.5.1.
     * Update Android Gradle plugin to v3.5.4 to be compatible with <queries> element in manifest files.


### PR DESCRIPTION
Add support for re-using AdViews after mount & un-mounts

- expiration not supported
- max number of cache not supported