### PR TITLE
feat/support_callback_native_components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Versions
 
 ## x.x.x
+* Add support for callback functions to  `AppLovinAdView` and `AppLovinNativeAdView` native UI components.
 * Update synchronous APIs to use `Promise`s.
 * Deprecated getConsentDialogState().
 ## 4.1.4

--- a/android/src/main/java/com/applovin/reactnative/AppLovinMAXAdView.java
+++ b/android/src/main/java/com/applovin/reactnative/AppLovinMAXAdView.java
@@ -7,10 +7,13 @@ import android.text.TextUtils;
 import com.applovin.mediation.MaxAd;
 import com.applovin.mediation.MaxAdFormat;
 import com.applovin.mediation.MaxAdListener;
+import com.applovin.mediation.MaxAdRevenueListener;
 import com.applovin.mediation.MaxAdViewAdListener;
 import com.applovin.mediation.MaxError;
 import com.applovin.mediation.ads.MaxAdView;
+import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.uimanager.ThemedReactContext;
+import com.facebook.react.uimanager.events.RCTEventEmitter;
 import com.facebook.react.views.view.ReactViewGroup;
 
 import androidx.annotation.Nullable;
@@ -20,7 +23,7 @@ import androidx.annotation.Nullable;
  */
 class AppLovinMAXAdView
         extends ReactViewGroup
-        implements MaxAdListener, MaxAdViewAdListener
+        implements MaxAdListener, MaxAdViewAdListener, MaxAdRevenueListener
 {
     private final ThemedReactContext reactContext;
 
@@ -36,7 +39,7 @@ class AppLovinMAXAdView
     public AppLovinMAXAdView(final Context context)
     {
         super( context );
-        this.reactContext = (ThemedReactContext) context;
+        reactContext = (ThemedReactContext) context;
     }
 
     public void setAdUnitId(final String value)
@@ -206,7 +209,7 @@ class AppLovinMAXAdView
 
             adView = new MaxAdView( adUnitId, adFormat, AppLovinMAXModule.getInstance().getSdk(), currentActivity );
             adView.setListener( this );
-            adView.setRevenueListener( AppLovinMAXModule.getInstance() );
+            adView.setRevenueListener( this );
             adView.setPlacement( placement );
             adView.setCustomData( customData );
             adView.setExtraParameter( "adaptive_banner", Boolean.toString( adaptiveBannerEnabled ) );
@@ -247,46 +250,57 @@ class AppLovinMAXAdView
     @Override
     public void onAdLoaded(final MaxAd ad)
     {
-        AppLovinMAXModule.getInstance().onAdLoaded( ad );
+        WritableMap adInfo = AppLovinMAXModule.getInstance().getAdInfo( ad );
+        reactContext.getJSModule( RCTEventEmitter.class ).receiveEvent( getId(), "onAdLoadedEvent", adInfo );
     }
 
     @Override
     public void onAdLoadFailed(final String adUnitId, final MaxError error)
     {
-        String name = ( adFormat == MaxAdFormat.MREC ) ? "OnMRecAdLoadFailedEvent" : "OnBannerAdLoadFailedEvent";
-        
-        AppLovinMAXModule.getInstance().sendReactNativeEventForAdLoadFailed( name, adUnitId, error );
+        WritableMap adLoadFailedInfo = AppLovinMAXModule.getInstance().getAdLoadFailedInfo( adUnitId, error );
+        reactContext.getJSModule( RCTEventEmitter.class ).receiveEvent( getId(), "onAdLoadFailedEvent", adLoadFailedInfo );
     }
 
     @Override
     public void onAdDisplayFailed(final MaxAd ad, final MaxError error)
     {
-        AppLovinMAXModule.getInstance().onAdDisplayFailed( ad, error );
+        WritableMap adDisplayFailedInfo = AppLovinMAXModule.getInstance().getAdDisplayFailedInfo( ad, error );
+        reactContext.getJSModule( RCTEventEmitter.class ).receiveEvent( getId(), "onAdDisplayFailedEvent", adDisplayFailedInfo );
     }
 
     @Override
     public void onAdClicked(final MaxAd ad)
     {
-        AppLovinMAXModule.getInstance().onAdClicked( ad );
+        WritableMap adInfo = AppLovinMAXModule.getInstance().getAdInfo( ad );
+        reactContext.getJSModule( RCTEventEmitter.class ).receiveEvent( getId(), "onAdClickedEvent", adInfo );
     }
 
     @Override
     public void onAdExpanded(final MaxAd ad)
     {
-        AppLovinMAXModule.getInstance().onAdExpanded( ad );
+        WritableMap adInfo = AppLovinMAXModule.getInstance().getAdInfo( ad );
+        reactContext.getJSModule( RCTEventEmitter.class ).receiveEvent( getId(), "onAdExpandedEvent", adInfo );
     }
 
     @Override
     public void onAdCollapsed(final MaxAd ad)
     {
-        AppLovinMAXModule.getInstance().onAdCollapsed( ad );
+        WritableMap adInfo = AppLovinMAXModule.getInstance().getAdInfo( ad );
+        reactContext.getJSModule( RCTEventEmitter.class ).receiveEvent( getId(), "onAdCollapsedEvent", adInfo );
+    }
+
+    @Override
+    public void onAdRevenuePaid(final MaxAd ad)
+    {
+        WritableMap adRevenueInfo = AppLovinMAXModule.getInstance().getAdRevenueInfo( ad );
+        reactContext.getJSModule( RCTEventEmitter.class ).receiveEvent( getId(), "onAdRevenuePaidEvent", adRevenueInfo );
     }
 
     /// Deprecated Callbacks
 
     @Override
-    public void onAdDisplayed(final MaxAd ad) {}
+    public void onAdDisplayed(final MaxAd ad) { }
 
     @Override
-    public void onAdHidden(final MaxAd ad) {}
+    public void onAdHidden(final MaxAd ad) { }
 }

--- a/android/src/main/java/com/applovin/reactnative/AppLovinMAXAdViewManager.java
+++ b/android/src/main/java/com/applovin/reactnative/AppLovinMAXAdViewManager.java
@@ -1,11 +1,14 @@
 package com.applovin.reactnative;
 
 import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.common.MapBuilder;
 import com.facebook.react.uimanager.SimpleViewManager;
 import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.annotations.ReactProp;
 
 import org.jetbrains.annotations.NotNull;
+
+import java.util.Map;
 
 import androidx.annotation.Nullable;
 
