### PR TITLE
feat/support_promise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Versions
 
 ## x.x.x
-* Add support for Promise to replace synchronous methods.
+* Update synchronous APIs to use `Promise`s.
 ## 4.1.4
 * Fix NPE for accessing a null icon in the native ad on Android.
 ## 4.1.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,131 +1,133 @@
 ## Versions
 
+## x.x.x
+* Add support for Promise to replace synchronous methods.
 ## 4.1.4
-    * Fix NPE for accessing a null icon in the native ad on Android.
+* Fix NPE for accessing a null icon in the native ad on Android.
 ## 4.1.3
-    * Fix `AppLovinMax.initialize(sdkKey, callback)` firing its callback multiple times on iOS.
+* Fix `AppLovinMax.initialize(sdkKey, callback)` firing its callback multiple times on iOS.
 ## 4.1.2
-    * Fix native ad UI components unmounting when fullscreen ad is displayed. 
+* Fix native ad UI components unmounting when fullscreen ad is displayed. 
 ## 4.1.1
-    * Depend on Android SDK 11.6.0 and iOS SDK 11.6.0.
-    * Fix banner and MREC native UI components unmounting when fullscreen ad is displayed. 
+* Depend on Android SDK 11.6.0 and iOS SDK 11.6.0.
+* Fix banner and MREC native UI components unmounting when fullscreen ad is displayed. 
 ## 4.1.0
-    * Depend on Android SDK 11.5.5 and iOS SDK 11.5.5.
-    * Add support for App Open ads.
-    * Fix NPE for accessing the MAX components before the SDK initialization.
-    * Fix media view not sizing correctly when the React Native view is initially not sized when native ad is loaded.
-    * Fix NPE for accessing the unmounted child views in the native ad.
-    * Fix not emitting an `"OnBannerAdLoadFailedEvent"` or `"OnMRecAdLoadFailedEvent"` event for native UI component banners and MRECs.
-    * Allow data passing APIs to be invoked before plugin initialization.
+* Depend on Android SDK 11.5.5 and iOS SDK 11.5.5.
+* Add support for App Open ads.
+* Fix NPE for accessing the MAX components before the SDK initialization.
+* Fix media view not sizing correctly when the React Native view is initially not sized when native ad is loaded.
+* Fix NPE for accessing the unmounted child views in the native ad.
+* Fix not emitting an `"OnBannerAdLoadFailedEvent"` or `"OnMRecAdLoadFailedEvent"` event for native UI component banners and MRECs.
+* Allow data passing APIs to be invoked before plugin initialization.
 ## 4.0.0
-    * Add support for native ads - [docs](https://dash.applovin.com/documentation/mediation/react-native/ad-formats/native-manual).
-    * Depend on Android SDK 11.5.3 and iOS SDK 11.5.3.
+* Add support for native ads - [docs](https://dash.applovin.com/documentation/mediation/react-native/ad-formats/native-manual).
+* Depend on Android SDK 11.5.3 and iOS SDK 11.5.3.
 ## 3.3.1
-    * Depend on Android SDK 11.5.1 and iOS SDK 11.5.1.
-    * Update Android Gradle plugin to v3.5.4 to be compatible with <queries> element in manifest files.
+* Depend on Android SDK 11.5.1 and iOS SDK 11.5.1.
+* Update Android Gradle plugin to v3.5.4 to be compatible with <queries> element in manifest files.
 ## 3.3.0
-    * Add autorefresh support for banner and MREC native UI components: `<AppLovinMAX.AdView autoRefresh={true/false} .../>`
-    * Add API for setting SDK extra parameters via `AppLovinMAX.setExtraParameter(<key>, <value>)`.
-    * Fix crash of accessing banner and MREC native UI components before AppLovin initialization by showing black views.
-    * Fix `java.lang.ClassCastException` in Android when ad is loaded due to processing `ad.waterfall` object.
-    * Fix not being able to show subsequent fullscreen ads if app is re-launched from app icon while in middle of an ad.
+* Add autorefresh support for banner and MREC native UI components: `<AppLovinMAX.AdView autoRefresh={true/false} .../>`
+* Add API for setting SDK extra parameters via `AppLovinMAX.setExtraParameter(<key>, <value>)`.
+* Fix crash of accessing banner and MREC native UI components before AppLovin initialization by showing black views.
+* Fix `java.lang.ClassCastException` in Android when ad is loaded due to processing `ad.waterfall` object.
+* Fix not being able to show subsequent fullscreen ads if app is re-launched from app icon while in middle of an ad.
 ## 3.2.2
-    * Depend on Android SDK 11.4.4 and iOS SDK 11.4.3.
+* Depend on Android SDK 11.4.4 and iOS SDK 11.4.3.
 ## 3.2.1
-    * Add support for getting DSP name if the ad is served by AppLovin Exchange via `ad.dspName`.
+* Add support for getting DSP name if the ad is served by AppLovin Exchange via `ad.dspName`.
 ## 3.2.0
-    * Depend on Android SDK 11.4.3 and iOS SDK 11.4.2.
-    * Add support for custom data.
-    * Add support for impression-level user revenue api.
-    * Add support for waterfall info API.
-    * Add support for setting user segment via `AppLovinMAX.userSegment.name`.
+* Depend on Android SDK 11.4.3 and iOS SDK 11.4.2.
+* Add support for custom data.
+* Add support for impression-level user revenue api.
+* Add support for waterfall info API.
+* Add support for setting user segment via `AppLovinMAX.userSegment.name`.
 ## 3.1.0
-    * Add support for data passing.
-    * Add API for Android to provide a built-in consent flow that sets the user consent flag.
+* Add support for data passing.
+* Add API for Android to provide a built-in consent flow that sets the user consent flag.
 ## 3.0.2
-    * Depend on Android SDK 11.3.2 and iOS SDK 11.3.2.
+* Depend on Android SDK 11.3.2 and iOS SDK 11.3.2.
 ## 3.0.1
-    * Depend on Android SDK 11.3.1 and iOS SDK 11.3.1.
-    * Fix safe area blocked if y offset used. (https://github.com/AppLovin/AppLovin-MAX-React-Native/issues/59)
+* Depend on Android SDK 11.3.1 and iOS SDK 11.3.1.
+* Fix safe area blocked if y offset used. (https://github.com/AppLovin/AppLovin-MAX-React-Native/issues/59)
 ## 3.0.0
-    * Depend on Android SDK 11.3.0 and iOS SDK 11.3.0.
+* Depend on Android SDK 11.3.0 and iOS SDK 11.3.0.
 ## 2.5.3
-    * Add API to set Terms of Service URL for iOS' MAX consent flow.
+* Add API to set Terms of Service URL for iOS' MAX consent flow.
 ## 2.5.2
-    * Depend on Android SDK 10.3.5 and iOS SDK 10.3.7.
+* Depend on Android SDK 10.3.5 and iOS SDK 10.3.7.
 ## 2.5.1
-    * Stop auto-refresh for native AdViews that have been removed from screen on Android. 
+* Stop auto-refresh for native AdViews that have been removed from screen on Android. 
 ## 2.5.0
-    * Update APIs for showing interstitials and rewarded ads. To show _without_ a placement, use `AppLovinMAX.showInterstitial(<Ad Unit ID>)` and `AppLovinMAX.showRewardedAd(<Ad Unit ID>)`. To show _with_ a placement, use `AppLovinMAX.showInterstitialWithPlacement(<Ad Unit ID>, <Placement>)` and `AppLovinMAX.showRewardedAdWithPlacement(<Ad Unit ID>, <Placement>)`.  
+* Update APIs for showing interstitials and rewarded ads. To show _without_ a placement, use `AppLovinMAX.showInterstitial(<Ad Unit ID>)` and `AppLovinMAX.showRewardedAd(<Ad Unit ID>)`. To show _with_ a placement, use `AppLovinMAX.showInterstitialWithPlacement(<Ad Unit ID>, <Placement>)` and `AppLovinMAX.showRewardedAdWithPlacement(<Ad Unit ID>, <Placement>)`.  
 ## 2.4.2
-    * Fix placements not being passed correctly. 
+* Fix placements not being passed correctly. 
 ## 2.4.1
-    * Remove test code on iOS using hard-coded credentials.
+* Remove test code on iOS using hard-coded credentials.
 ## 2.4.0
-    * Allow loading of multiple native UI AdView with same Ad Unit IDs.
+* Allow loading of multiple native UI AdView with same Ad Unit IDs.
 ## 2.3.2
-    * Fix `ClassCastException` related to Android native AdViews.
+* Fix `ClassCastException` related to Android native AdViews.
 ## 2.3.1
-    * Fix NPE in `positionAdView()`.
+* Fix NPE in `positionAdView()`.
 ## 2.3.0
-    * Enable adaptive banners by default.
-    * Add support for native ad placements. Docs can be found [here](https://dash.applovin.com/documentation/mediation/react-native/getting-started/advanced-settings#banners-/-mrecs-(native-ui-component-method)).
-    * Fix thread warning with native component AdViews.
+* Enable adaptive banners by default.
+* Add support for native ad placements. Docs can be found [here](https://dash.applovin.com/documentation/mediation/react-native/getting-started/advanced-settings#banners-/-mrecs-(native-ui-component-method)).
+* Fix thread warning with native component AdViews.
 ## 2.2.0
-    * Allow for multiple native `AppLovinMAX.AdView`s at once on a screen (e.g. a banner and a mrec).
+* Allow for multiple native `AppLovinMAX.AdView`s at once on a screen (e.g. a banner and a mrec).
 ## 2.1.3
-    * Add support for latest SDKs v10.3.1 with new callbacks.
+* Add support for latest SDKs v10.3.1 with new callbacks.
 ## 2.1.2
-    * Fix banners and MRECs native UI components not clicking if not styled by parent dom.
+* Fix banners and MRECs native UI components not clicking if not styled by parent dom.
 ## 2.1.1
-    * Fix iOS projects not building.
+* Fix iOS projects not building.
 ## 2.1.0
-    * Add API for passing in `errorInfo` for ad load failure callbacks with parameters "code", "message", and "adLoadFailureInfo".
-    * Add API for passing in `errorInfo` for ad display failure callbacks with parameters "code" and "message".
-    * Add API for creating and updating banner X and Y offsets. For example, to offset banner 50px from a bottom center position: `AppLovinMAX.createBannerWithOffsets(adUnitId, AppLovinMAX.AdViewPosition.BOTTOM_CENTER, 0, 50);`.
+* Add API for passing in `errorInfo` for ad load failure callbacks with parameters "code", "message", and "adLoadFailureInfo".
+* Add API for passing in `errorInfo` for ad display failure callbacks with parameters "code" and "message".
+* Add API for creating and updating banner X and Y offsets. For example, to offset banner 50px from a bottom center position: `AppLovinMAX.createBannerWithOffsets(adUnitId, AppLovinMAX.AdViewPosition.BOTTOM_CENTER, 0, 50);`.
 ## 2.0.6
-    * Add support for latest SDKs v10.3.0 with new callbacks.
+* Add support for latest SDKs v10.3.0 with new callbacks.
 ## 2.0.5
-    * Fallback to SDK key in Android Manifest and Info.plist if not passed programmatically.
-    * Add support for setting banner width.
+* Fallback to SDK key in Android Manifest and Info.plist if not passed programmatically.
+* Add support for setting banner width.
 ## 2.0.4
-    * Pass `"countryCode"` in initialization callback.
+* Pass `"countryCode"` in initialization callback.
 ## 2.0.3
-    * Fix ad callbacks not returning.
+* Fix ad callbacks not returning.
 ## 2.0.2
-    * Remove `getAdInfo(adUnitId)` API in lieu of ad callbacks.
-    * Return more data in ad callbacks in addition to `ad.adUnitId` (e.g. `adInfo.creativeId`, `adInfo.networkName`, `adInfo.placement`, `adInfo.revenue`).
+* Remove `getAdInfo(adUnitId)` API in lieu of ad callbacks.
+* Return more data in ad callbacks in addition to `ad.adUnitId` (e.g. `adInfo.creativeId`, `adInfo.networkName`, `adInfo.placement`, `adInfo.revenue`).
 ## 2.0.1
-    * Ensure exported iOS methods are invoked on the main queue.
+* Ensure exported iOS methods are invoked on the main queue.
 ## 2.0.0
-    * Initial support for MAX consent flow. Please see our documentation for instructions on enabling it.
-    * Add `AppLovinMAX.setCreativeDebuggerEnabled()` API to enable the creative debugger button.
-    * Revert from using the hardcoded SDK value of 10.1.1 to using +.
-    * Fix MRec ad expanded event not working on Android.
+* Initial support for MAX consent flow. Please see our documentation for instructions on enabling it.
+* Add `AppLovinMAX.setCreativeDebuggerEnabled()` API to enable the creative debugger button.
+* Revert from using the hardcoded SDK value of 10.1.1 to using +.
+* Fix MRec ad expanded event not working on Android.
 ## 1.1.10
-    * Hardcode Android SDK version to 10.1.1.
+* Hardcode Android SDK version to 10.1.1.
 ## 1.1.9
-    * Fix React Native version not being passed through to native SDKs.
+* Fix React Native version not being passed through to native SDKs.
 ## 1.1.8
-    * Remove need to define Android product flavors in `build.gradle`.
+* Remove need to define Android product flavors in `build.gradle`.
 ## 1.1.7
-    * Fix Android native UI banners rendering issues when mounting / unmounting.
-    * Add support for setting test device(s) using the advertising identifier (GAID / IDFA) printed in the initialization logs.
+* Fix Android native UI banners rendering issues when mounting / unmounting.
+* Add support for setting test device(s) using the advertising identifier (GAID / IDFA) printed in the initialization logs.
 ## 1.1.6
-    * Attempt fix for `loadInterstitial()` or `loadRewardedAd()` due to current Activity being null.
+* Attempt fix for `loadInterstitial()` or `loadRewardedAd()` due to current Activity being null.
 ## 1.1.5
-    * Fix `removeEventListener()` not working by explicitly calling `remove()`.
+* Fix `removeEventListener()` not working by explicitly calling `remove()`.
 ## 1.1.4
-    * Fix Android banners not working for fast refreshes.
-    * FIx iOS module's podspec pointing to invalid tag.
+* Fix Android banners not working for fast refreshes.
+* FIx iOS module's podspec pointing to invalid tag.
 ## 1.1.3
-    * Ensure values such as user id is set before initializing SDK.
-    * Add workaround for `getCurrentActivity()` returning `null`.
+* Ensure values such as user id is set before initializing SDK.
+* Add workaround for `getCurrentActivity()` returning `null`.
 ## 1.1.2
-    * Fix `ConsentDialogState.UNKNOWN` being returned for `getConsentDialogState()` on iOS.
+* Fix `ConsentDialogState.UNKNOWN` being returned for `getConsentDialogState()` on iOS.
 ## 1.1.1
-    * Fix `AppLovinMAX.removeEventListener()` crash.
+* Fix `AppLovinMAX.removeEventListener()` crash.
 ## 1.1.0
-    * Add support for native banner / MREC UI components via `<AppLovinMAX.AdView adUnitId={...} adFormat={...} />`.
+* Add support for native banner / MREC UI components via `<AppLovinMAX.AdView adUnitId={...} adFormat={...} />`.
 ## 1.0.0
-    * Initial release with support for interstitials, rewarded ads, banners, and MRECs.
+* Initial release with support for interstitials, rewarded ads, banners, and MRECs.

--- a/android/src/main/java/com/applovin/reactnative/AppLovinMAXModule.java
+++ b/android/src/main/java/com/applovin/reactnative/AppLovinMAXModule.java
@@ -385,7 +385,7 @@ public class AppLovinMAXModule
     }
 
     @ReactMethod
-    public void showConsentDialog(final Callback callback)
+    public void showConsentDialog(final Promise promise)
     {
         if ( sdk == null )
         {
@@ -398,7 +398,7 @@ public class AppLovinMAXModule
             @Override
             public void onDismiss()
             {
-                callback.invoke();
+                promise.resolve( null );
             }
         } );
     }

--- a/android/src/main/java/com/applovin/reactnative/AppLovinMAXModule.java
+++ b/android/src/main/java/com/applovin/reactnative/AppLovinMAXModule.java
@@ -47,6 +47,7 @@ import com.applovin.sdk.AppLovinUserService;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.Callback;
 import com.facebook.react.bridge.LifecycleEventListener;
+import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
@@ -167,20 +168,20 @@ public class AppLovinMAXModule
         return sCurrentActivity;
     }
 
-    @ReactMethod(isBlockingSynchronousMethod = true)
-    public boolean isInitialized()
+    @ReactMethod
+    public void isInitialized(final Promise promise)
     {
-        return isPluginInitialized && isSdkInitialized;
+        promise.resolve( isPluginInitialized && isSdkInitialized );
     }
 
     @ReactMethod
-    public void initialize(final String pluginVersion, final String sdkKey, final Callback callback)
+    public void initialize(final String pluginVersion, final String sdkKey, final Promise promise)
     {
         // Check if Activity is available
         Activity currentActivity = maybeGetCurrentActivity();
         if ( currentActivity != null )
         {
-            performInitialization( pluginVersion, sdkKey, currentActivity, callback );
+            performInitialization( pluginVersion, sdkKey, currentActivity, promise );
         }
         else
         {
@@ -198,13 +199,13 @@ public class AppLovinMAXModule
                         contextToUse = getReactApplicationContext();
                     }
 
-                    performInitialization( pluginVersion, sdkKey, contextToUse, callback );
+                    performInitialization( pluginVersion, sdkKey, contextToUse, promise );
                 }
             }, TimeUnit.SECONDS.toMillis( 3 ) );
         }
     }
 
