### PR TITLE
refact/use_rn_callback_for_props_update

### DIFF
--- a/android/src/main/java/com/applovin/reactnative/AppLovinMAXAdView.java
+++ b/android/src/main/java/com/applovin/reactnative/AppLovinMAXAdView.java
@@ -35,7 +35,7 @@ class AppLovinMAXAdView
     private           boolean     adaptiveBannerEnabled;
     private           boolean     autoRefresh;
 
-    private final AtomicBoolean shouldAddViewUpdate = new AtomicBoolean();
+    private final AtomicBoolean shouldAdViewAttach = new AtomicBoolean();
 
     public AppLovinMAXAdView(final Context context)
     {
@@ -54,7 +54,7 @@ class AppLovinMAXAdView
 
         adUnitId = value;
 
-        shouldAddViewUpdate.set( true );
+        shouldAdViewAttach.set( true );
     }
 
     public void setAdFormat(final String value)
@@ -80,7 +80,7 @@ class AppLovinMAXAdView
             return;
         }
 
-        shouldAddViewUpdate.set( true );
+        shouldAdViewAttach.set( true );
     }
 
     public void setPlacement(@Nullable final String value)
@@ -130,11 +130,12 @@ class AppLovinMAXAdView
         }
     }
 
-    // Called after all properties are set during the widget creation, but after the widget is
-    // created, called every property is updated.
+    // Called after all properties are set to the widget during its creation, but after the widget
+    // is created, this is called either when each property is updated or when a bulk of properties
+    // are updated.
     public void onSetProps()
     {
-        if ( shouldAddViewUpdate.compareAndSet( true, false ) )
+        if ( adUnitId != null && adFormat != null && shouldAdViewAttach.compareAndSet( true, false ) )
         {
             maybeAttachAdView();
         }

--- a/android/src/main/java/com/applovin/reactnative/AppLovinMAXAdView.java
+++ b/android/src/main/java/com/applovin/reactnative/AppLovinMAXAdView.java
@@ -130,7 +130,8 @@ class AppLovinMAXAdView
         }
     }
 
-    // Called after the all AdView properties are set
+    // Called after all properties are set during the widget creation, but after the widget is
+    // created, called every property is updated.
     public void onSetProps()
     {
         if ( shouldAddViewUpdate.compareAndSet( true, false ) )
@@ -194,53 +195,48 @@ class AppLovinMAXAdView
         final String adUnitId = this.adUnitId;
         final MaxAdFormat adFormat = this.adFormat;
 
-        reactContext.runOnUiQueueThread( new Runnable()
-        {
-            @Override
-            public void run()
+        reactContext.runOnUiQueueThread( () -> {
+            if ( TextUtils.isEmpty( adUnitId ) )
             {
-                if ( TextUtils.isEmpty( adUnitId ) )
-                {
-                    AppLovinMAXModule.e( "Attempting to attach MaxAdView without Ad Unit ID" );
-                    return;
-                }
-
-                if ( adFormat == null )
-                {
-                    AppLovinMAXModule.e( "Attempting to attach MaxAdView without ad format" );
-                    return;
-                }
-
-                if ( adView != null )
-                {
-                    AppLovinMAXModule.e( "Attempting to re-attach with existing MaxAdView: " + adView );
-                    return;
-                }
-
-                AppLovinMAXModule.d( "Attaching MaxAdView for " + adUnitId );
-
-                adView = new MaxAdView( adUnitId, adFormat, AppLovinMAXModule.getInstance().getSdk(), currentActivity );
-                adView.setListener( AppLovinMAXAdView.this );
-                adView.setRevenueListener( AppLovinMAXModule.getInstance() );
-                adView.setPlacement( placement );
-                adView.setCustomData( customData );
-                adView.setExtraParameter( "adaptive_banner", Boolean.toString( adaptiveBannerEnabled ) );
-                // Set this extra parameter to work around a SDK bug that ignores calls to stopAutoRefresh()
-                adView.setExtraParameter( "allow_pause_auto_refresh_immediately", "true" );
-
-                if ( autoRefresh )
-                {
-                    adView.startAutoRefresh();
-                }
-                else
-                {
-                    adView.stopAutoRefresh();
-                }
-
-                adView.loadAd();
-
-                addView( adView );
+                AppLovinMAXModule.e( "Attempting to attach MaxAdView without Ad Unit ID" );
+                return;
             }
+
+            if ( adFormat == null )
+            {
+                AppLovinMAXModule.e( "Attempting to attach MaxAdView without ad format" );
+                return;
+            }
+
+            if ( adView != null )
+            {
+                AppLovinMAXModule.e( "Attempting to re-attach with existing MaxAdView: " + adView );
+                return;
+            }
+
+            AppLovinMAXModule.d( "Attaching MaxAdView for " + adUnitId );
+
+            adView = new MaxAdView( adUnitId, adFormat, AppLovinMAXModule.getInstance().getSdk(), currentActivity );
+            adView.setListener( AppLovinMAXAdView.this );
+            adView.setRevenueListener( AppLovinMAXModule.getInstance() );
+            adView.setPlacement( placement );
+            adView.setCustomData( customData );
+            adView.setExtraParameter( "adaptive_banner", Boolean.toString( adaptiveBannerEnabled ) );
+            // Set this extra parameter to work around a SDK bug that ignores calls to stopAutoRefresh()
+            adView.setExtraParameter( "allow_pause_auto_refresh_immediately", "true" );
+
+            if ( autoRefresh )
+            {
+                adView.startAutoRefresh();
+            }
+            else
+            {
+                adView.stopAutoRefresh();
+            }
+
+            adView.loadAd();
+
+            addView( adView );
         } );
     }
 

--- a/android/src/main/java/com/applovin/reactnative/AppLovinMAXAdViewManager.java
+++ b/android/src/main/java/com/applovin/reactnative/AppLovinMAXAdViewManager.java
@@ -75,4 +75,12 @@ class AppLovinMAXAdViewManager
 
         super.onDropViewInstance( view );
     }
+
+    @Override
+    public void onAfterUpdateTransaction(final AppLovinMAXAdView view)
+    {
+        super.onAfterUpdateTransaction( view );
+
+        view.onSetProps();
+    }
 }