@@ -22,6 +25,22 @@ class AppLovinMAXAdViewManager
     public String getName()
     {
         return "AppLovinMAXAdView";
+    }
+
+    @Nullable
+    @Override
+    public Map<String, Object> getExportedCustomDirectEventTypeConstants()
+    {
+        // mapping Android events to JavaScript events
+        return MapBuilder.<String, Object>builder()
+                .put( "onAdLoadedEvent", MapBuilder.of( "registrationName", "onAdLoadedEvent" ) )
+                .put( "onAdLoadFailedEvent", MapBuilder.of( "registrationName", "onAdLoadFailedEvent" ) )
+                .put( "onAdDisplayFailedEvent", MapBuilder.of( "registrationName", "onAdDisplayFailedEvent" ) )
+                .put( "onAdClickedEvent", MapBuilder.of( "registrationName", "onAdClickedEvent" ) )
+                .put( "onAdExpandedEvent", MapBuilder.of( "registrationName", "onAdExpandedEvent" ) )
+                .put( "onAdCollapsedEvent", MapBuilder.of( "registrationName", "onAdCollapsedEvent" ) )
+                .put( "onAdRevenuePaidEvent", MapBuilder.of( "registrationName", "onAdRevenuePaidEvent" ) )
+                .build();
     }
 
     @NotNull

--- a/android/src/main/java/com/applovin/reactnative/AppLovinMAXModule.java
+++ b/android/src/main/java/com/applovin/reactnative/AppLovinMAXModule.java
@@ -976,10 +976,6 @@ public class AppLovinMAXModule
         {
             name = "OnRewardedAdLoadedEvent";
         }
-        else if ( MaxAdFormat.NATIVE == adFormat )
-        {
-            name = "OnNativeAdLoadedEvent";
-        }
         else if ( MaxAdFormat.APP_OPEN == adFormat )
         {
             name = "OnAppOpenAdLoadedEvent";
@@ -1028,24 +1024,9 @@ public class AppLovinMAXModule
         sendReactNativeEventForAdLoadFailed( name, adUnitId, error );
     }
 
-    public void sendReactNativeEventForAdLoadFailed(final String name, final String adUnitId, final @Nullable MaxError error)
+    void sendReactNativeEventForAdLoadFailed(final String name, final String adUnitId, @Nullable final MaxError error)
     {
-        WritableMap params = Arguments.createMap();
-        params.putString( "adUnitId", adUnitId );
-
-        if ( error != null )
-        {
-            params.putInt( "code", error.getCode() );
-            params.putString( "message", error.getMessage() );
-            params.putString( "adLoadFailureInfo", error.getAdLoadFailureInfo() );
-            params.putMap( "waterfall", createAdWaterfallInfo( error.getWaterfall() ) );
-        }
-        else
-        {
-            params.putInt( "code", MaxErrorCode.UNSPECIFIED );
-        }
-
-        sendReactNativeEvent( name, params );
+        sendReactNativeEvent( name, getAdLoadFailedInfo( adUnitId, error ) );
     }
 
     @Override
@@ -1068,10 +1049,6 @@ public class AppLovinMAXModule
         else if ( MaxAdFormat.REWARDED == adFormat )
         {
             name = "OnRewardedAdClickedEvent";
-        }
-        else if ( MaxAdFormat.NATIVE == adFormat )
-        {
-            name = "OnNativeAdClickedEvent";
         }
         else if ( MaxAdFormat.APP_OPEN == adFormat )
         {
@@ -1131,11 +1108,7 @@ public class AppLovinMAXModule
             name = "OnAppOpenAdFailedToDisplayEvent";
         }
 
-        WritableMap params = getAdInfo( ad );
-        params.putInt( "code", error.getCode() );
-        params.putString( "message", error.getMessage() );
-
-        sendReactNativeEvent( name, params );
+        sendReactNativeEvent( name, getAdDisplayFailedInfo( ad, error ) );
     }
 
     @Override
@@ -1209,10 +1182,6 @@ public class AppLovinMAXModule
         {
             name = "OnRewardedAdRevenuePaid";
         }
-        else if ( MaxAdFormat.NATIVE == adFormat )
-        {
-            name = "OnNativeAdRevenuePaid";
-        }
         else if ( MaxAdFormat.APP_OPEN == adFormat )
         {
             name = "OnAppOpenAdRevenuePaid";
@@ -1223,12 +1192,7 @@ public class AppLovinMAXModule
             return;
         }
 
-        WritableMap adInfo = getAdInfo( ad );
-        adInfo.putString( "networkPlacement", ad.getNetworkPlacement() );
-        adInfo.putString( "revenuePrecision", ad.getRevenuePrecision() );
-        adInfo.putString( "countryCode", sdkConfiguration.getCountryCode() );
-
-        sendReactNativeEvent( name, adInfo );
+        sendReactNativeEvent( name, getAdRevenueInfo( ad ) );
     }
 
     @Override
@@ -1959,7 +1923,7 @@ public class AppLovinMAXModule
 
     // AD INFO
 
-    private WritableMap getAdInfo(final MaxAd ad)
+    public WritableMap getAdInfo(final MaxAd ad)
     {
         WritableMap adInfo = Arguments.createMap();
         adInfo.putString( "adUnitId", ad.getAdUnitId() );
@@ -1970,6 +1934,43 @@ public class AppLovinMAXModule
         adInfo.putMap( "waterfall", createAdWaterfallInfo( ad.getWaterfall() ) );
         adInfo.putString( "dspName", !TextUtils.isEmpty( ad.getDspName() ) ? ad.getDspName() : "" );
 
+        return adInfo;
+    }
+
+    public WritableMap getAdLoadFailedInfo(final String adUnitId, @Nullable final MaxError error)
+    {
+        WritableMap errInfo = Arguments.createMap();
+        errInfo.putString( "adUnitId", adUnitId );
+
+        if ( error != null )
+        {
+            errInfo.putInt( "code", error.getCode() );
+            errInfo.putString( "message", error.getMessage() );
+            errInfo.putString( "adLoadFailureInfo", error.getAdLoadFailureInfo() );
+            errInfo.putMap( "waterfall", createAdWaterfallInfo( error.getWaterfall() ) );
+        }
+        else
+        {
+            errInfo.putInt( "code", MaxErrorCode.UNSPECIFIED );
+        }
+
+        return errInfo;
+    }
+
+    public WritableMap getAdDisplayFailedInfo(final MaxAd ad, final MaxError error)
+    {
+        WritableMap params = getAdInfo( ad );
+        params.putInt( "code", error.getCode() );
+        params.putString( "message", error.getMessage() );
+        return params;
+    }
+
+    public WritableMap getAdRevenueInfo(final MaxAd ad)
+    {
+        WritableMap adInfo = getAdInfo( ad );
+        adInfo.putString( "networkPlacement", ad.getNetworkPlacement() );
+        adInfo.putString( "revenuePrecision", ad.getRevenuePrecision() );
+        adInfo.putString( "countryCode", sdkConfiguration.getCountryCode() );
         return adInfo;
     }
 

--- a/android/src/main/java/com/applovin/reactnative/AppLovinMAXNativeAdView.java
+++ b/android/src/main/java/com/applovin/reactnative/AppLovinMAXNativeAdView.java
@@ -7,6 +7,7 @@ import android.view.ViewGroup;
 import android.widget.ImageView;
 
 import com.applovin.mediation.MaxAd;
