### PR TITLE
bug/npe_native_ad_views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Versions
 
 ## x.x.x
+    * Fix NPE for accessing the unmounted child views in the native ad.
     * Fix not emitting an `"OnBannerAdLoadFailedEvent"` or `"OnMRecAdLoadFailedEvent"` event for native UI component banners and MRECs.
 ## 4.0.0
     * Add support for native ads - [docs](https://dash.applovin.com/documentation/mediation/react-native/ad-formats/native-manual).

--- a/android/src/main/java/com/applovin/reactnative/AppLovinMAXNativeAdView.java
+++ b/android/src/main/java/com/applovin/reactnative/AppLovinMAXNativeAdView.java
@@ -135,6 +135,12 @@ public class AppLovinMAXNativeAdView
         if ( nativeAd.getNativeAd().getTitle() == null ) return;
 
         View view = findViewById( tag );
+        if ( view == null )
+        {
+            AppLovinMAXModule.e( "Cannot find a title view with tag \"" + tag + "\" for " + adUnitId );
+            return;
+        }
+
         view.setClickable( true );
 
         clickableViews.add( view );
@@ -145,6 +151,12 @@ public class AppLovinMAXNativeAdView
         if ( nativeAd.getNativeAd().getAdvertiser() == null ) return;
 
         View view = findViewById( tag );
+        if ( view == null )
+        {
+            AppLovinMAXModule.e( "Cannot find an advertiser view with tag \"" + tag + "\" for " + adUnitId );
+            return;
+        }
+
         view.setClickable( true );
 
         clickableViews.add( view );
@@ -155,6 +167,12 @@ public class AppLovinMAXNativeAdView
         if ( nativeAd.getNativeAd().getBody() == null ) return;
 
         View view = findViewById( tag );
+        if ( view == null )
+        {
+            AppLovinMAXModule.e( "Cannot find a body view with tag \"" + tag + "\" for " + adUnitId );
+            return;
+        }
+
         view.setClickable( true );
 
         clickableViews.add( view );
@@ -165,6 +183,12 @@ public class AppLovinMAXNativeAdView
         if ( nativeAd.getNativeAd().getCallToAction() == null ) return;
 
         View view = findViewById( tag );
+        if ( view == null )
+        {
+            AppLovinMAXModule.e( "Cannot find a callToAction view with tag \"" + tag + "\" for " + adUnitId );
+            return;
+        }
+
         view.setClickable( true );
 
         clickableViews.add( view );
@@ -262,8 +286,12 @@ public class AppLovinMAXNativeAdView
                 // Notify publisher
                 AppLovinMAXModule.getInstance().onAdLoaded( ad );
 
-                adLoader.a( clickableViews, AppLovinMAXNativeAdView.this, ad );
-                adLoader.b( ad );
+                // Loader can be null when the user hides before the properties are fully set 
+                if ( adLoader != null )
+                {
+                    adLoader.a( clickableViews, AppLovinMAXNativeAdView.this, ad );
+                    adLoader.b( ad );
+                }
 
                 isLoading.set( false );
             }, 500L );

--- a/ios/AppLovinMAXNativeAdView.m
+++ b/ios/AppLovinMAXNativeAdView.m
@@ -120,6 +120,12 @@
     if ( !self.nativeAd.nativeAd.title ) return;
   
     UIView *view = [self.bridge.uiManager viewForReactTag: tag];
+    if ( !view )
+    {
+        [[AppLovinMAX shared] log: @"Cannot find a title view with tag \"%@\" for %@", tag, self.adUnitId];
+        return;
+    }
+    
     [self.clickableViews addObject: view];
 }
 
@@ -128,6 +134,12 @@
     if ( !self.nativeAd.nativeAd.advertiser ) return;
   
     UIView *view = [self.bridge.uiManager viewForReactTag: tag];
+    if ( !view )
+    {
+        [[AppLovinMAX shared] log: @"Cannot find an advertiser view with tag \"%@\" for %@", tag, self.adUnitId];
+        return;
+    }
+
     [self.clickableViews addObject: view];
 }
 
@@ -136,6 +148,12 @@
     if ( !self.nativeAd.nativeAd.body ) return;
   
     UIView *view = [self.bridge.uiManager viewForReactTag: tag];
+    if ( !view )
+    {
+        [[AppLovinMAX shared] log: @"Cannot find a body view with tag \"%@\" for %@", tag, self.adUnitId];
+        return;
+    }
+
     [self.clickableViews addObject: view];
 }
 
@@ -144,6 +162,12 @@
     if ( !self.nativeAd.nativeAd.callToAction ) return;
   
     UIView *view = [self.bridge.uiManager viewForReactTag: tag];
+    if ( !view )
+    {
+        [[AppLovinMAX shared] log: @"Cannot find a callToAction view with tag \"%@\" for %@", tag, self.adUnitId];
+        return;
+    }
+
     [self.clickableViews addObject: view];
 }
 
@@ -152,6 +176,12 @@
     if ( !self.nativeAd.nativeAd.mediaView ) return;
     
     UIView *view = [self.bridge.uiManager viewForReactTag: tag];
+    if ( !view )
+    {
+        [[AppLovinMAX shared] log: @"Cannot find a media view with tag \"%@\" for %@", tag, self.adUnitId];
+        return;
+    }
+
     [self.clickableViews addObject: view];
   
     [view addSubview: self.nativeAd.nativeAd.mediaView];
@@ -163,6 +193,11 @@
     if ( !self.nativeAd.nativeAd.optionsView ) return;
        
     UIView *view = [self.bridge.uiManager viewForReactTag: tag];
+    if ( !view )
+    {
+        [[AppLovinMAX shared] log: @"Cannot find an option view with tag \"%@\" for %@", tag, self.adUnitId];
+        return;
+    }
   
     [view addSubview: self.nativeAd.nativeAd.optionsView];
     [self.nativeAd.nativeAd.optionsView al_pinToSuperview];


### PR DESCRIPTION
Fix NPE for accessing the unmounted child views in the native ad.

This is the reported NativeAdView.   With this fix, iOS works fine, but Android can't display MediaView since the RN view size is still zero when setting the actual MediaView from the SDK.  For now, MediaView should be mounted beforehand for the sizing.

```
                <AppLovinMAX.NativeAdView adUnitId={NATIVE_AD_UNIT_ID}
                                  placement='myplacement'
                                  customData='mycustomdata'
                                  ref={nativeAdViewRef}
                                  style={[styles.nativead,
                                         isNativeAdLoaded ? {height:350} : {height:0}]}>
                  {isNativeAdLoaded &&
                    (<View style={{flex: 1, flexDirection: 'column'}}>
                        <View style={{flexDirection: 'row', justifyContent: 'space-between'}}>
                        <AppLovinMAX.NativeAdView.IconView style={styles.icon}/>
                        <View style={{flexDirection: 'column', flexGrow: 1}}>
                        <AppLovinMAX.NativeAdView.TitleView style={styles.title}/>
                        <AppLovinMAX.NativeAdView.AdvertiserView style={styles.advertiser}/>
                        </View>
                        <AppLovinMAX.NativeAdView.OptionsView style={styles.optionsView}/>
                        </View>
                        <AppLovinMAX.NativeAdView.BodyView style={styles.body}/>
                        <AppLovinMAX.NativeAdView.MediaView style={styles.mediaView}/>
                        <AppLovinMAX.NativeAdView.CallToActionView style={styles.callToAction}/>
                    </View>)
                  }
                </AppLovinMAX.NativeAdView>
```