### PR TITLE
bug/adview_not_emitting_onadloadfailedevent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Versions
 
+## x.x.x
+    * Fix not emitting an adLoadFailed event for a native adView (banner/mrec)
 ## 4.0.0
     * Add support for native ads - [docs](https://dash.applovin.com/documentation/mediation/react-native/ad-formats/native-manual).
     * Depend on Android SDK 11.5.3 and iOS SDK 11.5.3.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Versions
 
 ## x.x.x
-    * Fix not emitting an adLoadFailed event for a native adView (banner/mrec)
+    * Fix not emitting an `"OnBannerAdLoadFailedEvent"` or `"OnMRecAdLoadFailedEvent"` event for native UI component banners and MRECs.
 ## 4.0.0
     * Add support for native ads - [docs](https://dash.applovin.com/documentation/mediation/react-native/ad-formats/native-manual).
     * Depend on Android SDK 11.5.3 and iOS SDK 11.5.3.

--- a/android/src/main/java/com/applovin/reactnative/AppLovinMAXAdView.java
+++ b/android/src/main/java/com/applovin/reactnative/AppLovinMAXAdView.java
@@ -251,24 +251,6 @@ class AppLovinMAXAdView
     }
 
     @Override
-    public void onAdDisplayed(final MaxAd ad)
-    {
-        AppLovinMAXModule.getInstance().onAdDisplayed( ad );
-    }
-
-    @Override
-    public void onAdHidden(final MaxAd ad)
-    {
-        AppLovinMAXModule.getInstance().onAdHidden( ad );
-    }
-
-    @Override
-    public void onAdClicked(final MaxAd ad)
-    {
-        AppLovinMAXModule.getInstance().onAdClicked( ad );
-    }
-
-    @Override
     public void onAdLoadFailed(final String adUnitId, final MaxError error)
     {
         String name = ( adFormat == MaxAdFormat.MREC ) ? "OnMRecAdLoadFailedEvent" : "OnBannerAdLoadFailedEvent";
@@ -283,6 +265,12 @@ class AppLovinMAXAdView
     }
 
     @Override
+    public void onAdClicked(final MaxAd ad)
+    {
+        AppLovinMAXModule.getInstance().onAdClicked( ad );
+    }
+
+    @Override
     public void onAdExpanded(final MaxAd ad)
     {
         AppLovinMAXModule.getInstance().onAdExpanded( ad );
@@ -292,5 +280,19 @@ class AppLovinMAXAdView
     public void onAdCollapsed(final MaxAd ad)
     {
         AppLovinMAXModule.getInstance().onAdCollapsed( ad );
+    }
+
+    /// Deprecated Callbacks
+
+    @Override
+    public void onAdDisplayed(final MaxAd ad)
+    {
+        AppLovinMAXModule.getInstance().onAdDisplayed( ad );
+    }
+
+    @Override
+    public void onAdHidden(final MaxAd ad)
+    {
+        AppLovinMAXModule.getInstance().onAdHidden( ad );
     }
 }

--- a/android/src/main/java/com/applovin/reactnative/AppLovinMAXAdView.java
+++ b/android/src/main/java/com/applovin/reactnative/AppLovinMAXAdView.java
@@ -288,8 +288,5 @@ class AppLovinMAXAdView
     public void onAdDisplayed(final MaxAd ad) {}
 
     @Override
-    public void onAdHidden(final MaxAd ad)
-    {
-        AppLovinMAXModule.getInstance().onAdHidden( ad );
-    }
+    public void onAdHidden(final MaxAd ad) {}
 }

--- a/android/src/main/java/com/applovin/reactnative/AppLovinMAXAdView.java
+++ b/android/src/main/java/com/applovin/reactnative/AppLovinMAXAdView.java
@@ -4,7 +4,11 @@ import android.app.Activity;
 import android.content.Context;
 import android.text.TextUtils;
 
+import com.applovin.mediation.MaxAd;
 import com.applovin.mediation.MaxAdFormat;
+import com.applovin.mediation.MaxAdListener;
+import com.applovin.mediation.MaxAdViewAdListener;
+import com.applovin.mediation.MaxError;
 import com.applovin.mediation.ads.MaxAdView;
 import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.views.view.ReactViewGroup;
