### PR TITLE
ref/deprecate_getConsentDialogState

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Versions
 
+## x.x.x
+    * Deprecated getConsentDialogState().
 ## 4.1.4
     * Fix NPE for accessing a null icon in the native ad on Android.
 ## 4.1.3

--- a/android/src/main/java/com/applovin/reactnative/AppLovinMAXModule.java
+++ b/android/src/main/java/com/applovin/reactnative/AppLovinMAXModule.java
@@ -401,7 +401,6 @@ public class AppLovinMAXModule
         } );
     }
 
-    @Deprecated
     @ReactMethod(isBlockingSynchronousMethod = true)
     public int getConsentDialogState()
     {

--- a/android/src/main/java/com/applovin/reactnative/AppLovinMAXModule.java
+++ b/android/src/main/java/com/applovin/reactnative/AppLovinMAXModule.java
@@ -401,6 +401,7 @@ public class AppLovinMAXModule
         } );
     }
 
+    @Deprecated
     @ReactMethod(isBlockingSynchronousMethod = true)
     public int getConsentDialogState()
     {

--- a/src/index.js
+++ b/src/index.js
@@ -402,6 +402,11 @@ const setAppOpenAdExtraParameter = (adUnitId, key, value) => {
   AppLovinMAX.setAppOpenAdExtraParameter(adUnitId, key, value);
 }
 
+const getConsentDialogState = () => {
+  console.warn("getConsentDialogState() has been deprecated and will be removed in a future release.");
+  return AppLovinMAX.getConsentDialogState();
+};
+
 export default {
   ...AppLovinMAX,
   AdView,
@@ -477,6 +482,11 @@ export default {
   showAppOpenAd,
   setAppOpenAdExtraParameter,
 
+  /*--------------------------------------------------*/
+  /* DEPRECATED (will be removed in a future release) */
+  /*--------------------------------------------------*/
+  getConsentDialogState,
+
   /*----------------------*/
   /** AUTO-DECLARED APIs **/
   /*----------------------*/
@@ -491,7 +501,6 @@ export default {
   /* PRIVACY APIs */
   /*--------------*/
   /* showConsentDialog(callback) */
-  /* getConsentDialogState() */
   /* setHasUserConsent(hasUserConsent) */
   /* hasUserConsent() */
   /* setIsAgeRestrictedUser(isAgeRestrictedUser) */


### PR DESCRIPTION
Add a warning message to deprecate `getConsentDialogState()`. 

The warning message is added to the JavaScript layer instead of the native modules.

  
<img width="1057" alt="Screen Shot 2023-01-23 at 1 41 26 PM" src="https://user-images.githubusercontent.com/100324169/213968195-091d7e8d-3bc4-4f95-b315-71af91563db8.png">