-    private void performInitialization(final String pluginVersion, final String sdkKey, final Context context, final Callback callback)
+    private void performInitialization(final String pluginVersion, final String sdkKey, final Context context, final Promise promise)
     {
         // Guard against running init logic multiple times
         if ( isPluginInitialized ) return;
@@ -233,7 +234,8 @@ public class AppLovinMAXModule
 
             if ( TextUtils.isEmpty( sdkKeyToUse ) )
             {
-                throw new IllegalStateException( "Unable to initialize AppLovin SDK - no SDK key provided and not found in Android Manifest!" );
+                promise.reject( new IllegalStateException( "Unable to initialize AppLovin SDK - no SDK key provided and not found in Android Manifest!" ) );
+                return;
             }
         }
 
@@ -356,18 +358,18 @@ public class AppLovinMAXModule
                 WritableMap sdkConfiguration = Arguments.createMap();
                 sdkConfiguration.putInt( "consentDialogState", configuration.getConsentDialogState().ordinal() );
                 sdkConfiguration.putString( "countryCode", configuration.getCountryCode() );
-                callback.invoke( sdkConfiguration );
+                promise.resolve( sdkConfiguration );
             }
         } );
     }
 
     // General Public API
 
-    @ReactMethod(isBlockingSynchronousMethod = true)
-    public boolean isTablet()
+    @ReactMethod
+    public void isTablet(final Promise promise)
     {
         Context contextToUse = ( maybeGetCurrentActivity() != null ) ? maybeGetCurrentActivity() : getReactApplicationContext();
-        return AppLovinSdkUtils.isTablet( contextToUse );
+        promise.resolve( AppLovinSdkUtils.isTablet( contextToUse ) );
     }
 
     @ReactMethod
@@ -382,7 +384,7 @@ public class AppLovinMAXModule
         sdk.showMediationDebugger();
     }
 
-    @ReactMethod()
+    @ReactMethod
     public void showConsentDialog(final Callback callback)
     {
         if ( sdk == null )
@@ -401,51 +403,51 @@ public class AppLovinMAXModule
         } );
     }
 
-    @ReactMethod(isBlockingSynchronousMethod = true)
-    public int getConsentDialogState()
+    @ReactMethod
+    public void getConsentDialogState(final Promise promise)
     {
-        if ( !isInitialized() ) return AppLovinSdkConfiguration.ConsentDialogState.UNKNOWN.ordinal();
-
-        return sdkConfiguration.getConsentDialogState().ordinal();
+        promise.resolve( isSdkInitialized ?
+                                 sdkConfiguration.getConsentDialogState().ordinal() :
+                                 AppLovinSdkConfiguration.ConsentDialogState.UNKNOWN.ordinal() );
     }
 
-    @ReactMethod()
-    public void setHasUserConsent(boolean hasUserConsent)
+    @ReactMethod
+    public void setHasUserConsent(final boolean hasUserConsent)
     {
         AppLovinPrivacySettings.setHasUserConsent( hasUserConsent, maybeGetCurrentActivity() );
     }
 
-    @ReactMethod(isBlockingSynchronousMethod = true)
-    public boolean hasUserConsent()
+    @ReactMethod
+    public void hasUserConsent(final Promise promise)
     {
-        return AppLovinPrivacySettings.hasUserConsent( maybeGetCurrentActivity() );
+        promise.resolve( AppLovinPrivacySettings.hasUserConsent( maybeGetCurrentActivity() ) );
     }
 
-    @ReactMethod()
-    public void setIsAgeRestrictedUser(boolean isAgeRestrictedUser)
+    @ReactMethod
+    public void setIsAgeRestrictedUser(final boolean isAgeRestrictedUser)
     {
         AppLovinPrivacySettings.setIsAgeRestrictedUser( isAgeRestrictedUser, maybeGetCurrentActivity() );
     }
 
-    @ReactMethod(isBlockingSynchronousMethod = true)
-    public boolean isAgeRestrictedUser()
+    @ReactMethod
+    public void isAgeRestrictedUser(final Promise promise)
     {
-        return AppLovinPrivacySettings.isAgeRestrictedUser( maybeGetCurrentActivity() );
+        promise.resolve( AppLovinPrivacySettings.isAgeRestrictedUser( maybeGetCurrentActivity() ) );
     }
 
-    @ReactMethod()
+    @ReactMethod
     public void setDoNotSell(final boolean doNotSell)
     {
         AppLovinPrivacySettings.setDoNotSell( doNotSell, maybeGetCurrentActivity() );
     }
 
-    @ReactMethod(isBlockingSynchronousMethod = true)
-    public boolean isDoNotSell()
+    @ReactMethod
+    public void isDoNotSell(final Promise promise)
     {
-        return AppLovinPrivacySettings.isDoNotSell( maybeGetCurrentActivity() );
+        promise.resolve( AppLovinPrivacySettings.isDoNotSell( maybeGetCurrentActivity() ) );
     }
 
-    @ReactMethod()
+    @ReactMethod
     public void setUserId(String userId)
     {
         if ( isPluginInitialized )
@@ -459,7 +461,7 @@ public class AppLovinMAXModule
         }
     }
 
-    @ReactMethod()
+    @ReactMethod
     public void setMuted(final boolean muted)
     {
         if ( !isPluginInitialized ) return;
@@ -467,15 +469,13 @@ public class AppLovinMAXModule
         sdk.getSettings().setMuted( muted );
     }
 