+import com.applovin.mediation.MaxAdRevenueListener;
 import com.applovin.mediation.MaxError;
 import com.applovin.mediation.nativeAds.MaxNativeAd;
 import com.applovin.mediation.nativeAds.MaxNativeAd.MaxNativeAdImage;
@@ -31,7 +32,7 @@ import static com.applovin.sdk.AppLovinSdkUtils.runOnUiThreadDelayed;
 
 public class AppLovinMAXNativeAdView
         extends ReactViewGroup
-        implements View.OnLayoutChangeListener
+        implements MaxAdRevenueListener, View.OnLayoutChangeListener
 {
     private final ReactContext      reactContext;
     @Nullable
@@ -111,7 +112,7 @@ public class AppLovinMAXNativeAdView
             if ( adLoader == null || !adUnitId.equals( adLoader.getAdUnitId() ) )
             {
                 adLoader = new MaxNativeAdLoader( adUnitId, AppLovinMAXModule.getInstance().getSdk(), reactContext );
-                adLoader.setRevenueListener( AppLovinMAXModule.getInstance() );
+                adLoader.setRevenueListener( this );
                 adLoader.setNativeAdListener( new NativeAdListener() );
             }
 
@@ -264,8 +265,14 @@ public class AppLovinMAXNativeAdView
     @Override
     public void onLayoutChange(View view, int left, int top, int right, int bottom, int oldLeft, int oldTop, int oldRight, int oldBottom)
     {
-        sizeToFit( mediaView, view );
-        sizeToFit( optionsView, view );
+        if ( view == mediaView.getParent() )
+        {
+            sizeToFit( mediaView, view );
+        }
+        else if ( view == optionsView.getParent() )
+        {
+            sizeToFit( optionsView, view );
+        }
     }
 
     private void sizeToFit(final @Nullable View view, final View parentView)
@@ -276,6 +283,15 @@ public class AppLovinMAXNativeAdView
                           MeasureSpec.makeMeasureSpec( parentView.getHeight(), MeasureSpec.EXACTLY ) );
             view.layout( 0, 0, parentView.getWidth(), parentView.getHeight() );
         }
+    }
+
+    /// Ad Revenue Callback
+
+    @Override
+    public void onAdRevenuePaid(final MaxAd ad)
+    {
+        WritableMap adRevenueInfo = AppLovinMAXModule.getInstance().getAdRevenueInfo( ad );
+        reactContext.getJSModule( RCTEventEmitter.class ).receiveEvent( getId(), "onAdRevenuePaidEvent", adRevenueInfo );
     }
 
     /// Ad Loader Callback
@@ -294,7 +310,8 @@ public class AppLovinMAXNativeAdView
                 isLoading.set( false );
 
                 AppLovinMAXModule.e( "Native ad is of template type, failing ad load..." );
-                AppLovinMAXModule.getInstance().sendReactNativeEventForAdLoadFailed( "OnNativeAdLoadFailedEvent", adUnitId, null );
+                WritableMap loadFailedInfo = AppLovinMAXModule.getInstance().getAdLoadFailedInfo( adUnitId, null );
+                reactContext.getJSModule( RCTEventEmitter.class ).receiveEvent( getId(), "onAdLoadFailedEvent", loadFailedInfo );
 
                 return;
             }
@@ -308,8 +325,6 @@ public class AppLovinMAXNativeAdView
 
             // After notifying the RN layer - have slight delay to let views bind to this layer in `clickableViews` before registering
             runOnUiThreadDelayed( () -> {
-                // Notify publisher
-                AppLovinMAXModule.getInstance().onAdLoaded( ad );
 
                 // Loader can be null when the user hides before the properties are fully set
                 if ( adLoader != null )
@@ -330,18 +345,54 @@ public class AppLovinMAXNativeAdView
             AppLovinMAXModule.e( "Failed to load native ad for Ad Unit ID " + adUnitId + " with error: " + error );
 
             // Notify publisher
-            AppLovinMAXModule.getInstance().sendReactNativeEventForAdLoadFailed( "OnNativeAdLoadFailedEvent", adUnitId, error );
+            WritableMap loadFailedInfo = AppLovinMAXModule.getInstance().getAdLoadFailedInfo( adUnitId, error );
+            reactContext.getJSModule( RCTEventEmitter.class ).receiveEvent( getId(), "onAdLoadFailedEvent", loadFailedInfo );
         }
 
         @Override
         public void onNativeAdClicked(final MaxAd ad)
         {
-            AppLovinMAXModule.getInstance().onAdClicked( ad );
+            WritableMap adInfo = AppLovinMAXModule.getInstance().getAdInfo( ad );
+            reactContext.getJSModule( RCTEventEmitter.class ).receiveEvent( getId(), "onAdClickedEvent", adInfo );
         }
     }
 
     private void sendAdLoadedReactNativeEventForAd(final MaxNativeAd ad)
     {
+        // 1. AdInfo for publisher to be notified via `onAdLoaded`
+
+        WritableMap nativeAdInfo = Arguments.createMap();
+        float aspectRatio = ad.getMediaContentAspectRatio();
+        if ( !Float.isNaN( aspectRatio ) )
+        {
+            // The aspect ratio can be 0.0f when it is not provided by the network.
+            if ( Math.signum( aspectRatio )  == 0 )
+            {
+                nativeAdInfo.putDouble( "mediaContentAspectRatio", 1.0 );
+            }
+            else
+            {
+                nativeAdInfo.putDouble( "mediaContentAspectRatio", aspectRatio );
+            }
+        }
+        else
+        {
+            nativeAdInfo.putDouble( "mediaContentAspectRatio", 1.0 );
+        }
+
+        nativeAdInfo.putBoolean( "hasTitleView", ( ad.getTitle() != null ) );
+        nativeAdInfo.putBoolean( "hasAdvertiserView", ( ad.getAdvertiser() != null ) );
+        nativeAdInfo.putBoolean( "hasBodyView", ( ad.getBody() != null ) );
+        nativeAdInfo.putBoolean( "hasCallToActionView", ( ad.getCallToAction() != null ) );
+        nativeAdInfo.putBoolean( "hasIconView", ( ad.getIcon() != null ) );
+        nativeAdInfo.putBoolean( "hasOptionsView", ( ad.getOptionsView() != null ) );
+        nativeAdInfo.putBoolean( "hasMediaView", ( ad.getMediaView() != null ) );
+
+        WritableMap adInfo = AppLovinMAXModule.getInstance().getAdInfo( nativeAd );
+        adInfo.putMap( "nativeAd", nativeAdInfo );
+
+        // 2. NativeAd for `AppLovinNativeAdView.js` to render the views
+
         WritableMap jsNativeAd = Arguments.createMap();
 
         jsNativeAd.putString( "title", ad.getTitle() );
@@ -371,14 +422,12 @@ public class AppLovinMAXNativeAdView
             }
         }
 