@@ -16,6 +20,7 @@ import androidx.annotation.Nullable;
  */
 class AppLovinMAXAdView
         extends ReactViewGroup
+        implements MaxAdListener, MaxAdViewAdListener
 {
     private final ThemedReactContext reactContext;
 
@@ -200,7 +205,7 @@ class AppLovinMAXAdView
             AppLovinMAXModule.d( "Attaching MaxAdView for " + adUnitId );
 
             adView = new MaxAdView( adUnitId, adFormat, AppLovinMAXModule.getInstance().getSdk(), currentActivity );
-            adView.setListener( AppLovinMAXModule.getInstance() );
+            adView.setListener( this );
             adView.setRevenueListener( AppLovinMAXModule.getInstance() );
             adView.setPlacement( placement );
             adView.setCustomData( customData );
@@ -237,5 +242,55 @@ class AppLovinMAXAdView
 
             adView = null;
         }
+    }
+
+    @Override
+    public void onAdLoaded(final MaxAd ad)
+    {
+        AppLovinMAXModule.getInstance().onAdLoaded( ad );
+    }
+
+    @Override
+    public void onAdDisplayed(final MaxAd ad)
+    {
+        AppLovinMAXModule.getInstance().onAdDisplayed( ad );
+    }
+
+    @Override
+    public void onAdHidden(final MaxAd ad)
+    {
+        AppLovinMAXModule.getInstance().onAdHidden( ad );
+    }
+
+    @Override
+    public void onAdClicked(final MaxAd ad)
+    {
+        AppLovinMAXModule.getInstance().onAdClicked( ad );
+    }
+
+    @Override
+    public void onAdLoadFailed(final String adUnitId, final MaxError error)
+    {
+        String name = ( adFormat == MaxAdFormat.MREC ) ? "OnMRecAdLoadFailedEvent" : "OnBannerAdLoadFailedEvent";
+        
+        AppLovinMAXModule.getInstance().sendReactNativeEventForAdLoadFailed( name, adUnitId, error );
+    }
+
+    @Override
+    public void onAdDisplayFailed(final MaxAd ad, final MaxError error)
+    {
+        AppLovinMAXModule.getInstance().onAdDisplayFailed( ad, error );
+    }
+
+    @Override
+    public void onAdExpanded(final MaxAd ad)
+    {
+        AppLovinMAXModule.getInstance().onAdExpanded( ad );
+    }
+
+    @Override
+    public void onAdCollapsed(final MaxAd ad)
+    {
+        AppLovinMAXModule.getInstance().onAdCollapsed( ad );
     }
 }

--- a/android/src/main/java/com/applovin/reactnative/AppLovinMAXAdView.java
+++ b/android/src/main/java/com/applovin/reactnative/AppLovinMAXAdView.java
@@ -285,10 +285,7 @@ class AppLovinMAXAdView
     /// Deprecated Callbacks
 
     @Override
-    public void onAdDisplayed(final MaxAd ad)
-    {
-        AppLovinMAXModule.getInstance().onAdDisplayed( ad );
-    }
+    public void onAdDisplayed(final MaxAd ad) {}
 
     @Override
     public void onAdHidden(final MaxAd ad)

--- a/android/src/main/java/com/applovin/reactnative/AppLovinMAXModule.java
+++ b/android/src/main/java/com/applovin/reactnative/AppLovinMAXModule.java
@@ -953,11 +953,6 @@ public class AppLovinMAXModule
         sendReactNativeEvent( name, getAdInfo( ad ) );
     }
 
-    public void handleNativeAdLoadFailureForAdUnitId(final String adUnitId, final MaxError error)
-    {
-        sendReactNativeEventForAdLoadFailed( "OnNativeAdLoadFailedEvent", adUnitId, error );
-    }
-
     @Override
     public void onAdLoadFailed(final String adUnitId, final MaxError error)
     {
@@ -989,7 +984,7 @@ public class AppLovinMAXModule
         sendReactNativeEventForAdLoadFailed( name, adUnitId, error );
     }
 