--- a/android/src/main/java/com/applovin/reactnative/AppLovinMAXAdViewManager.java
+++ b/android/src/main/java/com/applovin/reactnative/AppLovinMAXAdViewManager.java
@@ -69,18 +69,18 @@ class AppLovinMAXAdViewManager
     }
 
     @Override
-    public void onDropViewInstance(@NotNull AppLovinMAXAdView view)
-    {
-        view.destroy();
-
-        super.onDropViewInstance( view );
-    }
-
-    @Override
     public void onAfterUpdateTransaction(final AppLovinMAXAdView view)
     {
         super.onAfterUpdateTransaction( view );
 
         view.onSetProps();
+    }
+
+    @Override
+    public void onDropViewInstance(@NotNull AppLovinMAXAdView view)
+    {
+        view.destroy();
+
+        super.onDropViewInstance( view );
     }
 }

--- a/android/src/main/java/com/applovin/reactnative/AppLovinMAXNativeAdView.java
+++ b/android/src/main/java/com/applovin/reactnative/AppLovinMAXNativeAdView.java
@@ -37,7 +37,7 @@ public class AppLovinMAXNativeAdView
     @Nullable
     private       MaxAd             nativeAd;
     private final AtomicBoolean isLoading          = new AtomicBoolean(); // Guard against repeated ad loads
-    private final AtomicBoolean hasAdUnitIdUpdated = new AtomicBoolean();
+    private final AtomicBoolean shouldNativeAdLoad = new AtomicBoolean();
 
     @Nullable
     private View mediaView;
@@ -75,11 +75,18 @@ public class AppLovinMAXNativeAdView
 
     public void setAdUnitId(final String value)
     {
+        // Ad Unit ID must be set prior to creating MaxNativeAdLoader
+        if ( adLoader != null )
+        {
+            AppLovinMAXModule.e( "Attempting to set Ad Unit ID " + value + " after MaxNativeAdLoader is created" );
+            return;
+        }
+
         if ( TextUtils.isEmpty( value ) ) return;
 
         adUnitId = value;
 
-        hasAdUnitIdUpdated.set( true );
+        shouldNativeAdLoad.set( true );
     }
 
     public void setPlacement(@Nullable final String value)