-        float aspectRatio = ad.getMediaContentAspectRatio();
-        if ( !Float.isNaN( aspectRatio ) )
-        {
-            jsNativeAd.putDouble( "mediaContentAspectRatio", aspectRatio );
-        }
+        WritableMap arg = Arguments.createMap();
+        arg.putMap( "adInfo", adInfo );
+        arg.putMap( "nativeAd", jsNativeAd );
 
-        // Send to `AppLovinNativeAdView.js` to render the views
-        reactContext.getJSModule( RCTEventEmitter.class ).receiveEvent( getId(), "onAdLoaded", jsNativeAd );
+        // Send to `AppLovinNativeAdView.js`
+        reactContext.getJSModule( RCTEventEmitter.class ).receiveEvent( getId(), "onAdLoadedEvent", arg );
     }
 
     private void maybeDestroyCurrentAd()

--- a/android/src/main/java/com/applovin/reactnative/AppLovinMAXNativeAdViewManager.java
+++ b/android/src/main/java/com/applovin/reactnative/AppLovinMAXNativeAdViewManager.java
@@ -42,8 +42,12 @@ public class AppLovinMAXNativeAdViewManager
     @Override
     public Map<String, Object> getExportedCustomDirectEventTypeConstants()
     {
+        // mapping Android events to JavaScript events
         return MapBuilder.<String, Object>builder()
-                .put( "onAdLoaded", MapBuilder.of( "registrationName", "onAdLoaded" ) )
+                .put( "onAdLoadedEvent", MapBuilder.of( "registrationName", "onAdLoadedEvent" ) )
+                .put( "onAdLoadFailedEvent", MapBuilder.of( "registrationName", "onAdLoadFailedEvent" ) )
+                .put( "onAdClickedEvent", MapBuilder.of( "registrationName", "onAdClickedEvent" ) )
+                .put( "onAdRevenuePaidEvent", MapBuilder.of( "registrationName", "onAdRevenuePaidEvent" ) )
                 .build();
     }
 

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -232,20 +232,6 @@ const App = () => {
     AppLovinMAX.addEventListener('OnMRecAdRevenuePaid', (adInfo) => {
       setStatusText('MREC ad revenue paid: ' + adInfo.revenue);
     });
-
-    // Native Ad Listeners
-    AppLovinMAX.addEventListener('OnNativeAdLoadedEvent', (adInfo) => {
-      setStatusText('Native ad loaded from: ' + adInfo.networkName);
-    });
-    AppLovinMAX.addEventListener('OnNativeAdLoadFailedEvent', (errorInfo) => {
-      setStatusText('Native ad failed to load with error code ' + errorInfo.code + ' and message: ' + errorInfo.message);
-    });
-    AppLovinMAX.addEventListener('OnNativeAdClickedEvent', (adInfo) => {
-      setStatusText('Native ad clicked');
-    });
-    AppLovinMAX.addEventListener('OnNativeAdRevenuePaid', (adInfo) => {
-      setStatusText('Native ad revenue paid: ' + adInfo.revenue);
-    });
   }
 
   const getInterstitialButtonTitle = () => {
@@ -360,7 +346,26 @@ const App = () => {
           isNativeUIBannerShowing &&
             <AppLovinMAX.AdView adUnitId={BANNER_AD_UNIT_ID}
                                 adFormat={AppLovinMAX.AdFormat.BANNER}
-                                style={styles.banner}/>
+                                style={styles.banner}
+                                onAdLoaded={(adInfo) => {
+                                  setStatusText('Banner ad loaded from ' + adInfo.networkName);
+                                }}
+                                onAdLoadFailed={(errorInfo) => {
+                                  setStatusText('Banner ad failed to load with error code ' + errorInfo.code + ' and message: ' + errorInfo.message);
+                                }}
+                                onAdClicked={(adInfo) => {
+                                  setStatusText('Banner ad clicked');
+                                }}
+                                onAdExpanded={(adInfo) => {
+                                  setStatusText('Banner ad expanded')
+                                }}
+                                onAdCollapsed={(adInfo) => {
+                                  setStatusText('Banner ad collapsed')
+                                }}
+                                onAdRevenuePaid={(adInfo) => {
+                                  setStatusText('Banner ad revenue paid: ' + adInfo.revenue);
+                                }}
+            />
         }
         <AppButton
           title={isNativeUIMRecShowing ? 'Hide Native UI MREC' : 'Show Native UI MREC'}
@@ -373,8 +378,27 @@ const App = () => {
           isNativeUIMRecShowing &&
             <AppLovinMAX.AdView adUnitId={MREC_AD_UNIT_ID}
                                 adFormat={AppLovinMAX.AdFormat.MREC}
-                                style={styles.mrec}/>
-        }
+                                style={styles.mrec}
+                                onAdLoaded={(adInfo) => {
+                                  setStatusText('MREC ad loaded from ' + adInfo.networkName);
+                                }}
+                                onAdLoadFailed={(errorInfo) => {
+                                  setStatusText('MREC ad failed to load with error code ' + errorInfo.code + ' and message: ' + errorInfo.message);
+                                }}
+                                onAdClicked={(adInfo) => {
+                                  setStatusText('MREC ad clicked');
+                                }}
+                                onAdExpanded={(adInfo) => {
+                                  setStatusText('MREC ad expanded')
+                                }}
+                                onAdCollapsed={(adInfo) => {
+                                  setStatusText('MREC ad collapsed')
+                                }}
+                                onAdRevenuePaid={(adInfo) => {
+                                  setStatusText('MREC ad revenue paid: ' + adInfo.revenue);
+                                }}
+            />
+       }
         <AppButton
           title={isProgrammaticMRecShowing ? 'Hide Programmatic MREC' : 'Show Programmatic MREC'}
           enabled={isInitialized && !isNativeUIMRecShowing}
