### PR TITLE
fix/native_ad_UI_components_unmounting_when_fullscreen_ad_is_displayed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Versions
 
+## x.x.x
+    * Fix native ad UI components unmounting when fullscreen ad is displayed. 
 ## 4.1.1
     * Depend on Android SDK 11.6.0 and iOS SDK 11.6.0.
     * Fix banner and MREC native UI components unmounting when fullscreen ad is displayed. 

--- a/ios/AppLovinMAXNativeAdView.m
+++ b/ios/AppLovinMAXNativeAdView.m
@@ -72,7 +72,7 @@
 {
     [super didMoveToWindow];
     
-    if ( !self.window )
+    if ( !self.window && !self.superview )
     {
         [self destroyCurrentAdIfNeeded];
     }


### PR DESCRIPTION
Fix native ad UI components unmounting when fullscreen ad is displayed