@@ -259,7 +266,7 @@ public class AppLovinMAXNativeAdView
 
     public void onSetProps()
     {
-        if ( hasAdUnitIdUpdated.compareAndSet( true, false ) )
+        if ( shouldNativeAdLoad.compareAndSet( true, false ) )
         {
             loadAd();
         }

--- a/android/src/main/java/com/applovin/reactnative/AppLovinMAXNativeAdView.java
+++ b/android/src/main/java/com/applovin/reactnative/AppLovinMAXNativeAdView.java
@@ -36,8 +36,8 @@ public class AppLovinMAXNativeAdView
     private       MaxNativeAdLoader adLoader;
     @Nullable
     private       MaxAd             nativeAd;
-    private final AtomicBoolean     isLoading           = new AtomicBoolean(); // Guard against repeated ad loads
-    private final AtomicBoolean     hasAddUnitIdUpdated = new AtomicBoolean();
+    private final AtomicBoolean isLoading          = new AtomicBoolean(); // Guard against repeated ad loads
+    private final AtomicBoolean hasAdUnitIdUpdated = new AtomicBoolean();
 
     @Nullable
     private View mediaView;
@@ -79,7 +79,7 @@ public class AppLovinMAXNativeAdView
 
         adUnitId = value;
 
-        hasAddUnitIdUpdated.set( true );
+        hasAdUnitIdUpdated.set( true );
     }
 
     public void setPlacement(@Nullable final String value)
@@ -259,7 +259,7 @@ public class AppLovinMAXNativeAdView
 
     public void onSetProps()
     {
-        if ( hasAddUnitIdUpdated.compareAndSet( true, false ) )
+        if ( hasAdUnitIdUpdated.compareAndSet( true, false ) )
         {
             loadAd();
         }

--- a/android/src/main/java/com/applovin/reactnative/AppLovinMAXNativeAdViewManager.java
+++ b/android/src/main/java/com/applovin/reactnative/AppLovinMAXNativeAdViewManager.java
@@ -139,18 +139,18 @@ public class AppLovinMAXNativeAdViewManager
     }
 
     @Override
-    public void onDropViewInstance(@NonNull final AppLovinMAXNativeAdView view)
-    {
-        view.destroy();
-
-        super.onDropViewInstance( view );
-    }
-
-    @Override
     public void onAfterUpdateTransaction(@NonNull final AppLovinMAXNativeAdView view)
     {
         super.onAfterUpdateTransaction( view );
 
         view.onSetProps();
+    }
+
+    @Override
+    public void onDropViewInstance(@NonNull final AppLovinMAXNativeAdView view)
+    {
+        view.destroy();
+
+        super.onDropViewInstance( view );
     }
 }

--- a/android/src/main/java/com/applovin/reactnative/AppLovinMAXNativeAdViewManager.java
+++ b/android/src/main/java/com/applovin/reactnative/AppLovinMAXNativeAdViewManager.java
@@ -145,4 +145,12 @@ public class AppLovinMAXNativeAdViewManager
 
         super.onDropViewInstance( view );
     }
+
+    @Override
+    public void onAfterUpdateTransaction(@NonNull final AppLovinMAXNativeAdView view)
+    {
+        super.onAfterUpdateTransaction( view );
+
+        view.onSetProps();
+    }
 }

--- a/ios/AppLovinMAXAdView.m
+++ b/ios/AppLovinMAXAdView.m
@@ -21,7 +21,7 @@
 @property (nonatomic, assign, readonly, getter=isAdaptiveBannerEnabled) BOOL adaptiveBannerEnabled;
 @property (nonatomic, assign, readonly, getter=isAutoRefresh) BOOL autoRefresh;
 
-@property (nonatomic, strong) ALAtomicBoolean *shouldAddViewUpdate;
+@property (nonatomic, strong) ALAtomicBoolean *shouldAdViewAttach;
 
 @end
 
@@ -32,7 +32,7 @@
     self = [super init];
     if ( self )
     {
-        self.shouldAddViewUpdate = [[ALAtomicBoolean alloc] init];
+        self.shouldAdViewAttach = [[ALAtomicBoolean alloc] init];
     }
     return self;
 }