@@ -415,7 +439,13 @@ const App = () => {
         {
           isNativeAdShowing &&
             <View style={{ position: 'absolute', top: '12%', width: '100%' }}>
-              <NativeAdViewExample adUnitId={NATIVE_AD_UNIT_ID} ref={nativeAdViewRef}/>
+              <NativeAdViewExample
+                adUnitId={NATIVE_AD_UNIT_ID}
+                ref={nativeAdViewRef}
+                onStatusText={(text) => {
+                  setStatusText(text);
+                }}
+              />
             </View>
         }
       </View>

--- a/example/src/NativeAdViewExample.js
+++ b/example/src/NativeAdViewExample.js
@@ -1,27 +1,63 @@
-import React, {forwardRef} from 'react';
+import React, {forwardRef, useState, useEffect} from 'react';
 import {StyleSheet, Text, View} from 'react-native';
 import AppLovinMAX from '../../src/index';
 
 export const NativeAdViewExample = forwardRef((props, ref) => {
     const {adUnitId} = props;
+    const [aspectRatio, setAspectRatio] = useState(1.0);
+    const [mediaViewSize, setMediaViewSize] = useState({});
+    const [hasOptionsView, setHasOptionsView] = useState(false);
+
+    // adjust the size of MediaView when `aspectRatio` changes
+    useEffect(() => {
+        if (aspectRatio > 1) {
+            // landscape 
+            setMediaViewSize({aspectRatio: aspectRatio, width: '80%', height: undefined});
+        } else {
+            // portrait or square
+            setMediaViewSize({aspectRatio: aspectRatio, width: undefined, height: 180});
+        }
+    }, [aspectRatio]);
 
     return (
-        <AppLovinMAX.NativeAdView adUnitId={adUnitId}
-                                  placement='myplacement'
-                                  customData='mycustomdata'
-                                  ref={ref}
-                                  style={styles.nativead}>
+        <AppLovinMAX.NativeAdView
+            adUnitId={adUnitId}
+            placement='myplacement'
+            customData='mycustomdata'
+            ref={ref}
+            style={styles.nativead}
+            onAdLoaded={(adInfo) => {
+                setAspectRatio(adInfo.nativeAd.mediaContentAspectRatio);
+                setHasOptionsView(adInfo.nativeAd.hasOptionsView);
+                props.onStatusText('Native ad loaded from ' + adInfo.networkName);
+            }}
+            onAdLoadFailed={(errorInfo) => {
+                props.onStatusText('Native ad failed to load with error code ' + errorInfo.code + ' and message: ' + errorInfo.message);
+            }}
+            onAdClicked={(adInfo) => {
+                props.onStatusText('Native ad clicked');
+            }}
+            onAdRevenuePaid={(adInfo) => {
+                props.onStatusText('Native ad revenue paid: ' + adInfo.revenue);
+            }}
+            >
             <View style={{flex: 1, flexDirection: 'column'}}>
-                <View style={{flexDirection: 'row', justifyContent: 'space-between'}}>
+                <View style={{flexDirection: 'row'}}>
                     <AppLovinMAX.NativeAdView.IconView style={styles.icon}/>
                     <View style={{flexDirection: 'column', flexGrow: 1}}>
-                        <AppLovinMAX.NativeAdView.TitleView style={styles.title}/>
+                    {
+                        hasOptionsView ?
+                            <AppLovinMAX.NativeAdView.OptionsView style={styles.optionsView}/>
+                        :
+                            // show 'AD' when OptionsView is missing
+                            <Text style={styles.adMark}>AD</Text>
+                    }
                         <AppLovinMAX.NativeAdView.AdvertiserView style={styles.advertiser}/>
                     </View>
-                    <AppLovinMAX.NativeAdView.OptionsView style={styles.optionsView}/>
                 </View>
+                <AppLovinMAX.NativeAdView.TitleView style={styles.title}/>
+                <AppLovinMAX.NativeAdView.MediaView style={{...styles.mediaView, ...mediaViewSize}}/>
                 <AppLovinMAX.NativeAdView.BodyView style={styles.body}/>
-                <AppLovinMAX.NativeAdView.MediaView style={styles.mediaView}/>
                 <AppLovinMAX.NativeAdView.CallToActionView style={styles.callToAction}/>
             </View>
         </AppLovinMAX.NativeAdView>
@@ -31,48 +67,49 @@ export const NativeAdViewExample = forwardRef((props, ref) => {
 const styles = StyleSheet.create({
     nativead: {
         margin: 10,
-        padding: 10,
-        height: 350,
+        padding: 4,
         backgroundColor: '#EFEFEF',
     },
     title: {
-        fontSize: 20,
-        marginTop: 4,
-        marginHorizontal: 5,
-        textAlign: 'left',
+        alignSelf: 'center',
+        fontSize: 18,
         fontWeight: 'bold',
-        alignItems: 'center',
         color: 'black',
     },
     icon: {
-        margin: 5,
         height: 40,
         aspectRatio: 1,
         borderRadius: 5,
     },
     optionsView: {
+        alignSelf: 'flex-end',
         height: 20,
         width: 20,
         backgroundColor: '#EFEFEF',
     },
+    adMark: {
+        alignSelf: 'flex-end',
+        height: 20,
+        width: 20,
+        backgroundColor: '#EFEFEF',
+        fontWeight: 'bold',
+        fontSize: 12,
+    },
     advertiser: {
-        marginHorizontal: 5,
-        marginTop: 2,
+        alignSelf: 'flex-end',
         textAlign: 'left',
         fontSize: 16,
         fontWeight: '400',
         color: 'gray',
     },
     body: {
-        height: 'auto',
+        alignSelf: 'center',
         fontSize: 14,
-        marginVertical: 8,
+        margin: 4,
     },
     mediaView: {
-        flexGrow: 1,
-        height: 'auto',
-        width: '100%',
-        backgroundColor: 'black',
+        alignSelf: 'center',
+        aspectRatio: 1,
     },
     callToAction: {
         padding: 5,

--- a/ios/AppLovinMAX.h
+++ b/ios/AppLovinMAX.h
@@ -37,9 +37,24 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)log:(NSString *)format, ...;
 
 /**
- * Convenience method for invoking an ad load failure event.
+ * Returns a dictionay value of adInfo for the specified ad.
  */
-- (void)sendReactNativeEventForAdLoadFailed:(NSString *)name forAdUnitIdentifier:(NSString *)adUnitIdentifier withError:(nullable MAError *)error;
+- (NSDictionary<NSString *, id> *)adInfoForAd:(MAAd *)ad;
+
+/**
+ * Returns a dictionay value of adLoadFailedInfo for the specified error.
+ */
+- (NSDictionary<NSString *, id> *)adLoadFailedInfoForAd:(NSString *)adUnitIdentifier withError:(MAError *)error;
+
+/**
+ * Returns a dictionay value of adDisplayFailedInfo for the specified ad and error.
+ */
+- (NSDictionary<NSString *, id> *)adDisplayFailedInfoForAd:(MAAd *)ad withError:(MAError *)error;
+
+/**
+ * Returns a dictionay value of adRevenuInfo for the specified ad.
+ */
+- (NSDictionary<NSString *, id> *)adRevenueInfoForAd:(MAAd *)ad;
 
 @end
 

--- a/ios/AppLovinMAXAdView.m
+++ b/ios/AppLovinMAXAdView.m
@@ -9,7 +9,7 @@
 #import "AppLovinMAX.h"
 #import "AppLovinMAXAdView.h"
 
-@interface AppLovinMAXAdView()<MAAdViewAdDelegate>
+@interface AppLovinMAXAdView()<MAAdViewAdDelegate, MAAdRevenueDelegate>
 
 @property (nonatomic, strong, nullable) MAAdView *adView; // nil when unmounted
 
@@ -20,6 +20,14 @@
 @property (nonatomic, copy, nullable) NSString *customData;
 @property (nonatomic, assign, readonly, getter=isAdaptiveBannerEnabled) BOOL adaptiveBannerEnabled;
 @property (nonatomic, assign, readonly, getter=isAutoRefresh) BOOL autoRefresh;
+
+@property (nonatomic, copy) RCTDirectEventBlock onAdLoadedEvent;
+@property (nonatomic, copy) RCTDirectEventBlock onAdLoadFailedEvent;
+@property (nonatomic, copy) RCTDirectEventBlock onAdDisplayFailedEvent;
+@property (nonatomic, copy) RCTDirectEventBlock onAdClickedEvent;
+@property (nonatomic, copy) RCTDirectEventBlock onAdExpandedEvent;
+@property (nonatomic, copy) RCTDirectEventBlock onAdCollapsedEvent;
+@property (nonatomic, copy) RCTDirectEventBlock onAdRevenuePaidEvent;
 
 @end
 
@@ -146,7 +154,7 @@
                                                              sdk: [AppLovinMAX shared].sdk];
         self.adView.frame = (CGRect) { CGPointZero, self.frame.size };
         self.adView.delegate = self;
-        self.adView.revenueDelegate = [AppLovinMAX shared];
+        self.adView.revenueDelegate = self;
         self.adView.placement = self.placement;
         self.adView.customData = self.customData;
         [self.adView setExtraParameterForKey: @"adaptive_banner" value: [self isAdaptiveBannerEnabled] ? @"true" : @"false"];
@@ -198,36 +206,41 @@
 
 - (void)didLoadAd:(MAAd *)ad
 {
-    [[AppLovinMAX shared] didLoadAd: ad];
+    self.onAdLoadedEvent([[AppLovinMAX shared] adInfoForAd: ad]);
 }
 
 - (void)didFailToLoadAdForAdUnitIdentifier:(NSString *)adUnitIdentifier withError:(MAError *)error
 {
-    NSString *name = ( MAAdFormat.mrec == self.adFormat ) ? @"OnMRecAdLoadFailedEvent" : @"OnBannerAdLoadFailedEvent";
-    
-    [[AppLovinMAX shared] sendReactNativeEventForAdLoadFailed: name forAdUnitIdentifier: adUnitIdentifier withError: error];
+    self.onAdLoadFailedEvent([[AppLovinMAX shared] adLoadFailedInfoForAd: adUnitIdentifier withError: error]);
 }
 
 - (void)didFailToDisplayAd:(MAAd *)ad withError:(MAError *)error
 {
-    [[AppLovinMAX shared] didFailToDisplayAd: ad withError: error];
+    self.onAdDisplayFailedEvent([[AppLovinMAX shared] adDisplayFailedInfoForAd: ad withError: error]);
 }
 
 - (void)didClickAd:(MAAd *)ad
 {
-    [[AppLovinMAX shared] didClickAd: ad];
+    self.onAdClickedEvent([[AppLovinMAX shared] adInfoForAd: ad]);
 }
 
 #pragma mark - MAAdViewAdDelegate Protocol
 
 - (void)didExpandAd:(MAAd *)ad
 {
-    [[AppLovinMAX shared] didExpandAd: ad];
+    self.onAdExpandedEvent([[AppLovinMAX shared] adInfoForAd: ad]);
 }
 
 - (void)didCollapseAd:(MAAd *)ad
 {
-    [[AppLovinMAX shared] didCollapseAd: ad];
+    self.onAdCollapsedEvent([[AppLovinMAX shared] adInfoForAd: ad]);
+}
+
+#pragma mark - MAAdRevenueDelegate Protocol
+
+- (void)didPayRevenueForAd:(MAAd *)ad
+{
+    self.onAdRevenuePaidEvent([[AppLovinMAX shared] adRevenueInfoForAd: ad]);
 }
 
 #pragma mark - Deprecated Callbacks

--- a/ios/AppLovinMAXAdViewManager.m
+++ b/ios/AppLovinMAXAdViewManager.m
@@ -20,6 +20,14 @@ RCT_EXPORT_VIEW_PROPERTY(customData, NSString)
 RCT_EXPORT_VIEW_PROPERTY(adaptiveBannerEnabled, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(autoRefresh, BOOL)
 
+RCT_EXPORT_VIEW_PROPERTY(onAdLoadedEvent, RCTDirectEventBlock)
+RCT_EXPORT_VIEW_PROPERTY(onAdLoadFailedEvent, RCTDirectEventBlock)
+RCT_EXPORT_VIEW_PROPERTY(onAdDisplayFailedEvent, RCTDirectEventBlock)
+RCT_EXPORT_VIEW_PROPERTY(onAdClickedEvent, RCTDirectEventBlock)
+RCT_EXPORT_VIEW_PROPERTY(onAdExpandedEvent, RCTDirectEventBlock)
+RCT_EXPORT_VIEW_PROPERTY(onAdCollapsedEvent, RCTDirectEventBlock)
+RCT_EXPORT_VIEW_PROPERTY(onAdRevenuePaidEvent, RCTDirectEventBlock)
+
 + (BOOL)requiresMainQueueSetup
 {
     return YES;

--- a/ios/AppLovinMAXNativeAdView.m
+++ b/ios/AppLovinMAXNativeAdView.m
@@ -18,7 +18,7 @@
 - (void)handleNativeAdViewRenderedForAd:(MAAd *)ad;
 @end
 
-@interface AppLovinMAXNativeAdView()<MANativeAdDelegate>
+@interface AppLovinMAXNativeAdView()<MANativeAdDelegate, MAAdRevenueDelegate>
 
 @property (nonatomic, weak) RCTBridge *bridge;
 @property (nonatomic, strong, nullable) MANativeAdLoader *adLoader;
@@ -32,7 +32,10 @@
 @property (nonatomic, copy, nullable) NSDictionary *extraParameters;
 
 // Callback to `AppLovinNativeAdView.js`
-@property (nonatomic, copy) RCTDirectEventBlock onAdLoaded;
+@property (nonatomic, copy) RCTDirectEventBlock onAdLoadedEvent;
+@property (nonatomic, copy) RCTDirectEventBlock onAdLoadFailedEvent;
+@property (nonatomic, copy) RCTDirectEventBlock onAdClickedEvent;
+@property (nonatomic, copy) RCTDirectEventBlock onAdRevenuePaidEvent;
 
 // TODO: Allow publisher to select which views are clickable and which isn't via prop
 @property (nonatomic, strong) NSMutableArray<UIView *> *clickableViews;
@@ -62,7 +65,7 @@
     {
         _adLoader = [[MANativeAdLoader alloc] initWithAdUnitIdentifier: self.adUnitId sdk: [AppLovinMAX shared].sdk];
         _adLoader.nativeAdDelegate = self;
-        _adLoader.revenueDelegate = [AppLovinMAX shared];
+        _adLoader.revenueDelegate = self;
     }
     
     return _adLoader;
@@ -238,7 +241,7 @@
         [self.isLoading set: NO];
         
         [[AppLovinMAX shared] log: @"Native ad is of template type, failing ad load..."];
-        [[AppLovinMAX shared] sendReactNativeEventForAdLoadFailed: @"OnNativeAdLoadFailedEvent" forAdUnitIdentifier: self.adUnitId withError: nil];
+        self.onAdLoadFailedEvent([[AppLovinMAX shared] adLoadFailedInfoForAd: self.adUnitId withError: nil]);
         
         return;
     }
@@ -253,9 +256,6 @@
     // After notifying the RN layer - have slight delay to let views bind to this layer in `clickableViews` before registering
     dispatchOnMainQueueAfter(0.5, ^{
         
-        // Notify publisher
-        [[AppLovinMAX shared] didLoadAd: ad];
-        
         [self.adLoader registerClickableViews: self.clickableViews withContainer: self forAd: ad];
         [self.adLoader handleNativeAdViewRenderedForAd: ad];
       
@@ -265,8 +265,40 @@
 
 - (void)sendAdLoadedReactNativeEventForAd:(MANativeAd *)ad
 {
-    NSMutableDictionary<NSString *, id> *jsNativeAd = [NSMutableDictionary dictionaryWithCapacity: 6];
+    // 1. AdInfo for publisher to be notified via `onAdLoaded`
     
+    NSMutableDictionary<NSString *, id> *nativeAdInfo = [NSMutableDictionary dictionaryWithCapacity: 2];
+    if ( !isnan(ad.mediaContentAspectRatio) )
+    {
+        // The aspect ratio can be 0.0f when it is not provided by the network.
+        if ( fabs(ad.mediaContentAspectRatio) < FLT_EPSILON )
+        {
+            nativeAdInfo[@"mediaContentAspectRatio"] = @(1.0);
+        }
+        else
+        {
+            nativeAdInfo[@"mediaContentAspectRatio"] = @(ad.mediaContentAspectRatio);
+        }
+    }
+    else
+    {
+        nativeAdInfo[@"mediaContentAspectRatio"] = @(1.0);
+    }
+
+    nativeAdInfo[@"hasTitleView"] = ad.title ? @(YES) : @(NO);
+    nativeAdInfo[@"hasAdvertiserView"] = ad.advertiser ? @(YES) : @(NO);
+    nativeAdInfo[@"hasBodyView"] = ad.body ? @(YES) : @(NO);
+    nativeAdInfo[@"hasCallToActionView"] = ad.callToAction ? @(YES) : @(NO);
+    nativeAdInfo[@"hasIconView"] = ad.icon ? @(YES) : @(NO);
+    nativeAdInfo[@"hasOptionsView"] = ad.optionsView ? @(YES) : @(NO);
+    nativeAdInfo[@"hasMediaView"] = ad.mediaView ? @(YES) : @(NO);
+
+    NSMutableDictionary *adInfo = [[AppLovinMAX shared] adInfoForAd: self.nativeAd].mutableCopy;
+    adInfo[@"nativeAd"] = nativeAdInfo;
+    
+    // 2. NativeAd for `AppLovinNativeAdView.js` to render the views
+    
+    NSMutableDictionary<NSString *, id> *jsNativeAd = [NSMutableDictionary dictionaryWithCapacity: 5];
     if ( ad.title )
     {
         jsNativeAd[@"title"] = ad.title;
@@ -294,13 +326,13 @@
             jsNativeAd[@"image"] = @(YES);
         }
     }
-    if ( !isnan(ad.mediaContentAspectRatio) )
-    {
-        jsNativeAd[@"mediaContentAspectRatio"] = @(ad.mediaContentAspectRatio);
-    }
-     
-    // Send to `AppLovinNativeAdView.js` to render the views
-    self.onAdLoaded(jsNativeAd);
+    
+    NSMutableDictionary<NSString *, id> *arg = [NSMutableDictionary dictionaryWithCapacity: 2];
+    arg[@"adInfo"] = adInfo;
+    arg[@"nativeAd"] = jsNativeAd;
+    
+    // Send to `AppLovinNativeAdView.js`
+    self.onAdLoadedEvent(arg);
 }
 
 - (void)didFailToLoadNativeAdForAdUnitIdentifier:(NSString *)adUnitIdentifier withError:(MAError *)error
@@ -310,12 +342,19 @@
     [[AppLovinMAX shared] log: @"Failed to load native ad for Ad Unit ID %@ with error: %@", self.adUnitId, error];
     
     // Notify publisher
-    [[AppLovinMAX shared] sendReactNativeEventForAdLoadFailed: @"OnNativeAdLoadFailedEvent" forAdUnitIdentifier: self.adUnitId withError: error];
+    self.onAdLoadFailedEvent([[AppLovinMAX shared] adLoadFailedInfoForAd: adUnitIdentifier withError: error]);
 }
 
 - (void)didClickNativeAd:(MAAd *)ad
 {
-    [[AppLovinMAX shared] didClickAd: ad];
+    self.onAdClickedEvent([[AppLovinMAX shared] adInfoForAd: ad]);
+}
+
+#pragma mark - Ad Revenue Delegate
+
+- (void)didPayRevenueForAd:(MAAd *)ad
+{
+    self.onAdRevenuePaidEvent([[AppLovinMAX shared] adRevenueInfoForAd: ad]);
 }
 
 - (void)destroyCurrentAdIfNeeded

--- a/ios/AppLovinMAXNativeAdViewManager.m
+++ b/ios/AppLovinMAXNativeAdViewManager.m
@@ -20,7 +20,10 @@ RCT_EXPORT_VIEW_PROPERTY(customData, NSString)
 RCT_EXPORT_VIEW_PROPERTY(extraParameters, NSDictionary)
 
 // Callback
-RCT_EXPORT_VIEW_PROPERTY(onAdLoaded, RCTDirectEventBlock)
+RCT_EXPORT_VIEW_PROPERTY(onAdLoadedEvent, RCTDirectEventBlock)
+RCT_EXPORT_VIEW_PROPERTY(onAdLoadFailedEvent, RCTDirectEventBlock)
+RCT_EXPORT_VIEW_PROPERTY(onAdClickedEvent, RCTDirectEventBlock)
+RCT_EXPORT_VIEW_PROPERTY(onAdRevenuePaidEvent, RCTDirectEventBlock)
 
 // Asset views
 RCT_EXPORT_VIEW_PROPERTY(titleView, NSNumber)

--- a/src/AppLovinMAXAdView.js
+++ b/src/AppLovinMAXAdView.js
@@ -68,6 +68,34 @@ const AdView = (props) => {
     }
   }, [isInitialized]);
 
+  const onAdLoadedEvent = (event) => {
+    if (props.onAdLoaded) props.onAdLoaded(event.nativeEvent);
+  };
+
+  const onAdLoadFailedEvent = (event) => {
+    if (props.onAdLoadFailed) props.onAdLoadFailed(event.nativeEvent);
+  };
+
+  const onAdDisplayFailedEvent = (event) => {
+    if (props.onAdDisplayFailed) props.onAdDisplayFailed(event.nativeEvent);
+  };
+
+  const onAdClickedEvent = (event) => {
+    if (props.onAdClicked) props.onAdClicked(event.nativeEvent);
+  };
+
+  const onAdExpandedEvent = (event) => {
+    if (props.onAdExpanded) props.onAdExpanded(event.nativeEvent);
+  };
+
+  const onAdCollapsedEvent = (event) => {
+    if (props.onAdCollapsed) props.onAdCollapsed(event.nativeEvent);
+  };
+
+  const onAdRevenuePaidEvent = (event) => {
+    if (props.onAdRevenuePaid) props.onAdRevenuePaid(event.nativeEvent);
+  };
+
   // Not initialized
   if (!isInitialized) {
     return null;
@@ -85,6 +113,13 @@ const AdView = (props) => {
   return (
     <AppLovinMAXAdView
       style={{...style, ...dimensions}}
+      onAdLoadedEvent={onAdLoadedEvent}
+      onAdLoadFailedEvent={onAdLoadFailedEvent}
+      onAdDisplayFailedEvent={onAdDisplayFailedEvent}
+      onAdClickedEvent={onAdClickedEvent}
+      onAdExpandedEvent={onAdExpandedEvent}
+      onAdCollapsedEvent={onAdCollapsedEvent}
+      onAdRevenuePaidEvent={onAdRevenuePaidEvent}
       {...otherProps}
     />
   );
@@ -120,6 +155,41 @@ AdView.propTypes = {
    * A boolean value representing whether or not to enable auto-refresh. Note that auto-refresh is enabled by default.
    */
   autoRefresh: PropTypes.bool,
+
+  /**
+   * A callback fuction to be fired when a new ad has been loaded.
+   */
+  onAdLoaded: PropTypes.func,
+
+  /**
+   * A callback fuction to be fired when an ad could not be retrieved.
+   */
+  onAdLoadFailed: PropTypes.func,
+
+  /**
+   * A callback fuction to be fired when the ad failed to display.
+   */
+  onAdDisplayFailed: PropTypes.func,
+
+  /**
+   * A callback fuction to be fired when ad is clicked.
+   */
+  onAdClicked: PropTypes.func,
+
+  /**
+   * A callback fuction to be fired when the ad view is expanded.
+   */
+  onAdExpanded: PropTypes.func,
+
+  /**
+   * A callback fuction to be fired when the ad view is collapsed.
+   */
+  onAdCollapsed: PropTypes.func,
+
+  /**
+   * A callback fuction to be fired when the revenue event is detected.
+   */
+  onAdRevenuePaid: PropTypes.func,
 };
 
 // Defiens default values for the props.

--- a/src/NativeAdView.js
+++ b/src/NativeAdView.js
@@ -61,20 +61,39 @@ const NativeAdView = forwardRef((props, ref) => {
   useImperativeHandle(ref, () => ({ loadAd }), []);
 
   // save the DOM element via the ref callback
-  const saveElement = useCallback((element) => {
+  const saveElement = (element) => {
     if (element) {
       nativeAdViewRef.current = element;
       setNativeAdView(element);
     }
-  }, [nativeAdViewRef]);
+  };
 
-  // callback from the native module to set a loaded ad
-  const onAdLoaded = useCallback((event) => {
-    setNativeAd(event.nativeEvent);
-  }, []);
+  const onAdLoadedEvent = (event) => {
+    setNativeAd(event.nativeEvent.nativeAd);
+    if (props.onAdLoaded) props.onAdLoaded(event.nativeEvent.adInfo);
+  };
+
+  const onAdLoadFailedEvent = (event) => {
+    if (props.onAdLoadFailed) props.onAdLoadFailed(event.nativeEvent);
+  };
+
+  const onAdClickedEvent = (event) => {
+    if (props.onAdClicked) props.onAdClicked(event.nativeEvent);
+  };
+
+  const onAdRevenuePaidEvent = (event) => {
+    if (props.onAdRevenuePaid) props.onAdRevenuePaid(event.nativeEvent);
+  };
 
   return (
-    <AppLovinMAXNativeAdView {...props} ref={saveElement} onAdLoaded={onAdLoaded}>
+    <AppLovinMAXNativeAdView
+      ref={saveElement}
+      onAdLoadedEvent={onAdLoadedEvent}
+      onAdLoadFailedEvent={onAdLoadFailedEvent}
+      onAdClickedEvent={onAdClickedEvent}
+      onAdRevenuePaidEvent={onAdRevenuePaidEvent}
+      {...props}
+    >
       {props.children}
     </AppLovinMAXNativeAdView>
   );
@@ -100,6 +119,26 @@ NativeAdView.propTypes = {
    * A dictionary value representing the extra parameters to set a list of key-value string pairs.
    */
   extraParameters: PropTypes.object,
+
+  /**
+   * A callback fuction to be fired when a new ad has been loaded.
+   */
+  onAdLoaded: PropTypes.func,
+
+  /**
+   * A callback fuction to be fired when an ad could not be retrieved.
+   */
+  onAdLoadFailed: PropTypes.func,
+
+  /**
+   * A callback fuction to be fired when ad is clicked.
+   */
+  onAdClicked: PropTypes.func,
+
+  /**
+   * A callback fuction to be fired when the revenue event is detected.
+   */
+  onAdRevenuePaid: PropTypes.func,
 };
 
 // Add the child ad components


### PR DESCRIPTION
Add support for callback functions to  `AppLovinAdView` and `AppLovinNativeAdView` native UI components.

Also, new fields are added to `adInfo` in the `AppLovinNativeAdView`'s onAdLoaded.

1. MediaView aspect ratio

- `mediaContentAspectRatio`

It returns 1.0 if it is not available.

2. Boolean flags to indicate which native components are currently available.

- `hasTitleView`
- `hasAdvertiserView`
- `hasBodyView`
- `hasCallToActionView`
- `hasIconView`
- `hasOptionsView`
- `hasMediaView`

The developers can use their default views or change the layout when some views are missing from the network.   Nice to have but not necessarily to provide.   Please review.

```
<AppLovinMAX.NativeAdView
    adUnitId={adUnitId}
    onAdLoaded={(adInfo) => {
        setAspectRatio(adInfo.nativeAd.mediaContentAspectRatio);
        setHasOptionsView(adInfo.nativeAd.hasOptionsView);
    }}
```