-    @ReactMethod(isBlockingSynchronousMethod = true)
-    public boolean isMuted()
+    @ReactMethod
+    public void isMuted(final Promise promise)
     {
-        if ( !isPluginInitialized ) return false;
-
-        return sdk.getSettings().isMuted();
+        promise.resolve( isPluginInitialized ? sdk.getSettings().isMuted() : false );
     }
 
-    @ReactMethod()
+    @ReactMethod
     public void setVerboseLogging(final boolean enabled)
     {
         if ( isPluginInitialized )
@@ -489,7 +489,7 @@ public class AppLovinMAXModule
         }
     }
 
-    @ReactMethod()
+    @ReactMethod
     public void setCreativeDebuggerEnabled(final boolean enabled)
     {
         if ( isPluginInitialized )
@@ -503,7 +503,7 @@ public class AppLovinMAXModule
         }
     }
 
-    @ReactMethod()
+    @ReactMethod
     public void setTestDeviceAdvertisingIds(final ReadableArray rawAdvertisingIds)
     {
         List<String> advertisingIds = new ArrayList<>( rawAdvertisingIds.size() );
@@ -525,7 +525,7 @@ public class AppLovinMAXModule
         }
     }
 
-    @ReactMethod()
+    @ReactMethod
     public void setExtraParameter(final String key, @Nullable final String value)
     {
         if ( TextUtils.isEmpty( key ) )
@@ -546,18 +546,18 @@ public class AppLovinMAXModule
         }
     }
 
-    @ReactMethod()
+    @ReactMethod
     public void setConsentFlowEnabled(final boolean enabled) { }
 
-    @ReactMethod()
+    @ReactMethod
     public void setPrivacyPolicyUrl(final String urlString) { }
 
-    @ReactMethod()
+    @ReactMethod
     public void setTermsOfServiceUrl(final String urlString) { }
 
     // Data Passing
 
-    @ReactMethod()
+    @ReactMethod
     public void setTargetingDataYearOfBirth(final int yearOfBirth)
     {
         if ( sdk == null )
@@ -569,7 +569,7 @@ public class AppLovinMAXModule
         sdk.getTargetingData().setYearOfBirth( yearOfBirth <= 0 ? null : yearOfBirth );
     }
 
-    @ReactMethod()
+    @ReactMethod
     public void setTargetingDataGender(@Nullable final String gender)
     {
         if ( sdk == null )
@@ -581,7 +581,7 @@ public class AppLovinMAXModule
         sdk.getTargetingData().setGender( getAppLovinGender( gender ) );
     }
 
-    @ReactMethod()
+    @ReactMethod
     public void setTargetingDataMaximumAdContentRating(final int maximumAdContentRating)
     {
         if ( sdk == null )
@@ -593,7 +593,7 @@ public class AppLovinMAXModule
         sdk.getTargetingData().setMaximumAdContentRating( getAppLovinAdContentRating( maximumAdContentRating ) );
     }
 
-    @ReactMethod()
+    @ReactMethod
     public void setTargetingDataEmail(@Nullable final String email)
     {
         if ( sdk == null )
@@ -605,7 +605,7 @@ public class AppLovinMAXModule
         sdk.getTargetingData().setEmail( email );
     }
 
-    @ReactMethod()
+    @ReactMethod
     public void setTargetingDataPhoneNumber(@Nullable final String phoneNumber)
     {
         if ( sdk == null )
@@ -617,7 +617,7 @@ public class AppLovinMAXModule
         sdk.getTargetingData().setPhoneNumber( phoneNumber );
     }
 
-    @ReactMethod()
+    @ReactMethod
     public void setTargetingDataKeywords(@Nullable final ReadableArray rawKeywords)
     {
         if ( sdk == null )
@@ -629,7 +629,7 @@ public class AppLovinMAXModule
         sdk.getTargetingData().setKeywords( getStringArrayList( rawKeywords ) );
     }
 
-    @ReactMethod()
+    @ReactMethod
     public void setTargetingDataInterests(@Nullable final ReadableArray rawInterests)
     {
         if ( sdk == null )
@@ -641,7 +641,7 @@ public class AppLovinMAXModule
         sdk.getTargetingData().setInterests( getStringArrayList( rawInterests ) );
     }
 
-    @ReactMethod()
+    @ReactMethod
     public void clearAllTargetingData()
     {
         if ( sdk == null )
@@ -659,7 +659,7 @@ public class AppLovinMAXModule
         sdk.getTargetingData().clearAll();
     }
 