-    private void sendReactNativeEventForAdLoadFailed(final String name, final String adUnitId, final @Nullable MaxError error)
+    public void sendReactNativeEventForAdLoadFailed(final String name, final String adUnitId, final @Nullable MaxError error)
     {
         WritableMap params = Arguments.createMap();
         params.putString( "adUnitId", adUnitId );

--- a/android/src/main/java/com/applovin/reactnative/AppLovinMAXNativeAdView.java
+++ b/android/src/main/java/com/applovin/reactnative/AppLovinMAXNativeAdView.java
@@ -245,7 +245,7 @@ public class AppLovinMAXNativeAdView
                 isLoading.set( false );
 
                 AppLovinMAXModule.e( "Native ad is of template type, failing ad load..." );
-                AppLovinMAXModule.getInstance().handleNativeAdLoadFailureForAdUnitId( adUnitId, null );
+                AppLovinMAXModule.getInstance().sendReactNativeEventForAdLoadFailed( "OnNativeAdLoadFailedEvent", adUnitId, null );
 
                 return;
             }
@@ -277,7 +277,7 @@ public class AppLovinMAXNativeAdView
             AppLovinMAXModule.e( "Failed to load native ad for Ad Unit ID " + adUnitId + " with error: " + error );
 
             // Notify publisher
-            AppLovinMAXModule.getInstance().handleNativeAdLoadFailureForAdUnitId( adUnitId, error );
+            AppLovinMAXModule.getInstance().sendReactNativeEventForAdLoadFailed( "OnNativeAdLoadFailedEvent", adUnitId, error );
         }
 
         @Override

--- a/ios/AppLovinMAX.h
+++ b/ios/AppLovinMAX.h
@@ -37,9 +37,9 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)log:(NSString *)format, ...;
 
 /**
- * Convenience method for invoking a native ad load failure event.
+ * Convenience method for invoking an ad load failure event.
  */
-- (void)handleNativeAdLoadFailureForAdUnitIdentifier:(NSString *)adUnitIdentifier error:(nullable MAError *)error;
+- (void)sendReactNativeEventForAdLoadFailed:(NSString *)name forAdUnitIdentifier:(NSString *)adUnitIdentifier withError:(nullable MAError *)error;
 
 @end
 

--- a/ios/AppLovinMAX.m
+++ b/ios/AppLovinMAX.m
@@ -655,12 +655,6 @@ RCT_EXPORT_METHOD(destroyMRec:(NSString *)adUnitIdentifier)
 RCT_EXPORT_METHOD(loadInterstitial:(NSString *)adUnitIdentifier)
 {
     MAInterstitialAd *interstitial = [self retrieveInterstitialForAdUnitIdentifier: adUnitIdentifier];
-    if ( !interstitial )
-    {
-        [self sendReactNativeEventForAdLoadFailed: @"OnInterstitialLoadFailedEvent" forAdUnitIdentifier: adUnitIdentifier withError: nil];
-        return;
-    }
-    
     [interstitial loadAd];
 }
 