@@ -48,7 +48,7 @@
     
     _adUnitId = adUnitId;
     
-    [self.shouldAddViewUpdate set: YES];
+    [self.shouldAdViewAttach set: YES];
 }
 
 - (void)setAdFormat:(NSString *)adFormat
@@ -74,7 +74,7 @@
         return;
     }
     
-    [self.shouldAddViewUpdate set: YES];
+    [self.shouldAdViewAttach set: YES];
 }  
 
 - (void)setPlacement:(NSString *)placement
@@ -124,12 +124,12 @@
     }
 }
 
-
-// Called after all properties are set during the widget creation, but after the widget is created,
-// called every property is updated.
+// Called after all properties are set to the widget during its creation, but after the widget is
+// created, this is called either when each property is updated or when a bulk of properties are
+// updated.
 - (void)didSetProps:(NSArray<NSString *> *)changedProps
 {
-    if ( [self.shouldAddViewUpdate compareAndSet: YES update: NO] )
+    if ( self.adUnitId && self.adFormat && [self.shouldAdViewAttach compareAndSet: YES update: NO] )
     {
         [self attachAdViewIfNeeded];
     }

--- a/ios/AppLovinMAXAdView.m
+++ b/ios/AppLovinMAXAdView.m
@@ -124,7 +124,9 @@
     }
 }
 
-// Called after the all AdView properties are set
+
+// Called after all properties are set during the widget creation, but after the widget is created,
+// called every property is updated.
 - (void)didSetProps:(NSArray<NSString *> *)changedProps
 {
     if ( [self.shouldAddViewUpdate compareAndSet: YES update: NO] )

--- a/ios/AppLovinMAXNativeAdView.m
+++ b/ios/AppLovinMAXNativeAdView.m
@@ -24,7 +24,7 @@
 @property (nonatomic, strong, nullable) MANativeAdLoader *adLoader;
 @property (nonatomic, strong, nullable) MAAd *nativeAd;
 @property (nonatomic, strong) ALAtomicBoolean *isLoading; // Guard against repeated ad loads
-@property (nonatomic, strong) ALAtomicBoolean *hasAddUnitUpdated;
+@property (nonatomic, strong) ALAtomicBoolean *hasAdUnitUpdated;
 
 // JavaScript properties
 @property (nonatomic, copy) NSString *adUnitId;
@@ -49,7 +49,7 @@
     {
         self.bridge = bridge;
         self.isLoading = [[ALAtomicBoolean alloc] init];
-        self.hasAddUnitUpdated = [[ALAtomicBoolean alloc] init];
+        self.hasAdUnitUpdated = [[ALAtomicBoolean alloc] init];
         self.clickableViews = [NSMutableArray array];
     }
     return self;
@@ -86,7 +86,7 @@
         
     _adUnitId = adUnitId;
     
-    [self.hasAddUnitUpdated set: YES];
+    [self.hasAdUnitUpdated set: YES];
 }
 
 // Called when Ad Unit ID is set, and via RN layer
@@ -225,7 +225,7 @@
 
 - (void)didSetProps:(NSArray<NSString *> *)changedProps
 {
-    if ( [self.hasAddUnitUpdated compareAndSet:YES update: NO] )
+    if ( [self.hasAdUnitUpdated compareAndSet:YES update: NO] )
     {
         [self loadAd];
     }


### PR DESCRIPTION
Replace the timers with an RN callback to detect the props update on AdView/NativeAdView

Currently, the timers are used when creating AdView and NativeAdView because the widgets have to have all of the properties set before the creation but we don't know when the properties have been all set.   React Native provides a callback to fire after all properties are set in a widget.   With the callback,  we can create AdView and NativeAdView right after the properties are all set without timers.

The interfaces are:

- void com.facebook.react.uimanager.onAfterUpdateTransaction(@NonNull T view)
- ./Views/RCTComponent.h:- (void)didSetProps:(NSArray<NSString *> *)changedProps;

Can't find the doc for the APIs but it's been around for a long time.

https://stackoverflow.com/questions/41033795/react-native-native-ui-components

Verified on Android and iOS.