-    @ReactMethod()
+    @ReactMethod
     public void setLocationCollectionEnabled(final boolean enabled)
     {
         if ( isPluginInitialized )
@@ -675,7 +675,7 @@ public class AppLovinMAXModule
 
     // EVENT TRACKING
 
-    @ReactMethod()
+    @ReactMethod
     public void trackEvent(final String event, final ReadableMap parameters)
     {
         // Convert Map<String, Object> type of `parameters.toHashMap()` to Map<String, String>
@@ -694,147 +694,147 @@ public class AppLovinMAXModule
 
     // BANNERS
 
-    @ReactMethod()
+    @ReactMethod
     public void createBanner(final String adUnitId, final String bannerPosition)
     {
         createAdView( adUnitId, getDeviceSpecificBannerAdViewAdFormat(), bannerPosition, DEFAULT_AD_VIEW_OFFSET );
     }
 
-    @ReactMethod() // NOTE: No function overloading in JS so we need new method signature
+    @ReactMethod // NOTE: No function overloading in JS so we need new method signature
     public void createBannerWithOffsets(final String adUnitId, final String bannerPosition, final float x, final float y)
     {
         createAdView( adUnitId, getDeviceSpecificBannerAdViewAdFormat(), bannerPosition, getOffsetPixels( x, y, getCurrentActivity() ) );
     }
 
-    @ReactMethod()
+    @ReactMethod
     public void setBannerBackgroundColor(final String adUnitId, final String hexColorCode)
     {
         setAdViewBackgroundColor( adUnitId, getDeviceSpecificBannerAdViewAdFormat(), hexColorCode );
     }
 
-    @ReactMethod()
+    @ReactMethod
     public void setBannerPlacement(final String adUnitId, final String placement)
     {
         setAdViewPlacement( adUnitId, getDeviceSpecificBannerAdViewAdFormat(), placement );
     }
 
-    @ReactMethod()
+    @ReactMethod
     public void setBannerCustomData(final String adUnitId, final String customData)
     {
         setAdViewCustomData( adUnitId, getDeviceSpecificBannerAdViewAdFormat(), customData );
     }
 
-    @ReactMethod()
+    @ReactMethod
     public void setBannerWidth(final String adUnitId, final int widthDp)
     {
         setAdViewWidth( adUnitId, widthDp, getDeviceSpecificBannerAdViewAdFormat() );
     }
 
-    @ReactMethod()
+    @ReactMethod
     public void updateBannerPosition(final String adUnitId, final String bannerPosition)
     {
         updateAdViewPosition( adUnitId, bannerPosition, DEFAULT_AD_VIEW_OFFSET, getDeviceSpecificBannerAdViewAdFormat() );
     }
 
-    @ReactMethod()
+    @ReactMethod
     public void updateBannerOffsets(final String adUnitId, final float x, final float y)
     {
         updateAdViewPosition( adUnitId, mAdViewPositions.get( adUnitId ), getOffsetPixels( x, y, getCurrentActivity() ), getDeviceSpecificBannerAdViewAdFormat() );
     }
 
-    @ReactMethod()
+    @ReactMethod
     public void setBannerExtraParameter(final String adUnitId, final String key, final String value)
     {
         setAdViewExtraParameters( adUnitId, getDeviceSpecificBannerAdViewAdFormat(), key, value );
     }
 
-    @ReactMethod()
+    @ReactMethod
     public void startBannerAutoRefresh(final String adUnitId)
     {
         startAutoRefresh( adUnitId, getDeviceSpecificBannerAdViewAdFormat() );
     }
 
-    @ReactMethod()
+    @ReactMethod
     public void stopBannerAutoRefresh(final String adUnitId)
     {
         stopAutoRefresh( adUnitId, getDeviceSpecificBannerAdViewAdFormat() );
     }
 
-    @ReactMethod()
+    @ReactMethod
     public void showBanner(final String adUnitId)
     {
         showAdView( adUnitId, getDeviceSpecificBannerAdViewAdFormat() );
     }
 
-    @ReactMethod()
+    @ReactMethod
     public void hideBanner(final String adUnitId)
     {
         hideAdView( adUnitId, getDeviceSpecificBannerAdViewAdFormat() );
     }
 
-    @ReactMethod()
+    @ReactMethod
     public void destroyBanner(final String adUnitId)
     {
         destroyAdView( adUnitId, getDeviceSpecificBannerAdViewAdFormat() );
     }
 
-    @ReactMethod(isBlockingSynchronousMethod = true)
-    public float getAdaptiveBannerHeightForWidth(final float width)
+    @ReactMethod
+    public void getAdaptiveBannerHeightForWidth(final float width, final Promise promise)
     {
-        return getDeviceSpecificBannerAdViewAdFormat().getAdaptiveSize( (int) width, getCurrentActivity() ).getHeight();
+        promise.resolve( getDeviceSpecificBannerAdViewAdFormat().getAdaptiveSize( (int) width, getCurrentActivity() ).getHeight() );
     }
 
     // MRECS
 
-    @ReactMethod()
+    @ReactMethod
     public void createMRec(final String adUnitId, final String mrecPosition)
     {
         createAdView( adUnitId, MaxAdFormat.MREC, mrecPosition, DEFAULT_AD_VIEW_OFFSET );
     }
 
-    @ReactMethod()
+    @ReactMethod
     public void setMRecPlacement(final String adUnitId, final String placement)
     {
         setAdViewPlacement( adUnitId, MaxAdFormat.MREC, placement );
     }
 
-    @ReactMethod()
+    @ReactMethod
     public void setMRecCustomData(final String adUnitId, final String customData)
     {
         setAdViewCustomData( adUnitId, MaxAdFormat.MREC, customData );
     }
 
-    @ReactMethod()
+    @ReactMethod
     public void updateMRecPosition(final String adUnitId, final String mrecPosition)
     {
         updateAdViewPosition( adUnitId, mrecPosition, DEFAULT_AD_VIEW_OFFSET, MaxAdFormat.MREC );
     }
 
-    @ReactMethod()
+    @ReactMethod
     public void startMRecAutoRefresh(final String adUnitId)
     {
         startAutoRefresh( adUnitId, MaxAdFormat.MREC );
     }
 
-    @ReactMethod()
+    @ReactMethod
     public void stopMRecAutoRefresh(final String adUnitId)
     {
         stopAutoRefresh( adUnitId, MaxAdFormat.MREC );
     }
 
-    @ReactMethod()
+    @ReactMethod
     public void showMRec(final String adUnitId)
     {
         showAdView( adUnitId, MaxAdFormat.MREC );
     }
 
-    @ReactMethod()
+    @ReactMethod
     public void hideMRec(final String adUnitId)
     {
         hideAdView( adUnitId, MaxAdFormat.MREC );
     }
 
-    @ReactMethod()
+    @ReactMethod
     public void destroyMRec(final String adUnitId)
     {
         destroyAdView( adUnitId, MaxAdFormat.MREC );
@@ -842,7 +842,7 @@ public class AppLovinMAXModule
 
     // INTERSTITIALS
 
-    @ReactMethod()
+    @ReactMethod
     public void loadInterstitial(final String adUnitId)
     {
         MaxInterstitialAd interstitial = retrieveInterstitial( adUnitId );
@@ -855,21 +855,21 @@ public class AppLovinMAXModule
         interstitial.loadAd();
     }
 
-    @ReactMethod(isBlockingSynchronousMethod = true)
-    public boolean isInterstitialReady(final String adUnitId)
+    @ReactMethod
+    public void isInterstitialReady(final String adUnitId, final Promise promise)
     {
         MaxInterstitialAd interstitial = retrieveInterstitial( adUnitId );
-        return interstitial.isReady();
+        promise.resolve( interstitial.isReady() );
     }
 
-    @ReactMethod()
+    @ReactMethod
     public void showInterstitial(final String adUnitId, final String placement, final String customData)
     {
         MaxInterstitialAd interstitial = retrieveInterstitial( adUnitId );
         interstitial.showAd( placement, customData );
     }
 
-    @ReactMethod()
+    @ReactMethod
     public void setInterstitialExtraParameter(final String adUnitId, final String key, final String value)
     {
         MaxInterstitialAd interstitial = retrieveInterstitial( adUnitId );
@@ -878,7 +878,7 @@ public class AppLovinMAXModule
 
     // REWARDED
 
-    @ReactMethod()
+    @ReactMethod
     public void loadRewardedAd(final String adUnitId)
     {
         MaxRewardedAd rewardedAd = retrieveRewardedAd( adUnitId );
@@ -891,21 +891,21 @@ public class AppLovinMAXModule
         rewardedAd.loadAd();
     }
 
-    @ReactMethod(isBlockingSynchronousMethod = true)
-    public boolean isRewardedAdReady(final String adUnitId)
+    @ReactMethod
+    public void isRewardedAdReady(final String adUnitId, final Promise promise)
     {
         MaxRewardedAd rewardedAd = retrieveRewardedAd( adUnitId );
-        return rewardedAd.isReady();
+        promise.resolve( rewardedAd.isReady() );
     }
 
-    @ReactMethod()
+    @ReactMethod
     public void showRewardedAd(final String adUnitId, final String placement, final String customData)
     {
         MaxRewardedAd rewardedAd = retrieveRewardedAd( adUnitId );
         rewardedAd.showAd( placement, customData );
     }
 
-    @ReactMethod()
+    @ReactMethod
     public void setRewardedAdExtraParameter(final String adUnitId, final String key, final String value)
     {
         MaxRewardedAd rewardedAd = retrieveRewardedAd( adUnitId );
@@ -914,28 +914,28 @@ public class AppLovinMAXModule
 
     // APP OPEN AD
 
-    @ReactMethod()
+    @ReactMethod
     public void loadAppOpenAd(final String adUnitId)
     {
         MaxAppOpenAd appOpenAd = retrieveAppOpenAd( adUnitId );
         appOpenAd.loadAd();
     }
 
-    @ReactMethod(isBlockingSynchronousMethod = true)
-    public boolean isAppOpenAdReady(final String adUnitId)
+    @ReactMethod
+    public void isAppOpenAdReady(final String adUnitId, final Promise promise)
     {
         MaxAppOpenAd appOpenAd = retrieveAppOpenAd( adUnitId );
-        return appOpenAd.isReady();
+        promise.resolve( appOpenAd.isReady() );
     }
 
-    @ReactMethod()
+    @ReactMethod
     public void showAppOpenAd(final String adUnitId, @Nullable final String placement, @Nullable final String customData)
     {
         MaxAppOpenAd appOpenAd = retrieveAppOpenAd( adUnitId );
         appOpenAd.showAd( placement, customData );
     }
 
-    @ReactMethod()
+    @ReactMethod
     public void setAppOpenAdExtraParameter(final String adUnitId, final String key, final String value)
     {
         MaxAppOpenAd appOpenAd = retrieveAppOpenAd( adUnitId );

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -442,6 +442,9 @@ const styles = StyleSheet.create({
     backgroundColor: '#000000',
     position: 'absolute',
     width: '100%',
+    // Automatically sized to 50 on phones and 90 on tablets. When adaptiveBannerEnabled is on,
+    // sized to AppLovinMAX.getAdaptiveBannerHeightForWidth().
+    height: 'auto',
     bottom: Platform.select({
       ios: 36, // For bottom safe area
       android: 0,

--- a/ios/AppLovinMAX.m
+++ b/ios/AppLovinMAX.m
@@ -134,12 +134,12 @@ RCT_EXPORT_MODULE()
     return self;
 }
 
-RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(isInitialized)
+RCT_EXPORT_METHOD(isInitialized :(RCTPromiseResolveBlock)resolve :(RCTPromiseRejectBlock)reject)
 {
-    return @([self isPluginInitialized] && [self isSDKInitialized]);
+    resolve(@([self isPluginInitialized] && [self isSDKInitialized]));
 }
 
-RCT_EXPORT_METHOD(initialize:(NSString *)pluginVersion :(NSString *)sdkKey :(RCTResponseSenderBlock)callback)
+RCT_EXPORT_METHOD(initialize:(NSString *)pluginVersion :(NSString *)sdkKey :(RCTPromiseResolveBlock)resolve :(RCTPromiseRejectBlock)reject)
 {
     // Guard against running init logic multiple times
     if ( [self isPluginInitialized] ) return;
@@ -157,8 +157,8 @@ RCT_EXPORT_METHOD(initialize:(NSString *)pluginVersion :(NSString *)sdkKey :(RCT
         }
         else
         {
-            [NSException raise: NSInternalInconsistencyException
-                        format: @"Unable to initialize AppLovin SDK - no SDK key provided and not found in Info.plist!"];
+            reject(RCTErrorUnspecified, @"Unable to initialize AppLovin SDK - no SDK key provided and not found in Info.plist!", nil);
+            return;
         }
     }
     
@@ -262,16 +262,16 @@ RCT_EXPORT_METHOD(initialize:(NSString *)pluginVersion :(NSString *)sdkKey :(RCT
         self.sdkConfiguration = configuration;
         self.sdkInitialized = YES;
         
-        callback(@[@{@"consentDialogState" : @(configuration.consentDialogState),
-                     @"countryCode" : self.sdk.configuration.countryCode}]);
+        resolve(@[@{@"consentDialogState" : @(configuration.consentDialogState),
+                    @"countryCode" : self.sdk.configuration.countryCode}]);
     }];
 }
 
 #pragma mark - General Public API
 
-RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(isTablet)
+RCT_EXPORT_METHOD(isTablet :(RCTPromiseResolveBlock)resolve :(RCTPromiseRejectBlock)reject)
 {
-    return @([UIDevice currentDevice].userInterfaceIdiom == UIUserInterfaceIdiomPad);
+    resolve(@([UIDevice currentDevice].userInterfaceIdiom == UIUserInterfaceIdiomPad));
 }
 
 RCT_EXPORT_METHOD(showMediationDebugger)
@@ -292,11 +292,9 @@ RCT_EXPORT_METHOD(showConsentDialog:(RCTResponseSenderBlock)callback)
     callback(nil);
 }
 
-RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(getConsentDialogState)
+RCT_EXPORT_METHOD(getConsentDialogState :(RCTPromiseResolveBlock)resolve :(RCTPromiseRejectBlock)reject)
 {
-    if ( ![self isInitialized] ) return @(ALConsentDialogStateUnknown);
-    
-    return @(self.sdkConfiguration.consentDialogState);
+    resolve([self isSDKInitialized] ? @(self.sdkConfiguration.consentDialogState) : @(ALConsentDialogStateUnknown));
 }
 
 RCT_EXPORT_METHOD(setHasUserConsent:(BOOL)hasUserConsent)
@@ -304,9 +302,9 @@ RCT_EXPORT_METHOD(setHasUserConsent:(BOOL)hasUserConsent)
     [ALPrivacySettings setHasUserConsent: hasUserConsent];
 }
 
-RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(hasUserConsent)
+RCT_EXPORT_METHOD(hasUserConsent :(RCTPromiseResolveBlock)resolve :(RCTPromiseRejectBlock)reject)
 {
-    return @([ALPrivacySettings hasUserConsent]);
+    resolve(@([ALPrivacySettings hasUserConsent]));
 }
 
 RCT_EXPORT_METHOD(setIsAgeRestrictedUser:(BOOL)isAgeRestrictedUser)
@@ -314,9 +312,9 @@ RCT_EXPORT_METHOD(setIsAgeRestrictedUser:(BOOL)isAgeRestrictedUser)
     [ALPrivacySettings setIsAgeRestrictedUser: isAgeRestrictedUser];
 }
 
-RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(isAgeRestrictedUser)
+RCT_EXPORT_METHOD(isAgeRestrictedUser :(RCTPromiseResolveBlock)resolve :(RCTPromiseRejectBlock)reject)
 {
-    return @([ALPrivacySettings isAgeRestrictedUser]);
+    resolve(@([ALPrivacySettings isAgeRestrictedUser]));
 }
 
 RCT_EXPORT_METHOD(setDoNotSell:(BOOL)doNotSell)
@@ -324,9 +322,9 @@ RCT_EXPORT_METHOD(setDoNotSell:(BOOL)doNotSell)
     [ALPrivacySettings setDoNotSell: doNotSell];
 }
 
-RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(isDoNotSell)
+RCT_EXPORT_METHOD(isDoNotSell :(RCTPromiseResolveBlock)resolve :(RCTPromiseRejectBlock)reject)
 {
-    return @([ALPrivacySettings isDoNotSell]);
+    resolve(@([ALPrivacySettings isDoNotSell]));
 }
 
 RCT_EXPORT_METHOD(setUserId:(NSString *)userId)
@@ -349,11 +347,9 @@ RCT_EXPORT_METHOD(setMuted:(BOOL)muted)
     self.sdk.settings.muted = muted;
 }
 
-RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(isMuted)
+RCT_EXPORT_METHOD(isMuted :(RCTPromiseResolveBlock)resolve :(RCTPromiseRejectBlock)reject)
 {
-    if ( ![self isPluginInitialized] ) return @(NO);
-    
-    return @(self.sdk.settings.muted);
+    resolve([self isPluginInitialized] ? @(self.sdk.settings.muted) : @(NO) );
 }
 
 RCT_EXPORT_METHOD(setVerboseLogging:(BOOL)enabled)
@@ -619,9 +615,9 @@ RCT_EXPORT_METHOD(destroyBanner:(NSString *)adUnitIdentifier)
     [self destroyAdViewWithAdUnitIdentifier: adUnitIdentifier adFormat: DEVICE_SPECIFIC_ADVIEW_AD_FORMAT];
 }
 
-RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(getAdaptiveBannerHeightForWidth:(CGFloat)width)
+RCT_EXPORT_METHOD(getAdaptiveBannerHeightForWidth:(CGFloat)width :(RCTPromiseResolveBlock)resolve :(RCTPromiseRejectBlock)reject)
 {
-    return @([DEVICE_SPECIFIC_ADVIEW_AD_FORMAT adaptiveSizeForWidth: width].height);
+    resolve(@([DEVICE_SPECIFIC_ADVIEW_AD_FORMAT adaptiveSizeForWidth: width].height));
 }
 
 #pragma mark - MRECs
@@ -679,10 +675,10 @@ RCT_EXPORT_METHOD(loadInterstitial:(NSString *)adUnitIdentifier)
     [interstitial loadAd];
 }
 
-RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(isInterstitialReady:(NSString *)adUnitIdentifier)
+RCT_EXPORT_METHOD(isInterstitialReady:(NSString *)adUnitIdentifier :(RCTPromiseResolveBlock)resolve :(RCTPromiseRejectBlock)reject)
 {
     MAInterstitialAd *interstitial = [self retrieveInterstitialForAdUnitIdentifier: adUnitIdentifier];
-    return @([interstitial isReady]);
+    resolve(@([interstitial isReady]));
 }
 
 RCT_EXPORT_METHOD(showInterstitial:(NSString *)adUnitIdentifier :(nullable NSString *)placement :(nullable NSString *)customData)
@@ -705,10 +701,10 @@ RCT_EXPORT_METHOD(loadRewardedAd:(NSString *)adUnitIdentifier)
     [rewardedAd loadAd];
 }
 
-RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(isRewardedAdReady:(NSString *)adUnitIdentifier)
+RCT_EXPORT_METHOD(isRewardedAdReady:(NSString *)adUnitIdentifier :(RCTPromiseResolveBlock)resolve :(RCTPromiseRejectBlock)reject)
 {
     MARewardedAd *rewardedAd = [self retrieveRewardedAdForAdUnitIdentifier: adUnitIdentifier];
-    return @([rewardedAd isReady]);
+    resolve(@([rewardedAd isReady]));
 }
 
 RCT_EXPORT_METHOD(showRewardedAd:(NSString *)adUnitIdentifier :(nullable NSString *)placement :(nullable NSString *)customData)
@@ -731,10 +727,10 @@ RCT_EXPORT_METHOD(loadAppOpenAd:(NSString *)adUnitIdentifier)
     [appOpenAd loadAd];
 }
 
-RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(isAppOpenAdReady:(NSString *)adUnitIdentifier)
+RCT_EXPORT_METHOD(isAppOpenAdReady:(NSString *)adUnitIdentifier :(RCTPromiseResolveBlock)resolve :(RCTPromiseRejectBlock)reject)
 {
     MAAppOpenAd *appOpenAd = [self retrieveAppOpenAdForAdUnitIdentifier: adUnitIdentifier];
-    return @([appOpenAd isReady]);
+    resolve(@([appOpenAd isReady]));
 }
 
 RCT_EXPORT_METHOD(showAppOpenAd:(NSString *)adUnitIdentifier placement:(nullable NSString *)placement customData:(nullable NSString *)customData)

--- a/ios/AppLovinMAX.m
+++ b/ios/AppLovinMAX.m
@@ -134,7 +134,7 @@ RCT_EXPORT_MODULE()
     return self;
 }
 
-RCT_EXPORT_METHOD(isInitialized :(RCTPromiseResolveBlock)resolve :(RCTPromiseRejectBlock)reject)
+RCT_EXPORT_METHOD(isInitialized:(RCTPromiseResolveBlock)resolve :(RCTPromiseRejectBlock)reject)
 {
     resolve(@([self isPluginInitialized] && [self isSDKInitialized]));
 }
@@ -269,7 +269,7 @@ RCT_EXPORT_METHOD(initialize:(NSString *)pluginVersion :(NSString *)sdkKey :(RCT
 
 #pragma mark - General Public API
 
-RCT_EXPORT_METHOD(isTablet :(RCTPromiseResolveBlock)resolve :(RCTPromiseRejectBlock)reject)
+RCT_EXPORT_METHOD(isTablet:(RCTPromiseResolveBlock)resolve :(RCTPromiseRejectBlock)reject)
 {
     resolve(@([UIDevice currentDevice].userInterfaceIdiom == UIUserInterfaceIdiomPad));
 }
@@ -285,14 +285,14 @@ RCT_EXPORT_METHOD(showMediationDebugger)
     [self.sdk showMediationDebugger];
 }
 
-RCT_EXPORT_METHOD(showConsentDialog:(RCTResponseSenderBlock)callback)
+RCT_EXPORT_METHOD(showConsentDialog:(RCTPromiseResolveBlock)resolve :(RCTPromiseRejectBlock)reject)
 {
     [self log: @"Failed to show consent dialog - Unavailable on iOS, please use the consent flow: https://dash.applovin.com/documentation/mediation/react-native/getting-started/consent-flow"];
     
-    callback(nil);
+    resolve(nil);
 }
 
-RCT_EXPORT_METHOD(getConsentDialogState :(RCTPromiseResolveBlock)resolve :(RCTPromiseRejectBlock)reject)
+RCT_EXPORT_METHOD(getConsentDialogState:(RCTPromiseResolveBlock)resolve :(RCTPromiseRejectBlock)reject)
 {
     resolve([self isSDKInitialized] ? @(self.sdkConfiguration.consentDialogState) : @(ALConsentDialogStateUnknown));
 }
@@ -302,7 +302,7 @@ RCT_EXPORT_METHOD(setHasUserConsent:(BOOL)hasUserConsent)
     [ALPrivacySettings setHasUserConsent: hasUserConsent];
 }
 
-RCT_EXPORT_METHOD(hasUserConsent :(RCTPromiseResolveBlock)resolve :(RCTPromiseRejectBlock)reject)
+RCT_EXPORT_METHOD(hasUserConsent:(RCTPromiseResolveBlock)resolve :(RCTPromiseRejectBlock)reject)
 {
     resolve(@([ALPrivacySettings hasUserConsent]));
 }
@@ -312,7 +312,7 @@ RCT_EXPORT_METHOD(setIsAgeRestrictedUser:(BOOL)isAgeRestrictedUser)
     [ALPrivacySettings setIsAgeRestrictedUser: isAgeRestrictedUser];
 }
 
-RCT_EXPORT_METHOD(isAgeRestrictedUser :(RCTPromiseResolveBlock)resolve :(RCTPromiseRejectBlock)reject)
+RCT_EXPORT_METHOD(isAgeRestrictedUser:(RCTPromiseResolveBlock)resolve :(RCTPromiseRejectBlock)reject)
 {
     resolve(@([ALPrivacySettings isAgeRestrictedUser]));
 }
@@ -322,7 +322,7 @@ RCT_EXPORT_METHOD(setDoNotSell:(BOOL)doNotSell)
     [ALPrivacySettings setDoNotSell: doNotSell];
 }
 
-RCT_EXPORT_METHOD(isDoNotSell :(RCTPromiseResolveBlock)resolve :(RCTPromiseRejectBlock)reject)
+RCT_EXPORT_METHOD(isDoNotSell:(RCTPromiseResolveBlock)resolve :(RCTPromiseRejectBlock)reject)
 {
     resolve(@([ALPrivacySettings isDoNotSell]));
 }
@@ -347,7 +347,7 @@ RCT_EXPORT_METHOD(setMuted:(BOOL)muted)
     self.sdk.settings.muted = muted;
 }
 
-RCT_EXPORT_METHOD(isMuted :(RCTPromiseResolveBlock)resolve :(RCTPromiseRejectBlock)reject)
+RCT_EXPORT_METHOD(isMuted:(RCTPromiseResolveBlock)resolve :(RCTPromiseRejectBlock)reject)
 {
     resolve([self isPluginInitialized] ? @(self.sdk.settings.muted) : @(NO) );
 }

--- a/src/AppLovinMAXAdView.js
+++ b/src/AppLovinMAXAdView.js
@@ -1,6 +1,6 @@
 import { NativeModules, requireNativeComponent, UIManager, findNodeHandle, View, Text, StyleSheet } from "react-native";
 import PropTypes from "prop-types";
-import React from "react";
+import React, { useEffect, useState } from "react";
 
 const { AppLovinMAX } = NativeModules;
 
@@ -21,65 +21,50 @@ export const AdViewPosition = {
   BOTTOM_RIGHT: "bottom_right",
 };
 
-/**
- * Returns AdView when AppLovinMax has been initialized or returns a black empty View as 
- * a placeholder of AdView when AppLovinMax has not been initialized.  
- *
- * The purpose of this AdView wrapper is for the application not to access AdView 
- * before the completion of the AppLovinMax initialization. 
- *
- * Note: this does not re-render itself when the status of the AppLovinMax initialization
- * has changed so that the black view may stay even after the completion of 
- * the AppLovinMax initialization.
- */
-const AdViewWrapper = (props) => {
-  const {style, ...rest} = props;
-  return (
-    AppLovinMAX.isInitialized() ?
-      <AdView {...style} {...rest}/>
-    :
-      <View style={[styles.container, style]} {...rest}>
-        {
-          console.warn('[AppLovinSdk] [AppLovinMAX] <AdView/> has been mounted before AppLovin initialization')
-        } 
-      </View>
-  );
-};
-
-const styles = StyleSheet.create({
-  container: {
-    flexDirection: 'column',
-    justifyContent: 'flex-end',
-    alignItems: 'center',
-    backgroundColor: 'black',
-    borderColor: 'whitesmoke',
-    borderWidth: 1,
-  },
-});
-
 const AdView = (props) => {
   const {style, ...otherProps} = props;
+  const [isInitialized, setIsInitialized] = useState(false);
+  const [dimensions, setDimensions] = useState({});
 
-  const sizeForAdFormat = () => {
-    if (props.adFormat === AdFormat.BANNER) {
-      let width = AppLovinMAX.isTablet() ? 728 : 320;
-      let height;
-
-      if (props.adaptiveBannerEnabled) {
-        height = AppLovinMAX.getAdaptiveBannerHeightForWidth(-1);
-      } else {
-        height = AppLovinMAX.isTablet() ? 90 : 50;
+  useEffect(() => {
+    // check that AppLovinMAX has been initialized
+    AppLovinMAX.isInitialized().then(result => {
+      setIsInitialized(result);
+      if (!result) {
+        console.warn("ERROR: AppLovinMAX.AdView is mounted before the initialization of the AppLovin MAX React Native module");
       }
+    });
 
-      return { width: width, height: height }
-    } else {
-      return { width: 300, height: 250 }
+    const sizeForBannerFormat = async () => {
+      const isTablet = await AppLovinMAX.isTablet();
+      const width = isTablet ? 728 : 320;
+      let height;
+      if (props.adaptiveBannerEnabled) {
+        height = await AppLovinMAX.getAdaptiveBannerHeightForWidth(-1);
+      } else {
+        height = isTablet ? 90 : 50;
+      }
+      setDimensions({width: style.width ? style.width : width, height: style.height ? style.height : height});
     }
-  };
+
+    // set width and height when either one of them or both are not specified
+    if (!(style.width && style.height)) {
+      if (props.adFormat === AdFormat.BANNER) {
+        sizeForBannerFormat();
+      } else {
+        setDimensions({width: style.width ? style.width : 300, height: style.height ? style.height : 250});
+      }
+    }
+  }, []);
+
+  // Not ready to render AppLovinMAXAdView
+  if (!isInitialized || !((style.width && style.height) || (Object.keys(dimensions).length > 0))) {
+    return null;
+  }
 
   return (
     <AppLovinMAXAdView
-      style={[sizeForAdFormat(), style]}
+      style={{...dimensions, ...style}}
       {...otherProps}
     />
   );
@@ -123,8 +108,7 @@ AdView.defaultProps = {
   autoRefresh: true,
 };
 
-
 // requireNativeComponent automatically resolves 'AppLovinMAXAdView' to 'AppLovinMAXAdViewManager'
 const AppLovinMAXAdView = requireNativeComponent("AppLovinMAXAdView", AdView);
 
-export default AdViewWrapper;
+export default AdView;

--- a/src/AppLovinMAXAdView.js
+++ b/src/AppLovinMAXAdView.js
@@ -34,6 +34,12 @@ const AdView = (props) => {
         console.warn("ERROR: AppLovinMAX.AdView is mounted before the initialization of the AppLovin MAX React Native module");
       }
     });
+  }, []);
+
+  useEffect(() => {
+    if (!isInitialized) {
+      return;
+    }
 
     const sizeForBannerFormat = async () => {
       const isTablet = await AppLovinMAX.isTablet();
@@ -44,27 +50,41 @@ const AdView = (props) => {
       } else {
         height = isTablet ? 90 : 50;
       }
-      setDimensions({width: style.width ? style.width : width, height: style.height ? style.height : height});
+      setDimensions({width: (style.width && style.width !== 'auto') ? style.width : width,
+                     height: (style.height && style.height !== 'auto') ? style.height : height});
     }
 
-    // set width and height when either one of them or both are not specified
-    if (!(style.width && style.height)) {
+    // Check whether or not app specifies both width and height but not with 'auto'
+    const isSizeSpecified = ((style.width && style.width !== 'auto') &&
+                             (style.height && style.height !== 'auto'));
+
+    if (!isSizeSpecified) {
       if (props.adFormat === AdFormat.BANNER) {
         sizeForBannerFormat();
       } else {
-        setDimensions({width: style.width ? style.width : 300, height: style.height ? style.height : 250});
+        setDimensions({width: (style.width && style.width !== 'auto') ? style.width : 300,
+                       height: (style.height && style.height !== 'auto') ? style.height : 250});
       }
     }
-  }, []);
+  }, [isInitialized]);
 