@@ -687,12 +681,6 @@ RCT_EXPORT_METHOD(setInterstitialExtraParameter:(NSString *)adUnitIdentifier :(N
 RCT_EXPORT_METHOD(loadRewardedAd:(NSString *)adUnitIdentifier)
 {
     MARewardedAd *rewardedAd = [self retrieveRewardedAdForAdUnitIdentifier: adUnitIdentifier];
-    if ( !rewardedAd )
-    {
-        [self sendReactNativeEventForAdLoadFailed: @"OnRewardedAdLoadFailedEvent" forAdUnitIdentifier: adUnitIdentifier withError: nil];
-        return;
-    }
-    
     [rewardedAd loadAd];
 }
 
@@ -759,19 +747,15 @@ RCT_EXPORT_METHOD(setRewardedAdExtraParameter:(NSString *)adUnitIdentifier :(NSS
 
 - (void)sendReactNativeEventForAdLoadFailed:(NSString *)name forAdUnitIdentifier:(NSString *)adUnitIdentifier withError:(nullable MAError *)error
 {
-    NSMutableDictionary *body = @{@"adUnitId": adUnitIdentifier}.mutableCopy;
-    
-    if ( error )
-    {
-        [body addEntriesFromDictionary: @{@"code" : @(error.code),
-                                          @"message" : error.message,
-                                          @"adLoadFailureInfo" : error.adLoadFailureInfo ?: @"",
-                                          @"waterfall": [self createAdWaterfallInfo: error.waterfall]}];
-    }
-    else
-    {
-        [body addEntriesFromDictionary: @{@"code" : @(MAErrorCodeUnspecified)}];
-    }
+    NSDictionary *body = ( error ) ?
+        @{@"adUnitId": adUnitIdentifier,
+          @"code" : @(error.code),
+          @"message" : error.message,
+          @"adLoadFailureInfo" : error.adLoadFailureInfo ?: @"",
+          @"waterfall": [self createAdWaterfallInfo: error.waterfall]}
+    :
+        @{@"adUnitId": adUnitIdentifier,
+          @"code" : @(MAErrorCodeUnspecified)};
     
     [self sendReactNativeEventWithName: name body: body];
 }

--- a/ios/AppLovinMAXAdView.m
+++ b/ios/AppLovinMAXAdView.m
@@ -9,7 +9,7 @@
 #import "AppLovinMAX.h"
 #import "AppLovinMAXAdView.h"
 
-@interface AppLovinMAXAdView()
+@interface AppLovinMAXAdView()<MAAdViewAdDelegate>
 
 @property (nonatomic, strong, nullable) MAAdView *adView; // nil when unmounted
 
@@ -145,7 +145,7 @@
                                                         adFormat: adFormat
                                                              sdk: [AppLovinMAX shared].sdk];
         self.adView.frame = (CGRect) { CGPointZero, self.frame.size };
-        self.adView.delegate = [AppLovinMAX shared]; // Go through core class for callback forwarding to React Native layer
+        self.adView.delegate = self;
         self.adView.revenueDelegate = [AppLovinMAX shared];
         self.adView.placement = self.placement;
         self.adView.customData = self.customData;
@@ -192,6 +192,52 @@
             self.adView = nil;
         }
     }
+}
+
+#pragma mark - MAAdDelegate Protocol
+
+- (void)didLoadAd:(MAAd *)ad
+{
+    [[AppLovinMAX shared] didLoadAd: ad];
+}
+
+- (void)didFailToLoadAdForAdUnitIdentifier:(NSString *)adUnitIdentifier withError:(MAError *)error
+{
+    NSString *name = ( MAAdFormat.mrec == self.adFormat ) ? @"OnMRecAdLoadFailedEvent" : @"OnBannerAdLoadFailedEvent";
+    
+    [[AppLovinMAX shared] sendReactNativeEventForAdLoadFailed: name forAdUnitIdentifier: adUnitIdentifier withError: error];
+}
+
+- (void)didDisplayAd:(MAAd *)ad
+{
+    [[AppLovinMAX shared] didDisplayAd: ad];
+}
+
+- (void)didHideAd:(MAAd *)ad
+{
+    [[AppLovinMAX shared] didHideAd: ad];
+}
+
+- (void)didClickAd:(MAAd *)ad
+{
+    [[AppLovinMAX shared] didClickAd: ad];
+}
+
+- (void)didFailToDisplayAd:(MAAd *)ad withError:(MAError *)error
+{
+    [[AppLovinMAX shared] didFailToDisplayAd: ad withError: error];
+}
+
+#pragma mark - MAAdViewAdDelegate Protocol
+
+- (void)didExpandAd:(MAAd *)ad
+{
+    [[AppLovinMAX shared] didExpandAd: ad];
+}
+
+- (void)didCollapseAd:(MAAd *)ad
+{
+    [[AppLovinMAX shared] didCollapseAd: ad];
 }
 
 @end

--- a/ios/AppLovinMAXAdView.m
+++ b/ios/AppLovinMAXAdView.m
@@ -208,24 +208,14 @@
     [[AppLovinMAX shared] sendReactNativeEventForAdLoadFailed: name forAdUnitIdentifier: adUnitIdentifier withError: error];
 }
 
