### PR TITLE
fix/npe_for_accessing_null_icon_in_nativead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Versions
 
+## x.x.x
+    * Fix NPE for accessing a null icon in the native ad.
 ## 4.1.3
     * Fix `AppLovinMax.initialize(sdkKey, callback)` firing its callback multiple times on iOS.
 ## 4.1.2

--- a/android/src/main/java/com/applovin/reactnative/AppLovinMAXNativeAdView.java
+++ b/android/src/main/java/com/applovin/reactnative/AppLovinMAXNativeAdView.java
@@ -251,11 +251,13 @@ public class AppLovinMAXNativeAdView
         clickableViews.add( view );
 
         MaxNativeAdImage icon = nativeAd.getNativeAd().getIcon();
-
-        // Check if "URL" was missing and therefore need to set the image data
-        if ( icon.getUri() == null && icon.getDrawable() != null )
+        if ( icon != null )
         {
-            view.setImageDrawable( nativeAd.getNativeAd().getIcon().getDrawable() );
+            // Check if "URL" was missing and therefore need to set the image data
+            if ( icon.getUri() == null && icon.getDrawable() != null )
+            {
+                view.setImageDrawable( icon.getDrawable() );
+            }
         }
     }
 

--- a/ios/AppLovinMAXNativeAdView.m
+++ b/ios/AppLovinMAXNativeAdView.m
@@ -215,12 +215,14 @@
     [self.clickableViews addObject: view];
     
     MANativeAdImage *icon = self.nativeAd.nativeAd.icon;
-    
-    // Check if "URL" was missing and therefore need to set the image data
-    if ( !icon.URL && icon.image )
+    if ( icon )
     {
-        RCTImageView *iconImageView = (RCTImageView *) view;
-        iconImageView.defaultImage = self.nativeAd.nativeAd.icon.image;
+        // Check if "URL" was missing and therefore need to set the image data
+        if ( !icon.URL && icon.image )
+        {
+            RCTImageView *iconImageView = (RCTImageView *) view;
+            iconImageView.defaultImage = icon.image;
+        }
     }
 }
 


### PR DESCRIPTION
Fix NPE for accessing a null icon in the native ad.    This is reported in issue #139.

```
Caused by java.lang.NullPointerException: Attempt to invoke virtual method 'android.net.Uri com.applovin.mediation.nativeAds.MaxNativeAd$MaxNativeAdImage.getUri()' on a null object reference
       at com.applovin.reactnative.AppLovinMAXNativeAdView.setIconView(AppLovinMAXNativeAdView.java:256)
       at com.applovin.reactnative.AppLovinMAXNativeAdViewManager.setIconView(AppLovinMAXNativeAdViewManager.java:138)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.facebook.react.uimanager.ViewManagersPropertyCache$PropSetter.updateViewProp(ViewManagersPropertyCache.java:93)
       at com.facebook.react.uimanager.ViewManagerPropertyUpdater$FallbackViewManagerSetter.setProperty(ViewManagerPropertyUpdater.java:136)
       at com.facebook.react.uimanager.ViewManagerPropertyUpdater.updateProps(ViewManagerPropertyUpdater.java:56)
       at com.facebook.react.uimanager.ViewManager.updateProperties(ViewManager.java:86)
       at com.facebook.react.uimanager.NativeViewHierarchyManager.updateProperties(NativeViewHierarchyManager.java:142)
       at com.facebook.react.uimanager.UIViewOperationQueue$UpdatePropertiesOperation.execute(UIViewOperationQueue.java:93)
       at com.facebook.react.uimanager.UIViewOperationQueue$1.run(UIViewOperationQueue.java:915)
       at com.facebook.react.uimanager.UIViewOperationQueue.flushPendingBatches(UIViewOperationQueue.java:1026)
       at com.facebook.react.uimanager.UIViewOperationQueue.access$2600(UIViewOperationQueue.java:47)
       at com.facebook.react.uimanager.UIViewOperationQueue$DispatchUIFrameCallback.doFrameGuarded(UIViewOperationQueue.java:1086)
       at com.facebook.react.uimanager.GuardedFrameCallback.doFrame(GuardedFrameCallback.java:29)
       at com.facebook.react.modules.core.ReactChoreographer$ReactChoreographerDispatcher.doFrame(ReactChoreographer.java:175)
       at com.facebook.react.modules.core.ChoreographerCompat$FrameCallback$1.doFrame(ChoreographerCompat.java:85)
       at android.view.Choreographer$CallbackRecord.run(Choreographer.java:974)
       at android.view.Choreographer.doCallbacks(Choreographer.java:799)
       at android.view.Choreographer.doFrame(Choreographer.java:730)
       at android.view.Choreographer$FrameDisplayEventReceiver.run(Choreographer.java:961)
       at android.os.Handler.handleCallback(Handler.java:938)
       at android.os.Handler.dispatchMessage(Handler.java:99)
       at android.os.Looper.loop(Looper.java:236)
       at android.app.ActivityThread.main(ActivityThread.java:8115)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:620)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1011)
```