-  // Not ready to render AppLovinMAXAdView
-  if (!isInitialized || !((style.width && style.height) || (Object.keys(dimensions).length > 0))) {
+  // Not initialized
+  if (!isInitialized) {
     return null;
+  } else {
+    const isSizeSpecified = ((style.width && style.width !== 'auto') &&
+                             (style.height && style.height !== 'auto'));
+    const isDimensionsSet = (Object.keys(dimensions).length > 0);
+
+    // Not sized yet
+    if (!(isSizeSpecified || isDimensionsSet)) {
+      return null;
+    }
   }
 
   return (
     <AppLovinMAXAdView
-      style={{...dimensions, ...style}}
+      style={{ ...style, ...dimensions}}
       {...otherProps}
     />
   );

--- a/src/AppLovinMAXAdView.js
+++ b/src/AppLovinMAXAdView.js
@@ -84,7 +84,7 @@ const AdView = (props) => {
 
   return (
     <AppLovinMAXAdView
-      style={{ ...style, ...dimensions}}
+      style={{...style, ...dimensions}}
       {...otherProps}
     />
   );

--- a/src/NativeAdView.js
+++ b/src/NativeAdView.js
@@ -1,4 +1,4 @@
-import React, { forwardRef, useContext, useImperativeHandle, useRef, useCallback } from "react";
+import React, { forwardRef, useContext, useImperativeHandle, useRef, useCallback, useState, useEffect } from "react";
 import PropTypes from "prop-types";
 import { NativeModules, requireNativeComponent, UIManager, findNodeHandle, View, StyleSheet } from "react-native";
 import { NativeAdViewContext, NativeAdViewProvider } from "./NativeAdViewProvider";
@@ -6,33 +6,29 @@ import { TitleView, AdvertiserView, BodyView, CallToActionView, IconView, Option
 
 const { AppLovinMAX } = NativeModules;
 
-// Returns NativeAdView if AppLovinMAX has been initialized, or returns an empty black view if
-// AppLovinMAX has not been initialized
 const NativeAdViewWrapper = forwardRef((props, ref) => {
-  const {style, ...rest} = props;
-  return (
-    AppLovinMAX.isInitialized() ?
-      <NativeAdViewProvider>
-        <NativeAdView {...props} ref={ref}/>
-      </NativeAdViewProvider>
-    :
-      <View style={[styles.container, style]} {...rest}>
-        {
-          console.warn('[AppLovinSdk] [AppLovinMAX] <NativeAdView/> has been mounted before AppLovin initialization')
-        } 
-      </View>
-  );
-});
+  const [isInitialized, setIsInitialized] = useState(false);
 
-const styles = StyleSheet.create({
-  container: {
-    flexDirection: 'column',
-    justifyContent: 'flex-end',
-    alignItems: 'center',
-    backgroundColor: 'black',
-    borderColor: 'whitesmoke',
-    borderWidth: 1,
-  },
+  useEffect(() => {
+    // check that AppLovinMAX has been initialized
+    AppLovinMAX.isInitialized().then(result => {
+      setIsInitialized(result);
+      if (!result) {
+        console.warn("ERROR: AppLovinMAX.NativeAdView is mounted before the initialization of the AppLovin MAX React Native module");
+      }
+    });
+  }, []);
+
+  // Not ready to render NativeAdView
+  if (!isInitialized) {
+    return null;
+  }
+
+  return (
+    <NativeAdViewProvider>
+      <NativeAdView {...props} ref={ref}/>
+    </NativeAdViewProvider>
+  );
 });
 
 const AppLovinMAXNativeAdView = requireNativeComponent('AppLovinMAXNativeAdView', NativeAdView);

--- a/src/index.js
+++ b/src/index.js
@@ -49,7 +49,7 @@ const removeEventListener = (event) => {
 };
 
 const logUninitializedAccessError = (callingMethod) => {
-  console.warn( "ERROR: Failed to execute " + callingMethod + "() - please ensure the AppLovin MAX React Native module has been initialized by calling 'AppLovinMAX.initialize(...);'!" );
+  console.warn("ERROR: Failed to execute " + callingMethod + "() - please ensure the AppLovin MAX React Native module has been initialized by calling 'AppLovinMAX.initialize(...);'!");
 }
 
 /*---------*/
@@ -57,107 +57,133 @@ const logUninitializedAccessError = (callingMethod) => {
 /*---------*/
 
 const createBanner = (adUnitId, bannerPosition) => {
-  if (!AppLovinMAX.isInitialized()) {
-    logUninitializedAccessError('createBanner');
-    return;
-  }
-  AppLovinMAX.createBanner(adUnitId, bannerPosition);
+  AppLovinMAX.isInitialized().then(isInitialized => {
+    if (isInitialized) {
+      AppLovinMAX.createBanner(adUnitId, bannerPosition);
+    } else {
+      logUninitializedAccessError('createBanner');
+    }
+  });
 }
 
 const createBannerWithOffsets = (adUnitId, bannerPosition, xOffset, yOffset) => {
-  if (!AppLovinMAX.isInitialized()) {
-    logUninitializedAccessError('createBannerWithOffsets');
-    return;
-  }
-  AppLovinMAX.createBannerWithOffsets(adUnitId, bannerPosition, xOffset, yOffset);
+  AppLovinMAX.isInitialized().then(isInitialized => {
+    if (isInitialized) {
+      AppLovinMAX.createBannerWithOffsets(adUnitId, bannerPosition, xOffset, yOffset);
+    } else {
+      logUninitializedAccessError('createBannerWithOffsets');
+    }
+  });
 }
 
 const setBannerBackgroundColor = (adUnitId, hexColorCode) => {
-  if (!AppLovinMAX.isInitialized()) {
-    logUninitializedAccessError('setBannerBackgroundColor');
-    return;
-  }
-  AppLovinMAX.setBannerBackgroundColor(adUnitId, hexColorCode);
+  AppLovinMAX.isInitialized().then(isInitialized => {
+    if (isInitialized) {
+      AppLovinMAX.setBannerBackgroundColor(adUnitId, hexColorCode);
+    } else {
+      logUninitializedAccessError('setBannerBackgroundColor');
+    }
+  });
 }
 
 const setBannerPlacement = (adUnitId, placement) => {
-  if (!AppLovinMAX.isInitialized()) {
-    logUninitializedAccessError('setBannerPlacement');
-    return;
-  }
-  AppLovinMAX.setBannerPlacement(adUnitId, placement);
+  AppLovinMAX.isInitialized().then(isInitialized => {
+    if (isInitialized) {
+      AppLovinMAX.setBannerPlacement(adUnitId, placement);
+    } else {
+      logUninitializedAccessError('setBannerPlacement');
+    }
+  });
 }
 
 const setBannerWidth = (adUnitId, width) => {
-  if (!AppLovinMAX.isInitialized()) {
-    logUninitializedAccessError('setBannerWidth');
-    return;
-  }
-  AppLovinMAX.setBannerWidth(adUnitId, width);
+  AppLovinMAX.isInitialized().then(isInitialized => {
+    if (isInitialized) {
+      AppLovinMAX.setBannerWidth(adUnitId, width);
+    } else {
+      logUninitializedAccessError('setBannerWidth');
+    }
+  });
 }
 
 const updateBannerPosition = (adUnitId, bannerPosition) => {
-  if (!AppLovinMAX.isInitialized()) {
-    logUninitializedAccessError('updateBannerPosition');
-    return;
-  }
-  AppLovinMAX.updateBannerPosition(adUnitId, bannerPosition);
+  AppLovinMAX.isInitialized().then(isInitialized => {
+    if (isInitialized) {
+      AppLovinMAX.updateBannerPosition(adUnitId, bannerPosition);
+    } else {
+      logUninitializedAccessError('updateBannerPosition');
+    }
+  });
 }
 
 const updateBannerOffsets = (adUnitId, xOffset, yOffset) => {
-  if (!AppLovinMAX.isInitialized()) {
-    logUninitializedAccessError('updateBannerOffsets');
-    return;
-  }
-  AppLovinMAX.updateBannerOffsets(adUnitId, xOffset, yOffset);
+  AppLovinMAX.isInitialized().then(isInitialized => {
+    if (isInitialized) {
+      AppLovinMAX.updateBannerOffsets(adUnitId, xOffset, yOffset);
+    } else {
+      logUninitializedAccessError('updateBannerOffsets');
+    }
+  });
 }
 
 const setBannerExtraParameter = (adUnitId, key, value) => {
-  if (!AppLovinMAX.isInitialized()) {
-    logUninitializedAccessError('setBannerExtraParameter');
-    return;
-  }
-  AppLovinMAX.setBannerExtraParameter(adUnitId, key, value);
+  AppLovinMAX.isInitialized().then(isInitialized => {
+    if (isInitialized) {
+      AppLovinMAX.setBannerExtraParameter(adUnitId, key, value);
+    } else {
+      logUninitializedAccessError('setBannerExtraParameter');
+    }
+  });
 }
 
 const startBannerAutoRefresh = (adUnitId) => {
-  if (!AppLovinMAX.isInitialized()) {
-    logUninitializedAccessError('startBannerAutoRefresh');
-    return;
-  }
-  AppLovinMAX.startBannerAutoRefresh(adUnitId);
+  AppLovinMAX.isInitialized().then(isInitialized => {
+    if (isInitialized) {
+      AppLovinMAX.startBannerAutoRefresh(adUnitId);
+    } else {
+      logUninitializedAccessError('startBannerAutoRefresh');
+    }
+  });
 }
 
 const stopBannerAutoRefresh = (adUnitId) => {
-  if (!AppLovinMAX.isInitialized()) {
-    logUninitializedAccessError('stopBannerAutoRefresh');
-    return;
-  }
-  AppLovinMAX.stopBannerAutoRefresh(adUnitId);
+  AppLovinMAX.isInitialized().then(isInitialized => {
+    if (isInitialized) {
+      AppLovinMAX.stopBannerAutoRefresh(adUnitId);
+    } else {
+      logUninitializedAccessError('stopBannerAutoRefresh');
+    }
+  });
 }
 
 const showBanner = (adUnitId) => {
-  if (!AppLovinMAX.isInitialized()) {
-    logUninitializedAccessError('showBanner');
-    return;
-  }
-  AppLovinMAX.showBanner(adUnitId);
+  AppLovinMAX.isInitialized().then(isInitialized => {
+    if (isInitialized) {
+      AppLovinMAX.showBanner(adUnitId);
+    } else {
+      logUninitializedAccessError('showBanner');
+    }
+  });
 }
 
 const hideBanner = (adUnitId) => {
-  if (!AppLovinMAX.isInitialized()) {
-    logUninitializedAccessError('hideBanner');
-    return;
-  }
-  AppLovinMAX.hideBanner(adUnitId);
+  AppLovinMAX.isInitialized().then(isInitialized => {
+    if (isInitialized) {
+      AppLovinMAX.hideBanner(adUnitId);
+    } else {
+      logUninitializedAccessError('hideBanner');
+    }
+  });
 }
 
 const destroyBanner = (adUnitId) => {
-  if (!AppLovinMAX.isInitialized()) {
-    logUninitializedAccessError('destroyBanner');
-    return;
-  }
-  AppLovinMAX.destroyBanner(adUnitId);
+  AppLovinMAX.isInitialized().then(isInitialized => {
+    if (isInitialized) {
+      AppLovinMAX.destroyBanner(adUnitId);
+    } else {
+      logUninitializedAccessError('destroyBanner');
+    }
+  });
 }
 
 /*-------*/
@@ -165,91 +191,113 @@ const destroyBanner = (adUnitId) => {
 /*-------*/
 
 const createMRec = (adUnitId, mrecPosition) => {
-  if (!AppLovinMAX.isInitialized()) {
-    logUninitializedAccessError('createMRec');
-    return;
-  }
-  AppLovinMAX.createMRec(adUnitId, mrecPosition);
+  AppLovinMAX.isInitialized().then(isInitialized => {
+    if (isInitialized) {
+      AppLovinMAX.createMRec(adUnitId, mrecPosition);
+    } else {
+      logUninitializedAccessError('createMRec');
+    }
+  });
 }
 
 const setMRecBackgroundColor = (adUnitId, hexColorCode) => {
-  if (!AppLovinMAX.isInitialized()) {
-    logUninitializedAccessError('setMRecBackgroundColor');
-    return;
-  }
-  AppLovinMAX.setMRecBackgroundColor(adUnitId, hexColorCode);
+  AppLovinMAX.isInitialized().then(isInitialized => {
+    if (isInitialized) {
+      AppLovinMAX.setMRecBackgroundColor(adUnitId, hexColorCode);
+    } else {
+      logUninitializedAccessError('setMRecBackgroundColor');
+    }
+  });
 }
 
 const setMRecPlacement = (adUnitId, placement) => {
-  if (!AppLovinMAX.isInitialized()) {
-    logUninitializedAccessError('setMRecPlacement');
-    return;
-  }
-  AppLovinMAX.setMRecPlacement(adUnitId, placement);
+  AppLovinMAX.isInitialized().then(isInitialized => {
+    if (isInitialized) {
+      AppLovinMAX.setMRecPlacement(adUnitId, placement);
+    } else {
+      logUninitializedAccessError('setMRecPlacement');
+    }
+  });
 }
 
 const setMRecCustomData = (adUnitId, customData) => {
-  if (!AppLovinMAX.isInitialized()) {
-    logUninitializedAccessError('setMRecCustomData');
-    return;
-  }
-  AppLovinMAX.setMRecCustomData(adUnitId, customData);
+  AppLovinMAX.isInitialized().then(isInitialized => {
+    if (isInitialized) {
+      AppLovinMAX.setMRecCustomData(adUnitId, customData);
+    } else {
+      logUninitializedAccessError('setMRecCustomData');
+    }
+  });
 }
 
 const updateMRecPosition = (adUnitId, mrecPosition) => {
-  if (!AppLovinMAX.isInitialized()) {
-    logUninitializedAccessError('updateMRecPosition');
-    return;
-  }
-  AppLovinMAX.updateMRecPosition(adUnitId, mrecPosition);
+  AppLovinMAX.isInitialized().then(isInitialized => {
+    if (isInitialized) {
+      AppLovinMAX.updateMRecPosition(adUnitId, mrecPosition);
+    } else {
+      logUninitializedAccessError('updateMRecPosition');
+    }
+  });
 }
 
 const setMRecExtraParameter = (adUnitId, key, value) => {
-  if (!AppLovinMAX.isInitialized()) {
-    logUninitializedAccessError('setMRecExtraParameter');
-    return;
-  }
-  AppLovinMAX.setMRecExtraParameter(adUnitId, key, value);
+  AppLovinMAX.isInitialized().then(isInitialized => {
+    if (isInitialized) {
+      AppLovinMAX.setMRecExtraParameter(adUnitId, key, value);
+    } else {
+      logUninitializedAccessError('setMRecExtraParameter');
+    }
+  });
 }
 
 const startMRecAutoRefresh = (adUnitId) => {
-  if (!AppLovinMAX.isInitialized()) {
-    logUninitializedAccessError('startMRecAutoRefresh');
-    return;
-  }
-  AppLovinMAX.startMRecAutoRefresh(adUnitId);
+  AppLovinMAX.isInitialized().then(isInitialized => {
+    if (isInitialized) {
+      AppLovinMAX.startMRecAutoRefresh(adUnitId);
+    } else {
+      logUninitializedAccessError('startMRecAutoRefresh');
+    }
+  });
 }
 
 const stopMRecAutoRefresh = (adUnitId) => {
-  if (!AppLovinMAX.isInitialized()) {
-    logUninitializedAccessError('stopMRecAutoRefresh');
-    return;
-  }
-  AppLovinMAX.stopMRecAutoRefresh(adUnitId);
+  AppLovinMAX.isInitialized().then(isInitialized => {
+    if (isInitialized) {
+      AppLovinMAX.stopMRecAutoRefresh(adUnitId);
+    } else {
+      logUninitializedAccessError('stopMRecAutoRefresh');
+    }
+  });
 }
 
 const showMRec = (adUnitId) => {
-  if (!AppLovinMAX.isInitialized()) {
-    logUninitializedAccessError('showMRec');
-    return;
-  }
-  AppLovinMAX.showMRec(adUnitId);
+  AppLovinMAX.isInitialized().then(isInitialized => {
+    if (isInitialized) {
+      AppLovinMAX.showMRec(adUnitId);
+    } else {
+      logUninitializedAccessError('showMRec');
+    }
+  });
 }
 
 const hideMRec = (adUnitId) => {
-  if (!AppLovinMAX.isInitialized()) {
-    logUninitializedAccessError('hideMRec');
-    return;
-  }
-  AppLovinMAX.hideMRec(adUnitId);
+  AppLovinMAX.isInitialized().then(isInitialized => {
+    if (isInitialized) {
+      AppLovinMAX.hideMRec(adUnitId);
+    } else {
+      logUninitializedAccessError('hideMRec');
+    }
+  });
 }
 
 const destroyMRec = (adUnitId) => {
-  if (!AppLovinMAX.isInitialized()) {
-    logUninitializedAccessError('destroyMRec');
-    return;
-  }
-  AppLovinMAX.destroyMRec(adUnitId);
+  AppLovinMAX.isInitialized().then(isInitialized => {
+    if (isInitialized) {
+      AppLovinMAX.destroyMRec(adUnitId);
+    } else {
+      logUninitializedAccessError('destroyMRec');
+    }
+  });
 }
 
 /*---------------*/
@@ -257,49 +305,60 @@ const destroyMRec = (adUnitId) => {
 /*---------------*/
 
 const loadInterstitial = (adUnitId) => {
-  if (!AppLovinMAX.isInitialized()) {
-    logUninitializedAccessError('loadInterstitial');
-    return;
-  }
-  AppLovinMAX.loadInterstitial(adUnitId);
+  AppLovinMAX.isInitialized().then(isInitialized => {
+    if (isInitialized) {
+      AppLovinMAX.loadInterstitial(adUnitId);
+    } else {
+      logUninitializedAccessError('loadInterstitial');
+    }
+  });
 }
 
 const isInterstitialReady = (adUnitId) => {
-  if (!AppLovinMAX.isInitialized()) {
-    logUninitializedAccessError('isInterstitialReady');
-    return false;
-  }
-  return AppLovinMAX.isInterstitialReady(adUnitId);
+  return new Promise((resolve, reject) => {
+    resolve(AppLovinMAX.isInitialized());
+  }).then(isInitialized => {
+    if (isInitialized) {
+      return new Promise((resolve, reject) => {
+        resolve(AppLovinMAX.isInterstitialReady(adUnitId));
+      });
+    } else {
+      throw new Error("Failed to execute isInterstitialReady() - please ensure the AppLovin MAX React Native module has been initialized by calling 'AppLovinMAX.initialize(...);'!");
+    }
+  });
 }
 
 const showInterstitial = (adUnitId, ...args) => {
-  if (!AppLovinMAX.isInitialized()) {
-    logUninitializedAccessError('showInterstitial');
-    return;
-  }
-
-  switch (args.length) {
-  case 0:
-    AppLovinMAX.showInterstitial(adUnitId, null, null);
-    break;
-  case 1:
-    AppLovinMAX.showInterstitial(adUnitId, args[0], null);
-    break;
-  case 2:
-    AppLovinMAX.showInterstitial(adUnitId, args[0], args[1]);
-    break;
-  default:
-    // do nothing - unexpected number of arguments
-    break;
-  }
+  AppLovinMAX.isInitialized().then(isInitialized => {
+    if (isInitialized) {
+      switch (args.length) {
+      case 0:
+        AppLovinMAX.showInterstitial(adUnitId, null, null);
+        break;
+      case 1:
+        AppLovinMAX.showInterstitial(adUnitId, args[0], null);
+        break;
+      case 2:
+        AppLovinMAX.showInterstitial(adUnitId, args[0], args[1]);
+        break;
+      default:
+        // do nothing - unexpected number of arguments
+        break;
+      }
+    } else {
+      logUninitializedAccessError('showInterstitial');
+    }
+  });
 };
 
 const setInterstitialExtraParameter = (adUnitId, key, value) => {
-  if (!AppLovinMAX.isInitialized()) {
-    logUninitializedAccessError('setInterstitialExtraParameter');
-    return;
-  }
-  AppLovinMAX.setInterstitialExtraParameter(adUnitId, key, value);
+  AppLovinMAX.isInitialized().then(isInitialized => {
+    if (isInitialized) {
+      AppLovinMAX.setInterstitialExtraParameter(adUnitId, key, value);
+    } else {
+      logUninitializedAccessError('setInterstitialExtraParameter');
+    }
+  });
 }
 
 /*----------*/
@@ -307,49 +366,60 @@ const setInterstitialExtraParameter = (adUnitId, key, value) => {
 /*----------*/
 
 const loadRewardedAd = (adUnitId) => {
-  if (!AppLovinMAX.isInitialized()) {
-    logUninitializedAccessError('loadRewardedAd');
-    return;
-  }
-  AppLovinMAX.loadRewardedAd(adUnitId);
+  AppLovinMAX.isInitialized().then(isInitialized => {
+    if (isInitialized) {
+      AppLovinMAX.loadRewardedAd(adUnitId);
+    } else {
+      logUninitializedAccessError('loadRewardedAd');
+    }
+  });
 }
 
 const isRewardedAdReady = (adUnitId) => {
-  if (!AppLovinMAX.isInitialized()) {
-    logUninitializedAccessError('isRewardedAdReady');
-    return false;
-  }
-  return AppLovinMAX.isRewardedAdReady(adUnitId);
+  return new Promise((resolve, reject) => {
+    resolve(AppLovinMAX.isInitialized());
+  }).then(isInitialized => {
+    if (isInitialized) {
+      return new Promise((resolve, reject) => {
+        resolve(AppLovinMAX.isRewardedAdReady(adUnitId));
+      });
+    } else {
+      throw new Error("Failed to execute isRewardedAdReady() - please ensure the AppLovin MAX React Native module has been initialized by calling 'AppLovinMAX.initialize(...);'!");
+    }
+  });
 }
 
 const showRewardedAd = (adUnitId, ...args) => {
-  if (!AppLovinMAX.isInitialized()) {
-    logUninitializedAccessError('showRewardedAd');
-    return;
-  }
-
-  switch (args.length) {
-  case 0:
-    AppLovinMAX.showRewardedAd(adUnitId, null, null);
-    break;
-  case 1:
-    AppLovinMAX.showRewardedAd(adUnitId, args[0], null);
-    break;
-  case 2:
-    AppLovinMAX.showRewardedAd(adUnitId, args[0], args[1]);
-    break;
-  default:
-    // do nothing - unexpected number of arguments
-    break;
-  }
+  AppLovinMAX.isInitialized().then(isInitialized => {
+    if (isInitialized) {
+      switch (args.length) {
+      case 0:
+        AppLovinMAX.showRewardedAd(adUnitId, null, null);
+        break;
+      case 1:
+        AppLovinMAX.showRewardedAd(adUnitId, args[0], null);
+        break;
+      case 2:
+        AppLovinMAX.showRewardedAd(adUnitId, args[0], args[1]);
+        break;
+      default:
+        // do nothing - unexpected number of arguments
+        break;
+      }
+    } else {
+      logUninitializedAccessError('showRewardedAd');
+    }
+  });
 };
 
 const setRewardedAdExtraParameter = (adUnitId, key, value) => {
-  if (!AppLovinMAX.isInitialized()) {
-    logUninitializedAccessError('setRewardedAdExtraParameter');
-    return;
-  }
-  AppLovinMAX.setRewardedAdExtraParameter(adUnitId, key, value);
+  AppLovinMAX.isInitialized().then(isInitialized => {
+    if (isInitialized) {
+      AppLovinMAX.setRewardedAdExtraParameter(adUnitId, key, value);
+    } else {
+      logUninitializedAccessError('setRewardedAdExtraParameter');
+    }
+  });
 }
 
 /*----------*/
@@ -357,49 +427,60 @@ const setRewardedAdExtraParameter = (adUnitId, key, value) => {
 /*----------*/
 
 const loadAppOpenAd = (adUnitId) => {
-  if (!AppLovinMAX.isInitialized()) {
-    logUninitializedAccessError('loadAppOpenAd');
-    return;
-  }
-  AppLovinMAX.loadAppOpenAd(adUnitId);
+  AppLovinMAX.isInitialized().then(isInitialized => {
+    if (isInitialized) {
+      AppLovinMAX.loadAppOpenAd(adUnitId);
+    } else {
+      logUninitializedAccessError('loadAppOpenAd');
+    }
+  });
 }
 
 const isAppOpenAdReady = (adUnitId) => {
-  if (!AppLovinMAX.isInitialized()) {
-    logUninitializedAccessError('isAppOpenAdReady');
-    return false;
-  }
-  return AppLovinMAX.isAppOpenAdReady(adUnitId);
+  return new Promise((resolve, reject) => {
+    resolve(AppLovinMAX.isInitialized());
+  }).then(isInitialized => {
+    if (isInitialized) {
+      return new Promise((resolve, reject) => {
+        resolve(AppLovinMAX.isAppOpenAdReady(adUnitId));
+      });
+    } else {
+      throw new Error("Failed to execute isAppOpenAdReady() - please ensure the AppLovin MAX React Native module has been initialized by calling 'AppLovinMAX.initialize(...);'!");
+    }
+  });
 }
 
 const showAppOpenAd = (adUnitId, ...args) => {
-  if (!AppLovinMAX.isInitialized()) {
-    logUninitializedAccessError('showAppOpenAd');
-    return;
-  }
-
-  switch (args.length) {
-  case 0:
-    AppLovinMAX.showAppOpenAd(adUnitId, null, null);
-    break;
-  case 1:
-    AppLovinMAX.showAppOpenAd(adUnitId, args[0], null);
-    break;
-  case 2:
-    AppLovinMAX.showAppOpenAd(adUnitId, args[0], args[1]);
-    break;
-  default:
-    // do nothing - unexpected number of arguments
-    break;
-  }
+  AppLovinMAX.isInitialized().then(isInitialized => {
+    if (isInitialized) {
+      switch (args.length) {
+      case 0:
+        AppLovinMAX.showAppOpenAd(adUnitId, null, null);
+        break;
+      case 1:
+        AppLovinMAX.showAppOpenAd(adUnitId, args[0], null);
+        break;
+      case 2:
+        AppLovinMAX.showAppOpenAd(adUnitId, args[0], args[1]);
+        break;
+      default:
+        // do nothing - unexpected number of arguments
+        break;
+      }
+    } else {
+      logUninitializedAccessError('showAppOpenAd');
+    }
+  });
 };
 
 const setAppOpenAdExtraParameter = (adUnitId, key, value) => {
-  if (!AppLovinMAX.isInitialized()) {
-    logUninitializedAccessError('setAppOpenAdExtraParameter');
-    return;
-  }
-  AppLovinMAX.setAppOpenAdExtraParameter(adUnitId, key, value);
+  AppLovinMAX.isInitialized().then(isInitialized => {
+    if (isInitialized) {
+      AppLovinMAX.setAppOpenAdExtraParameter(adUnitId, key, value);
+    } else {
+      logUninitializedAccessError('setAppOpenAdExtraParameter');
+    }
+  });
 }
 
 export default {
@@ -416,9 +497,10 @@ export default {
   NativeAdView,
   addEventListener,
   removeEventListener,
-  // Use callback to avoid need for attaching listeners at top level on each re-render
-  initialize(sdkKey, callback) {
-    AppLovinMAX.initialize(VERSION, sdkKey, callback); // Inject VERSION into native code
+  initialize(sdkKey) {
+    return new Promise((resolve, reject) => {
+      resolve(AppLovinMAX.initialize(VERSION, sdkKey));
+    });
   },
 
   /*---------*/
@@ -484,29 +566,29 @@ export default {
   /*----------------*/
   /* INITIALIZATION */
   /*----------------*/
-  /* isInitialized() */
-  /* initialize(pluginVersion, sdkKey, callback) */
+  /* isInitialized(promise) */
+  /* initialize(pluginVersion, sdkKey, promise) */
 
   /*--------------*/
   /* PRIVACY APIs */
   /*--------------*/
   /* showConsentDialog(callback) */
-  /* getConsentDialogState() */
+  /* getConsentDialogState(promise) */
   /* setHasUserConsent(hasUserConsent) */
-  /* hasUserConsent() */
+  /* hasUserConsent(promise) */
   /* setIsAgeRestrictedUser(isAgeRestrictedUser) */
-  /* isAgeRestrictedUser() */
+  /* isAgeRestrictedUser(promise) */
   /* setDoNotSell(doNotSell) */
-  /* isDoNotSell() */
+  /* isDoNotSell(promise) */
 
   /*--------------------*/
   /* GENERAL PUBLIC API */
   /*--------------------*/
   /* showMediationDebugger() */
-  /* isTablet() */
+  /* isTablet(promise) */
   /* setUserId(userId) */
   /* setMuted(muted) */
-  /* isMuted() */
+  /* isMuted(promise) */
   /* setVerboseLogging(verboseLoggingEnabled) */
   /* setTestDeviceAdvertisingIds(advertisingIds) */
   /* setCreativeDebuggerEnabled(enabled) */
@@ -524,5 +606,5 @@ export default {
   /*---------*/
   /* BANNERS */
   /*---------*/
-  /* getAdaptiveBannerHeightForWidth(width) */
+  /* getAdaptiveBannerHeightForWidth(width, promise) */
 };

--- a/src/index.js
+++ b/src/index.js
@@ -315,13 +315,9 @@ const loadInterstitial = (adUnitId) => {
 }
 
 const isInterstitialReady = (adUnitId) => {
-  return new Promise((resolve, reject) => {
-    resolve(AppLovinMAX.isInitialized());
-  }).then(isInitialized => {
+  return AppLovinMAX.isInitialized().then(isInitialized => {
     if (isInitialized) {
-      return new Promise((resolve, reject) => {
-        resolve(AppLovinMAX.isInterstitialReady(adUnitId));
-      });
+      return AppLovinMAX.isInterstitialReady(adUnitId);
     } else {
       throw new Error("Failed to execute isInterstitialReady() - please ensure the AppLovin MAX React Native module has been initialized by calling 'AppLovinMAX.initialize(...);'!");
     }
@@ -376,13 +372,9 @@ const loadRewardedAd = (adUnitId) => {
 }
 
 const isRewardedAdReady = (adUnitId) => {
-  return new Promise((resolve, reject) => {
-    resolve(AppLovinMAX.isInitialized());
-  }).then(isInitialized => {
+  return AppLovinMAX.isInitialized().then(isInitialized => {
     if (isInitialized) {
-      return new Promise((resolve, reject) => {
-        resolve(AppLovinMAX.isRewardedAdReady(adUnitId));
-      });
+      return AppLovinMAX.isRewardedAdReady(adUnitId);
     } else {
       throw new Error("Failed to execute isRewardedAdReady() - please ensure the AppLovin MAX React Native module has been initialized by calling 'AppLovinMAX.initialize(...);'!");
     }
@@ -437,13 +429,9 @@ const loadAppOpenAd = (adUnitId) => {
 }
 
 const isAppOpenAdReady = (adUnitId) => {
-  return new Promise((resolve, reject) => {
-    resolve(AppLovinMAX.isInitialized());
-  }).then(isInitialized => {
+  return AppLovinMAX.isInitialized().then(isInitialized => {
     if (isInitialized) {
-      return new Promise((resolve, reject) => {
-        resolve(AppLovinMAX.isAppOpenAdReady(adUnitId));
-      });
+      return AppLovinMAX.isAppOpenAdReady(adUnitId);
     } else {
       throw new Error("Failed to execute isAppOpenAdReady() - please ensure the AppLovin MAX React Native module has been initialized by calling 'AppLovinMAX.initialize(...);'!");
     }
@@ -503,9 +491,7 @@ export default {
   addEventListener,
   removeEventListener,
   initialize(sdkKey) {
-    return new Promise((resolve, reject) => {
-      resolve(AppLovinMAX.initialize(VERSION, sdkKey));
-    });
+    return AppLovinMAX.initialize(VERSION, sdkKey);
   },
 
   /*---------*/

--- a/src/index.js
+++ b/src/index.js
@@ -572,7 +572,7 @@ export default {
   /*--------------*/
   /* PRIVACY APIs */
   /*--------------*/
-  /* showConsentDialog(callback) */
+  /* showConsentDialog(promise) */
   /* getConsentDialogState(promise) */
   /* setHasUserConsent(hasUserConsent) */
   /* hasUserConsent(promise) */


### PR DESCRIPTION
Added support for Promise.    This will give us a better performance by not using synchronous methods and also allows us to support the Google Chrome debugger.

This is a list of the APIs where the signature has been updated.   The deprecated methods are replaced with new ones and removed.   Upgrading should be straightforward.  

- isInitialized
- initialize
- isTablet
- getConsentDialogState
- hasUserConsent
- isAgeRestrictedUser
- isDoNotSell
- isMuted
- getAdaptiveBannerHeightForWidth
- isInterstitialReady
- isRewardedAdReady
- isAppOpenAdReady

Also, removed the headspace from CHANGE.md to show it correctly. 