-- (void)didDisplayAd:(MAAd *)ad
+- (void)didFailToDisplayAd:(MAAd *)ad withError:(MAError *)error
 {
-    [[AppLovinMAX shared] didDisplayAd: ad];
-}
-
-- (void)didHideAd:(MAAd *)ad
-{
-    [[AppLovinMAX shared] didHideAd: ad];
+    [[AppLovinMAX shared] didFailToDisplayAd: ad withError: error];
 }
 
 - (void)didClickAd:(MAAd *)ad
 {
     [[AppLovinMAX shared] didClickAd: ad];
-}
-
-- (void)didFailToDisplayAd:(MAAd *)ad withError:(MAError *)error
-{
-    [[AppLovinMAX shared] didFailToDisplayAd: ad withError: error];
 }
 
 #pragma mark - MAAdViewAdDelegate Protocol
@@ -238,6 +228,18 @@
 - (void)didCollapseAd:(MAAd *)ad
 {
     [[AppLovinMAX shared] didCollapseAd: ad];
+}
+
+#pragma mark - Deprecated Callbacks
+
+- (void)didDisplayAd:(MAAd *)ad
+{
+    [[AppLovinMAX shared] didDisplayAd: ad];
+}
+
+- (void)didHideAd:(MAAd *)ad
+{
+    [[AppLovinMAX shared] didHideAd: ad];
 }
 
 @end

--- a/ios/AppLovinMAXAdView.m
+++ b/ios/AppLovinMAXAdView.m
@@ -232,14 +232,7 @@
 
 #pragma mark - Deprecated Callbacks
 
-- (void)didDisplayAd:(MAAd *)ad
-{
-    [[AppLovinMAX shared] didDisplayAd: ad];
-}
-
-- (void)didHideAd:(MAAd *)ad
-{
-    [[AppLovinMAX shared] didHideAd: ad];
-}
+- (void)didDisplayAd:(MAAd *)ad {}
+- (void)didHideAd:(MAAd *)ad {}
 
 @end

--- a/ios/AppLovinMAXNativeAdView.m
+++ b/ios/AppLovinMAXNativeAdView.m
@@ -176,11 +176,11 @@
         [[AppLovinMAX shared] log: @"Cannot find an icon image view with tag \"%@\" for %@", tag, self.adUnitId];
         return;
     }
- 
-  [self.clickableViews addObject: view];
-  
-  MANativeAdImage *icon = self.nativeAd.nativeAd.icon;
-  
+    
+    [self.clickableViews addObject: view];
+    
+    MANativeAdImage *icon = self.nativeAd.nativeAd.icon;
+    
     // Check if "URL" was missing and therefore need to set the image data
     if ( !icon.URL && icon.image )
     {
@@ -201,7 +201,7 @@
         [self.isLoading set: NO];
         
         [[AppLovinMAX shared] log: @"Native ad is of template type, failing ad load..."];
-        [[AppLovinMAX shared] handleNativeAdLoadFailureForAdUnitIdentifier: self.adUnitId error: nil];
+        [[AppLovinMAX shared] sendReactNativeEventForAdLoadFailed: @"OnNativeAdLoadFailedEvent" forAdUnitIdentifier: self.adUnitId withError: nil];
         
         return;
     }
@@ -273,7 +273,7 @@
     [[AppLovinMAX shared] log: @"Failed to load native ad for Ad Unit ID %@ with error: %@", self.adUnitId, error];
     
     // Notify publisher
-    [[AppLovinMAX shared] handleNativeAdLoadFailureForAdUnitIdentifier: self.adUnitId error: error];
+    [[AppLovinMAX shared] sendReactNativeEventForAdLoadFailed: @"OnNativeAdLoadFailedEvent" forAdUnitIdentifier: self.adUnitId withError: error];
 }
 
 - (void)didClickNativeAd:(MAAd *)ad


### PR DESCRIPTION
### Fix not emitting an adLoadFailed event for a native adView (banner/mrec)

Originally reported in Issue #115

The new native AdView won't invoke OnBannerAdLoadFailedEvent()/OnMRecAdLoadFailedEvent() when failing to load ads.

Fix:  use sendReactNativeEventForAdLoadFailed for both adView and nativeAdView.