### PR TITLE
fix/options_view_not_created_example_android

### DIFF
--- a/example/src/NativeAdViewExample.js
+++ b/example/src/NativeAdViewExample.js
@@ -53,6 +53,7 @@ const styles = StyleSheet.create({
     optionsView: {
         height: 20,
         width: 20,
+        backgroundColor: '#EFEFEF',
     },
     advertiser: {
         marginHorizontal: 5,


### PR DESCRIPTION
Fix not creating OptionsView in the NativeAdView example on Android

`12-08 18:01:39.898 24204 24204 E AppLovinSdk: [AppLovinMAXModule] Cannot find an options view with tag "139" for c946ea41e8c39bfe`

Fixed by adding `backgroundColor` from [the RN doc](https://reactnative.dev/docs/height-and-width#fixed-dimensions).

Verified on both Android and iOS.