### PR TITLE
ref/add_event_listeners_using_event_names

### DIFF
--- a/android/src/main/java/com/applovin/reactnative/AppLovinMAXAdView.java
+++ b/android/src/main/java/com/applovin/reactnative/AppLovinMAXAdView.java
@@ -65,11 +65,11 @@ class AppLovinMAXAdView
             return;
         }
 
-        if ( "banner".equals( value ) )
+        if ( MaxAdFormat.BANNER.getLabel().equals( value ) )
         {
             adFormat = AppLovinMAXModule.getDeviceSpecificBannerAdViewAdFormat( reactContext );
         }
-        else if ( "mrec".equals( value ) )
+        else if ( MaxAdFormat.MREC.getLabel().equals( value ) )
         {
             adFormat = MaxAdFormat.MREC;
         }

--- a/android/src/main/java/com/applovin/reactnative/AppLovinMAXModule.java
+++ b/android/src/main/java/com/applovin/reactnative/AppLovinMAXModule.java
@@ -45,7 +45,6 @@ import com.applovin.sdk.AppLovinSdkSettings;
 import com.applovin.sdk.AppLovinSdkUtils;
 import com.applovin.sdk.AppLovinUserService;
 import com.facebook.react.bridge.Arguments;
-import com.facebook.react.bridge.Callback;
 import com.facebook.react.bridge.LifecycleEventListener;
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
@@ -80,6 +79,55 @@ public class AppLovinMAXModule
 {
     private static final String SDK_TAG = "AppLovinSdk";
     private static final String TAG     = "AppLovinMAXModule";
+
+    private static final String ON_BANNER_AD_LOADED_EVENT     = "OnBannerAdLoadedEvent";
+    private static final String ON_BANNER_AD_LOADFAILED_EVENT = "OnBannerAdLoadFailedEvent";
+    private static final String ON_BANNER_AD_CLICKED_EVENT    = "OnBannerAdClickedEvent";
+    private static final String ON_BANNER_AD_COLLAPSED_EVENT  = "OnBannerAdCollapsedEvent";
+    private static final String ON_BANNER_AD_EXPANDED_EVENT   = "OnBannerAdExpandedEvent";
+    private static final String ON_BANNER_AD_REVENUE_PAID     = "OnBannerAdRevenuePaid";
+
+    private static final String ON_MREC_AD_LOADED_EVENT     = "OnMRecAdLoadedEvent";
+    private static final String ON_MREC_AD_LOADFAILED_EVENT = "OnMRecAdLoadFailedEvent";
+    private static final String ON_MREC_AD_CLICKED_EVENT    = "OnMRecAdClickedEvent";
+    private static final String ON_MREC_AD_COLLAPSED_EVENT  = "OnMRecAdCollapsedEvent";
+    private static final String ON_MREC_AD_EXPANDED_EVENT   = "OnMRecAdExpandedEvent";
+    private static final String ON_MREC_AD_REVENUE_PAID     = "OnMRecAdRevenuePaid";
+
+    private static final String ON_INTERSTITIAL_LOADED_EVENT             = "OnInterstitialLoadedEvent";
+    private static final String ON_INTERSTITIAL_LOADFAILED_EVENT         = "OnInterstitialLoadFailedEvent";
+    private static final String ON_INTERSTITIAL_CLICKED_EVENT            = "OnInterstitialClickedEvent";
+    private static final String ON_INTERSTITIAL_DISPLAYED_EVENT          = "OnInterstitialDisplayedEvent";
+    private static final String ON_INTERSTITIAL_AD_FAILEDTODISPLAY_EVENT = "OnInterstitialAdFailedToDisplayEvent";
+    private static final String ON_INTERSTITIAL_HIDDEN_EVENT             = "OnInterstitialHiddenEvent";
+    private static final String ON_INTERSTITIAL_AD_REVENUE_PAID          = "OnInterstitialAdRevenuePaid";
+
+    private static final String ON_REWARDED_AD_LOADED_EVENT          = "OnRewardedAdLoadedEvent";
+    private static final String ON_REWARDED_AD_LOADFAILED_EVENT      = "OnRewardedAdLoadFailedEvent";
+    private static final String ON_REWARDED_AD_CLICKED_EVENT         = "OnRewardedAdClickedEvent";
+    private static final String ON_REWARDED_AD_DISPLAYED_EVENT       = "OnRewardedAdDisplayedEvent";
+    private static final String ON_REWARDED_AD_FAILEDTODISPLAY_EVENT = "OnRewardedAdFailedToDisplayEvent";
+    private static final String ON_REWARDED_AD_HIDDEN_EVENT          = "OnRewardedAdHiddenEvent";
+    private static final String ON_REWARDED_AD_RECEIVEDREWARD_EVENT  = "OnRewardedAdReceivedRewardEvent";
+    private static final String ON_REWARDED_AD_REVENUE_PAID          = "OnRewardedAdRevenuePaid";
+
+    private static final String ON_APPOPEN_AD_LOADED_EVENT          = "OnAppOpenAdLoadedEvent";
+    private static final String ON_APPOPEN_AD_LOADFAILED_EVENT      = "OnAppOpenAdLoadFailedEvent";
+    private static final String ON_APPOPEN_AD_CLICKED_EVENT         = "OnAppOpenAdClickedEvent";
+    private static final String ON_APPOPEN_AD_DISPLAYED_EVENT       = "OnAppOpenAdDisplayedEvent";
+    private static final String ON_APPOPEN_AD_FAILEDTODISPLAY_EVENT = "OnAppOpenAdFailedToDisplayEvent";
+    private static final String ON_APPOPEN_AD_HIDDEN_EVENT          = "OnAppOpenAdHiddenEvent";
+    private static final String ON_APPOPEN_AD_REVENUE_PAID          = "OnAppOpenAdRevenuePaid";
+
+    private static final String TOP_CENTER    = "top_center";
+    private static final String TOP_LEFT      = "top_left";
+    private static final String TOP_RIGHT     = "top_right";
+    private static final String CENTERED      = "centered";
+    private static final String CENTER_LEFT   = "center_left";
+    private static final String CENTER_RIGHT  = "center_right";
+    private static final String BOTTOM_LEFT   = "bottom_left";
+    private static final String BOTTOM_CENTER = "bottom_center";
+    private static final String BOTTOM_RIGHT  = "bottom_right";
 
     private static final Point DEFAULT_AD_VIEW_OFFSET = new Point( 0, 0 );
 
@@ -848,7 +896,7 @@ public class AppLovinMAXModule
         MaxInterstitialAd interstitial = retrieveInterstitial( adUnitId );
         if ( interstitial == null )
         {
-            sendReactNativeEventForAdLoadFailed( "OnInterstitialLoadFailedEvent", adUnitId, null );
+            sendReactNativeEventForAdLoadFailed( ON_INTERSTITIAL_LOADFAILED_EVENT, adUnitId, null );
             return;
         }
 
@@ -884,7 +932,7 @@ public class AppLovinMAXModule
         MaxRewardedAd rewardedAd = retrieveRewardedAd( adUnitId );
         if ( rewardedAd == null )
         {
-            sendReactNativeEventForAdLoadFailed( "OnRewardedAdLoadFailedEvent", adUnitId, null );
+            sendReactNativeEventForAdLoadFailed( ON_REWARDED_AD_LOADFAILED_EVENT, adUnitId, null );
             return;
         }
 
@@ -951,7 +999,7 @@ public class AppLovinMAXModule
         MaxAdFormat adFormat = ad.getFormat();
         if ( MaxAdFormat.BANNER == adFormat || MaxAdFormat.LEADER == adFormat || MaxAdFormat.MREC == adFormat )
         {
-            name = ( MaxAdFormat.MREC == adFormat ) ? "OnMRecAdLoadedEvent" : "OnBannerAdLoadedEvent";
+            name = ( MaxAdFormat.MREC == adFormat ) ? ON_MREC_AD_LOADED_EVENT : ON_BANNER_AD_LOADED_EVENT;
 
             String adViewPosition = mAdViewPositions.get( ad.getAdUnitId() );
             if ( !TextUtils.isEmpty( adViewPosition ) )
@@ -970,15 +1018,15 @@ public class AppLovinMAXModule
         }
         else if ( MaxAdFormat.INTERSTITIAL == adFormat )
         {
-            name = "OnInterstitialLoadedEvent";
+            name = ON_INTERSTITIAL_LOADED_EVENT;
         }
         else if ( MaxAdFormat.REWARDED == adFormat )
         {
-            name = "OnRewardedAdLoadedEvent";
+            name = ON_REWARDED_AD_LOADED_EVENT;
         }
         else if ( MaxAdFormat.APP_OPEN == adFormat )
         {
-            name = "OnAppOpenAdLoadedEvent";
+            name = ON_APPOPEN_AD_LOADED_EVENT;
         }
         else
         {
@@ -1001,19 +1049,19 @@ public class AppLovinMAXModule
         String name;
         if ( mAdViews.containsKey( adUnitId ) )
         {
-            name = ( MaxAdFormat.MREC == mAdViewAdFormats.get( adUnitId ) ) ? "OnMRecAdLoadFailedEvent" : "OnBannerAdLoadFailedEvent";
+            name = ( MaxAdFormat.MREC == mAdViewAdFormats.get( adUnitId ) ) ? ON_MREC_AD_LOADFAILED_EVENT : ON_BANNER_AD_LOADFAILED_EVENT;
         }
         else if ( mInterstitials.containsKey( adUnitId ) )
         {
-            name = "OnInterstitialLoadFailedEvent";
+            name = ON_INTERSTITIAL_LOADFAILED_EVENT;
         }
         else if ( mRewardedAds.containsKey( adUnitId ) )
         {
-            name = "OnRewardedAdLoadFailedEvent";
+            name = ON_REWARDED_AD_LOADFAILED_EVENT;
         }
         else if ( mAppOpenAds.containsKey( adUnitId ) )
         {
-            name = "OnAppOpenAdLoadFailedEvent";
+            name = ON_APPOPEN_AD_LOADFAILED_EVENT;
         }
         else
         {
@@ -1036,23 +1084,23 @@ public class AppLovinMAXModule
         final String name;
         if ( MaxAdFormat.BANNER == adFormat || MaxAdFormat.LEADER == adFormat )
         {
-            name = "OnBannerAdClickedEvent";
+            name = ON_BANNER_AD_CLICKED_EVENT;
         }
         else if ( MaxAdFormat.MREC == adFormat )
         {
-            name = "OnMRecAdClickedEvent";
+            name = ON_MREC_AD_CLICKED_EVENT;
         }
         else if ( MaxAdFormat.INTERSTITIAL == adFormat )
         {
-            name = "OnInterstitialClickedEvent";
+            name = ON_INTERSTITIAL_CLICKED_EVENT;
         }
         else if ( MaxAdFormat.REWARDED == adFormat )
         {
-            name = "OnRewardedAdClickedEvent";
+            name = ON_REWARDED_AD_CLICKED_EVENT;
         }
         else if ( MaxAdFormat.APP_OPEN == adFormat )
         {
-            name = "OnAppOpenAdClickedEvent";
+            name = ON_APPOPEN_AD_CLICKED_EVENT;
         }
         else
         {
@@ -1073,15 +1121,15 @@ public class AppLovinMAXModule
         final String name;
         if ( MaxAdFormat.INTERSTITIAL == adFormat )
         {
-            name = "OnInterstitialDisplayedEvent";
+            name = ON_INTERSTITIAL_DISPLAYED_EVENT;
         }
         else if ( MaxAdFormat.REWARDED == adFormat )
         {
-            name = "OnRewardedAdDisplayedEvent";
+            name = ON_REWARDED_AD_DISPLAYED_EVENT;
         }
         else // APP OPEN
         {
-            name = "OnAppOpenAdDisplayedEvent";
+            name = ON_APPOPEN_AD_DISPLAYED_EVENT;
         }
 
         sendReactNativeEvent( name, getAdInfo( ad ) );
@@ -1097,15 +1145,15 @@ public class AppLovinMAXModule
         final String name;
         if ( MaxAdFormat.INTERSTITIAL == adFormat )
         {
-            name = "OnInterstitialAdFailedToDisplayEvent";
+            name = ON_INTERSTITIAL_AD_FAILEDTODISPLAY_EVENT;
         }
         else if ( MaxAdFormat.REWARDED == adFormat )
         {
-            name = "OnRewardedAdFailedToDisplayEvent";
+            name = ON_REWARDED_AD_FAILEDTODISPLAY_EVENT;
         }
         else // APP OPEN
         {
-            name = "OnAppOpenAdFailedToDisplayEvent";
+            name = ON_APPOPEN_AD_FAILEDTODISPLAY_EVENT;
         }
 
         sendReactNativeEvent( name, getAdDisplayFailedInfo( ad, error ) );
@@ -1121,15 +1169,15 @@ public class AppLovinMAXModule
         String name;
         if ( MaxAdFormat.INTERSTITIAL == adFormat )
         {
-            name = "OnInterstitialHiddenEvent";
+            name = ON_INTERSTITIAL_HIDDEN_EVENT;
         }
         else if ( MaxAdFormat.REWARDED == adFormat )
         {
-            name = "OnRewardedAdHiddenEvent";
+            name = ON_REWARDED_AD_HIDDEN_EVENT;
         }
         else // APP OPEN
         {
-            name = "OnAppOpenAdHiddenEvent";
+            name = ON_APPOPEN_AD_HIDDEN_EVENT;
         }
 
         sendReactNativeEvent( name, getAdInfo( ad ) );
@@ -1145,7 +1193,7 @@ public class AppLovinMAXModule
             return;
         }
 
-        sendReactNativeEvent( ( MaxAdFormat.MREC == adFormat ) ? "OnMRecAdExpandedEvent" : "OnBannerAdExpandedEvent", getAdInfo( ad ) );
+        sendReactNativeEvent( ( MaxAdFormat.MREC == adFormat ) ? ON_MREC_AD_EXPANDED_EVENT : ON_BANNER_AD_EXPANDED_EVENT, getAdInfo( ad ) );
     }
 
     @Override
@@ -1158,7 +1206,7 @@ public class AppLovinMAXModule
             return;
         }
 
-        sendReactNativeEvent( ( MaxAdFormat.MREC == adFormat ) ? "OnMRecAdCollapsedEvent" : "OnBannerAdCollapsedEvent", getAdInfo( ad ) );
+        sendReactNativeEvent( ( MaxAdFormat.MREC == adFormat ) ? ON_MREC_AD_COLLAPSED_EVENT : ON_BANNER_AD_COLLAPSED_EVENT, getAdInfo( ad ) );
     }
 
     @Override
@@ -1168,23 +1216,23 @@ public class AppLovinMAXModule
         final String name;
         if ( MaxAdFormat.BANNER == adFormat || MaxAdFormat.LEADER == adFormat )
         {
-            name = "OnBannerAdRevenuePaid";
+            name = ON_BANNER_AD_REVENUE_PAID;
         }
         else if ( MaxAdFormat.MREC == adFormat )
         {
-            name = "OnMRecAdRevenuePaid";
+            name = ON_MREC_AD_REVENUE_PAID;
         }
         else if ( MaxAdFormat.INTERSTITIAL == adFormat )
         {
-            name = "OnInterstitialAdRevenuePaid";
+            name = ON_INTERSTITIAL_AD_REVENUE_PAID;
         }
         else if ( MaxAdFormat.REWARDED == adFormat )
         {
-            name = "OnRewardedAdRevenuePaid";
+            name = ON_REWARDED_AD_REVENUE_PAID;
         }
         else if ( MaxAdFormat.APP_OPEN == adFormat )
         {
-            name = "OnAppOpenAdRevenuePaid";
+            name = ON_APPOPEN_AD_REVENUE_PAID;
         }
         else
         {
@@ -1676,7 +1724,7 @@ public class AppLovinMAXModule
             adViewWidthDp = mAdViewWidths.get( adUnitId );
         }
         // Top center / bottom center stretches full screen
-        else if ( "top_center".equalsIgnoreCase( adViewPosition ) || "bottom_center".equalsIgnoreCase( adViewPosition ) )
+        else if ( TOP_CENTER.equalsIgnoreCase( adViewPosition ) || BOTTOM_CENTER.equalsIgnoreCase( adViewPosition ) )
         {
             int adViewWidthPx = windowRect.width();
             adViewWidthDp = AppLovinSdkUtils.pxToDp( getCurrentActivity(), adViewWidthPx );
@@ -1716,7 +1764,7 @@ public class AppLovinMAXModule
         adView.setTranslationX( 0 );
         params.setMargins( 0, 0, 0, 0 );
 
-        if ( "centered".equalsIgnoreCase( adViewPosition ) )
+        if ( CENTERED.equalsIgnoreCase( adViewPosition ) )
         {
             gravity = Gravity.CENTER_VERTICAL | Gravity.CENTER_HORIZONTAL;
 
@@ -2097,6 +2145,64 @@ public class AppLovinMAXModule
     @Nullable
     public Map<String, Object> getConstants()
     {
-        return super.getConstants();
+        final Map<String, Object> constants = new HashMap<>();
+
+        constants.put( "ON_MREC_AD_LOADED_EVENT", ON_MREC_AD_LOADED_EVENT );
+        constants.put( "ON_MREC_AD_LOADFAILED_EVENT", ON_MREC_AD_LOADFAILED_EVENT );
+        constants.put( "ON_MREC_AD_CLICKED_EVENT", ON_MREC_AD_CLICKED_EVENT );
+        constants.put( "ON_MREC_AD_COLLAPSED_EVENT", ON_MREC_AD_COLLAPSED_EVENT );
+        constants.put( "ON_MREC_AD_EXPANDED_EVENT", ON_MREC_AD_EXPANDED_EVENT );
+        constants.put( "ON_MREC_AD_REVENUE_PAID", ON_MREC_AD_REVENUE_PAID );
+
+        constants.put( "ON_BANNER_AD_LOADED_EVENT", ON_BANNER_AD_LOADED_EVENT );
+        constants.put( "ON_BANNER_AD_LOADFAILED_EVENT", ON_BANNER_AD_LOADFAILED_EVENT );
+        constants.put( "ON_BANNER_AD_CLICKED_EVENT", ON_BANNER_AD_CLICKED_EVENT );
+        constants.put( "ON_BANNER_AD_COLLAPSED_EVENT", ON_BANNER_AD_COLLAPSED_EVENT );
+        constants.put( "ON_BANNER_AD_EXPANDED_EVENT", ON_BANNER_AD_EXPANDED_EVENT );
+        constants.put( "ON_BANNER_AD_REVENUE_PAID", ON_BANNER_AD_REVENUE_PAID );
+
+        constants.put( "ON_INTERSTITIAL_LOADED_EVENT", ON_INTERSTITIAL_LOADED_EVENT );
+        constants.put( "ON_INTERSTITIAL_LOADFAILED_EVENT", ON_INTERSTITIAL_LOADFAILED_EVENT );
+        constants.put( "ON_INTERSTITIAL_CLICKED_EVENT", ON_INTERSTITIAL_CLICKED_EVENT );
+        constants.put( "ON_INTERSTITIAL_DISPLAYED_EVENT", ON_INTERSTITIAL_DISPLAYED_EVENT );
+        constants.put( "ON_INTERSTITIAL_AD_FAILEDTODISPLAY_EVENT", ON_INTERSTITIAL_AD_FAILEDTODISPLAY_EVENT );
+        constants.put( "ON_INTERSTITIAL_HIDDEN_EVENT", ON_INTERSTITIAL_HIDDEN_EVENT );
+        constants.put( "ON_INTERSTITIAL_AD_REVENUE_PAID", ON_INTERSTITIAL_AD_REVENUE_PAID );
+
+        constants.put( "ON_REWARDED_AD_LOADED_EVENT", ON_REWARDED_AD_LOADED_EVENT );
+        constants.put( "ON_REWARDED_AD_LOADFAILED_EVENT", ON_REWARDED_AD_LOADFAILED_EVENT );
+        constants.put( "ON_REWARDED_AD_CLICKED_EVENT", ON_REWARDED_AD_CLICKED_EVENT );
+        constants.put( "ON_REWARDED_AD_DISPLAYED_EVENT", ON_REWARDED_AD_DISPLAYED_EVENT );
+        constants.put( "ON_REWARDED_AD_FAILEDTODISPLAY_EVENT", ON_REWARDED_AD_FAILEDTODISPLAY_EVENT );
+        constants.put( "ON_REWARDED_AD_HIDDEN_EVENT", ON_REWARDED_AD_HIDDEN_EVENT );
+        constants.put( "ON_REWARDED_AD_RECEIVEDREWARD_EVENT", ON_REWARDED_AD_RECEIVEDREWARD_EVENT );
+        constants.put( "ON_REWARDED_AD_REVENUE_PAID", ON_REWARDED_AD_REVENUE_PAID );
+
+        constants.put( "ON_APPOPEN_AD_LOADED_EVENT", ON_APPOPEN_AD_LOADED_EVENT );
+        constants.put( "ON_APPOPEN_AD_LOADFAILED_EVENT", ON_APPOPEN_AD_LOADFAILED_EVENT );
+        constants.put( "ON_APPOPEN_AD_CLICKED_EVENT", ON_APPOPEN_AD_CLICKED_EVENT );
+        constants.put( "ON_APPOPEN_AD_DISPLAYED_EVENT", ON_APPOPEN_AD_DISPLAYED_EVENT );
+        constants.put( "ON_APPOPEN_AD_FAILEDTODISPLAY_EVENT", ON_APPOPEN_AD_FAILEDTODISPLAY_EVENT );
+        constants.put( "ON_APPOPEN_AD_HIDDEN_EVENT", ON_APPOPEN_AD_HIDDEN_EVENT );
+        constants.put( "ON_APPOPEN_AD_REVENUE_PAID", ON_APPOPEN_AD_REVENUE_PAID );
+
+        constants.put( "TOP_CENTER_POSITION", TOP_CENTER );
+        constants.put( "TOP_LEFT_POSITION", TOP_LEFT );
+        constants.put( "TOP_RIGHT_POSITION", TOP_RIGHT );
+        constants.put( "CENTERED_POSITION", CENTERED );
+        constants.put( "CENTER_LEFT_POSITION", CENTER_LEFT );
+        constants.put( "CENTER_RIGHT_POSITION", CENTER_RIGHT );
+        constants.put( "BOTTOM_LEFT_POSITION", BOTTOM_LEFT );
+        constants.put( "BOTTOM_CENTER_POSITION", BOTTOM_CENTER );
+        constants.put( "BOTTOM_RIGHT_POSITION", BOTTOM_RIGHT );
+
+        constants.put( "BANNER_AD_FORMAT_LABEL", MaxAdFormat.BANNER.getLabel() );
+        constants.put( "MREC_AD_FORMAT_LABEL", MaxAdFormat.MREC.getLabel() );
+
+        constants.put( "CONSENT_DIALOG_STATE_UNKNOWN", AppLovinSdkConfiguration.ConsentDialogState.UNKNOWN.ordinal() );
+        constants.put( "CONSENT_DIALOG_STATE_APPLIES", AppLovinSdkConfiguration.ConsentDialogState.APPLIES.ordinal() );
+        constants.put( "CONSENT_DIALOG_STATE_DOES_NOT_APPLY", AppLovinSdkConfiguration.ConsentDialogState.DOES_NOT_APPLY.ordinal() );
+
+        return constants;
     }
 }

--- a/android/src/main/java/com/applovin/reactnative/AppLovinMAXModule.java
+++ b/android/src/main/java/com/applovin/reactnative/AppLovinMAXModule.java
@@ -80,44 +80,44 @@ public class AppLovinMAXModule
     private static final String SDK_TAG = "AppLovinSdk";
     private static final String TAG     = "AppLovinMAXModule";
 
-    private static final String ON_BANNER_AD_LOADED_EVENT     = "OnBannerAdLoadedEvent";
+    private static final String ON_BANNER_AD_LOADED_EVENT      = "OnBannerAdLoadedEvent";
     private static final String ON_BANNER_AD_LOAD_FAILED_EVENT = "OnBannerAdLoadFailedEvent";
-    private static final String ON_BANNER_AD_CLICKED_EVENT    = "OnBannerAdClickedEvent";
-    private static final String ON_BANNER_AD_COLLAPSED_EVENT  = "OnBannerAdCollapsedEvent";
-    private static final String ON_BANNER_AD_EXPANDED_EVENT   = "OnBannerAdExpandedEvent";
-    private static final String ON_BANNER_AD_REVENUE_PAID     = "OnBannerAdRevenuePaid";
+    private static final String ON_BANNER_AD_CLICKED_EVENT     = "OnBannerAdClickedEvent";
+    private static final String ON_BANNER_AD_COLLAPSED_EVENT   = "OnBannerAdCollapsedEvent";
+    private static final String ON_BANNER_AD_EXPANDED_EVENT    = "OnBannerAdExpandedEvent";
+    private static final String ON_BANNER_AD_REVENUE_PAID      = "OnBannerAdRevenuePaid";
 
-    private static final String ON_MREC_AD_LOADED_EVENT     = "OnMRecAdLoadedEvent";
+    private static final String ON_MREC_AD_LOADED_EVENT      = "OnMRecAdLoadedEvent";
     private static final String ON_MREC_AD_LOAD_FAILED_EVENT = "OnMRecAdLoadFailedEvent";
-    private static final String ON_MREC_AD_CLICKED_EVENT    = "OnMRecAdClickedEvent";
-    private static final String ON_MREC_AD_COLLAPSED_EVENT  = "OnMRecAdCollapsedEvent";
-    private static final String ON_MREC_AD_EXPANDED_EVENT   = "OnMRecAdExpandedEvent";
-    private static final String ON_MREC_AD_REVENUE_PAID     = "OnMRecAdRevenuePaid";
+    private static final String ON_MREC_AD_CLICKED_EVENT     = "OnMRecAdClickedEvent";
+    private static final String ON_MREC_AD_COLLAPSED_EVENT   = "OnMRecAdCollapsedEvent";
+    private static final String ON_MREC_AD_EXPANDED_EVENT    = "OnMRecAdExpandedEvent";
+    private static final String ON_MREC_AD_REVENUE_PAID      = "OnMRecAdRevenuePaid";
 
-    private static final String ON_INTERSTITIAL_LOADED_EVENT             = "OnInterstitialLoadedEvent";
-    private static final String ON_INTERSTITIAL_LOAD_FAILED_EVENT         = "OnInterstitialLoadFailedEvent";
-    private static final String ON_INTERSTITIAL_CLICKED_EVENT            = "OnInterstitialClickedEvent";
-    private static final String ON_INTERSTITIAL_DISPLAYED_EVENT          = "OnInterstitialDisplayedEvent";
+    private static final String ON_INTERSTITIAL_LOADED_EVENT               = "OnInterstitialLoadedEvent";
+    private static final String ON_INTERSTITIAL_LOAD_FAILED_EVENT          = "OnInterstitialLoadFailedEvent";
+    private static final String ON_INTERSTITIAL_CLICKED_EVENT              = "OnInterstitialClickedEvent";
+    private static final String ON_INTERSTITIAL_DISPLAYED_EVENT            = "OnInterstitialDisplayedEvent";
     private static final String ON_INTERSTITIAL_AD_FAILED_TO_DISPLAY_EVENT = "OnInterstitialAdFailedToDisplayEvent";
-    private static final String ON_INTERSTITIAL_HIDDEN_EVENT             = "OnInterstitialHiddenEvent";
-    private static final String ON_INTERSTITIAL_AD_REVENUE_PAID          = "OnInterstitialAdRevenuePaid";
+    private static final String ON_INTERSTITIAL_HIDDEN_EVENT               = "OnInterstitialHiddenEvent";
+    private static final String ON_INTERSTITIAL_AD_REVENUE_PAID            = "OnInterstitialAdRevenuePaid";
 
-    private static final String ON_REWARDED_AD_LOADED_EVENT          = "OnRewardedAdLoadedEvent";
-    private static final String ON_REWARDED_AD_LOAD_FAILED_EVENT      = "OnRewardedAdLoadFailedEvent";
-    private static final String ON_REWARDED_AD_CLICKED_EVENT         = "OnRewardedAdClickedEvent";
-    private static final String ON_REWARDED_AD_DISPLAYED_EVENT       = "OnRewardedAdDisplayedEvent";
+    private static final String ON_REWARDED_AD_LOADED_EVENT            = "OnRewardedAdLoadedEvent";
+    private static final String ON_REWARDED_AD_LOAD_FAILED_EVENT       = "OnRewardedAdLoadFailedEvent";
+    private static final String ON_REWARDED_AD_CLICKED_EVENT           = "OnRewardedAdClickedEvent";
+    private static final String ON_REWARDED_AD_DISPLAYED_EVENT         = "OnRewardedAdDisplayedEvent";
     private static final String ON_REWARDED_AD_FAILED_TO_DISPLAY_EVENT = "OnRewardedAdFailedToDisplayEvent";
-    private static final String ON_REWARDED_AD_HIDDEN_EVENT          = "OnRewardedAdHiddenEvent";
-    private static final String ON_REWARDED_AD_RECEIVED_REWARD_EVENT  = "OnRewardedAdReceivedRewardEvent";
-    private static final String ON_REWARDED_AD_REVENUE_PAID          = "OnRewardedAdRevenuePaid";
+    private static final String ON_REWARDED_AD_HIDDEN_EVENT            = "OnRewardedAdHiddenEvent";
+    private static final String ON_REWARDED_AD_RECEIVED_REWARD_EVENT   = "OnRewardedAdReceivedRewardEvent";
+    private static final String ON_REWARDED_AD_REVENUE_PAID            = "OnRewardedAdRevenuePaid";
 
-    private static final String ON_APPOPEN_AD_LOADED_EVENT          = "OnAppOpenAdLoadedEvent";
-    private static final String ON_APPOPEN_AD_LOAD_FAILED_EVENT      = "OnAppOpenAdLoadFailedEvent";
-    private static final String ON_APPOPEN_AD_CLICKED_EVENT         = "OnAppOpenAdClickedEvent";
-    private static final String ON_APPOPEN_AD_DISPLAYED_EVENT       = "OnAppOpenAdDisplayedEvent";
+    private static final String ON_APPOPEN_AD_LOADED_EVENT            = "OnAppOpenAdLoadedEvent";
+    private static final String ON_APPOPEN_AD_LOAD_FAILED_EVENT       = "OnAppOpenAdLoadFailedEvent";
+    private static final String ON_APPOPEN_AD_CLICKED_EVENT           = "OnAppOpenAdClickedEvent";
+    private static final String ON_APPOPEN_AD_DISPLAYED_EVENT         = "OnAppOpenAdDisplayedEvent";
     private static final String ON_APPOPEN_AD_FAILED_TO_DISPLAY_EVENT = "OnAppOpenAdFailedToDisplayEvent";
-    private static final String ON_APPOPEN_AD_HIDDEN_EVENT          = "OnAppOpenAdHiddenEvent";
-    private static final String ON_APPOPEN_AD_REVENUE_PAID          = "OnAppOpenAdRevenuePaid";
+    private static final String ON_APPOPEN_AD_HIDDEN_EVENT            = "OnAppOpenAdHiddenEvent";
+    private static final String ON_APPOPEN_AD_REVENUE_PAID            = "OnAppOpenAdRevenuePaid";
 
     private static final String TOP_CENTER    = "top_center";
     private static final String TOP_LEFT      = "top_left";

--- a/android/src/main/java/com/applovin/reactnative/AppLovinMAXModule.java
+++ b/android/src/main/java/com/applovin/reactnative/AppLovinMAXModule.java
@@ -404,7 +404,6 @@ public class AppLovinMAXModule
                 }.enable();
 
                 WritableMap sdkConfiguration = Arguments.createMap();
-                sdkConfiguration.putInt( "consentDialogState", configuration.getConsentDialogState().ordinal() );
                 sdkConfiguration.putString( "countryCode", configuration.getCountryCode() );
                 promise.resolve( sdkConfiguration );
             }
@@ -449,14 +448,6 @@ public class AppLovinMAXModule
                 promise.resolve( null );
             }
         } );
-    }
-
-    @ReactMethod
-    public void getConsentDialogState(final Promise promise)
-    {
-        promise.resolve( isSdkInitialized ?
-                                 sdkConfiguration.getConsentDialogState().ordinal() :
-                                 AppLovinSdkConfiguration.ConsentDialogState.UNKNOWN.ordinal() );
     }
 
     @ReactMethod
@@ -2198,10 +2189,6 @@ public class AppLovinMAXModule
 
         constants.put( "BANNER_AD_FORMAT_LABEL", MaxAdFormat.BANNER.getLabel() );
         constants.put( "MREC_AD_FORMAT_LABEL", MaxAdFormat.MREC.getLabel() );
-
-        constants.put( "CONSENT_DIALOG_STATE_UNKNOWN", AppLovinSdkConfiguration.ConsentDialogState.UNKNOWN.ordinal() );
-        constants.put( "CONSENT_DIALOG_STATE_APPLIES", AppLovinSdkConfiguration.ConsentDialogState.APPLIES.ordinal() );
-        constants.put( "CONSENT_DIALOG_STATE_DOES_NOT_APPLY", AppLovinSdkConfiguration.ConsentDialogState.DOES_NOT_APPLY.ordinal() );
 
         return constants;
     }

--- a/android/src/main/java/com/applovin/reactnative/AppLovinMAXModule.java
+++ b/android/src/main/java/com/applovin/reactnative/AppLovinMAXModule.java
@@ -81,41 +81,41 @@ public class AppLovinMAXModule
     private static final String TAG     = "AppLovinMAXModule";
 
     private static final String ON_BANNER_AD_LOADED_EVENT     = "OnBannerAdLoadedEvent";
-    private static final String ON_BANNER_AD_LOADFAILED_EVENT = "OnBannerAdLoadFailedEvent";
+    private static final String ON_BANNER_AD_LOAD_FAILED_EVENT = "OnBannerAdLoadFailedEvent";
     private static final String ON_BANNER_AD_CLICKED_EVENT    = "OnBannerAdClickedEvent";
     private static final String ON_BANNER_AD_COLLAPSED_EVENT  = "OnBannerAdCollapsedEvent";
     private static final String ON_BANNER_AD_EXPANDED_EVENT   = "OnBannerAdExpandedEvent";
     private static final String ON_BANNER_AD_REVENUE_PAID     = "OnBannerAdRevenuePaid";
 
     private static final String ON_MREC_AD_LOADED_EVENT     = "OnMRecAdLoadedEvent";
-    private static final String ON_MREC_AD_LOADFAILED_EVENT = "OnMRecAdLoadFailedEvent";
+    private static final String ON_MREC_AD_LOAD_FAILED_EVENT = "OnMRecAdLoadFailedEvent";
     private static final String ON_MREC_AD_CLICKED_EVENT    = "OnMRecAdClickedEvent";
     private static final String ON_MREC_AD_COLLAPSED_EVENT  = "OnMRecAdCollapsedEvent";
     private static final String ON_MREC_AD_EXPANDED_EVENT   = "OnMRecAdExpandedEvent";
     private static final String ON_MREC_AD_REVENUE_PAID     = "OnMRecAdRevenuePaid";
 
     private static final String ON_INTERSTITIAL_LOADED_EVENT             = "OnInterstitialLoadedEvent";
-    private static final String ON_INTERSTITIAL_LOADFAILED_EVENT         = "OnInterstitialLoadFailedEvent";
+    private static final String ON_INTERSTITIAL_LOAD_FAILED_EVENT         = "OnInterstitialLoadFailedEvent";
     private static final String ON_INTERSTITIAL_CLICKED_EVENT            = "OnInterstitialClickedEvent";
     private static final String ON_INTERSTITIAL_DISPLAYED_EVENT          = "OnInterstitialDisplayedEvent";
-    private static final String ON_INTERSTITIAL_AD_FAILEDTODISPLAY_EVENT = "OnInterstitialAdFailedToDisplayEvent";
+    private static final String ON_INTERSTITIAL_AD_FAILED_TO_DISPLAY_EVENT = "OnInterstitialAdFailedToDisplayEvent";
     private static final String ON_INTERSTITIAL_HIDDEN_EVENT             = "OnInterstitialHiddenEvent";
     private static final String ON_INTERSTITIAL_AD_REVENUE_PAID          = "OnInterstitialAdRevenuePaid";
 
     private static final String ON_REWARDED_AD_LOADED_EVENT          = "OnRewardedAdLoadedEvent";
-    private static final String ON_REWARDED_AD_LOADFAILED_EVENT      = "OnRewardedAdLoadFailedEvent";
+    private static final String ON_REWARDED_AD_LOAD_FAILED_EVENT      = "OnRewardedAdLoadFailedEvent";
     private static final String ON_REWARDED_AD_CLICKED_EVENT         = "OnRewardedAdClickedEvent";
     private static final String ON_REWARDED_AD_DISPLAYED_EVENT       = "OnRewardedAdDisplayedEvent";
-    private static final String ON_REWARDED_AD_FAILEDTODISPLAY_EVENT = "OnRewardedAdFailedToDisplayEvent";
+    private static final String ON_REWARDED_AD_FAILED_TO_DISPLAY_EVENT = "OnRewardedAdFailedToDisplayEvent";
     private static final String ON_REWARDED_AD_HIDDEN_EVENT          = "OnRewardedAdHiddenEvent";
-    private static final String ON_REWARDED_AD_RECEIVEDREWARD_EVENT  = "OnRewardedAdReceivedRewardEvent";
+    private static final String ON_REWARDED_AD_RECEIVED_REWARD_EVENT  = "OnRewardedAdReceivedRewardEvent";
     private static final String ON_REWARDED_AD_REVENUE_PAID          = "OnRewardedAdRevenuePaid";
 
     private static final String ON_APPOPEN_AD_LOADED_EVENT          = "OnAppOpenAdLoadedEvent";
-    private static final String ON_APPOPEN_AD_LOADFAILED_EVENT      = "OnAppOpenAdLoadFailedEvent";
+    private static final String ON_APPOPEN_AD_LOAD_FAILED_EVENT      = "OnAppOpenAdLoadFailedEvent";
     private static final String ON_APPOPEN_AD_CLICKED_EVENT         = "OnAppOpenAdClickedEvent";
     private static final String ON_APPOPEN_AD_DISPLAYED_EVENT       = "OnAppOpenAdDisplayedEvent";
-    private static final String ON_APPOPEN_AD_FAILEDTODISPLAY_EVENT = "OnAppOpenAdFailedToDisplayEvent";
+    private static final String ON_APPOPEN_AD_FAILED_TO_DISPLAY_EVENT = "OnAppOpenAdFailedToDisplayEvent";
     private static final String ON_APPOPEN_AD_HIDDEN_EVENT          = "OnAppOpenAdHiddenEvent";
     private static final String ON_APPOPEN_AD_REVENUE_PAID          = "OnAppOpenAdRevenuePaid";
 
@@ -896,7 +896,7 @@ public class AppLovinMAXModule
         MaxInterstitialAd interstitial = retrieveInterstitial( adUnitId );
         if ( interstitial == null )
         {
-            sendReactNativeEventForAdLoadFailed( ON_INTERSTITIAL_LOADFAILED_EVENT, adUnitId, null );
+            sendReactNativeEventForAdLoadFailed( ON_INTERSTITIAL_LOAD_FAILED_EVENT, adUnitId, null );
             return;
         }
 
@@ -932,7 +932,7 @@ public class AppLovinMAXModule
         MaxRewardedAd rewardedAd = retrieveRewardedAd( adUnitId );
         if ( rewardedAd == null )
         {
-            sendReactNativeEventForAdLoadFailed( ON_REWARDED_AD_LOADFAILED_EVENT, adUnitId, null );
+            sendReactNativeEventForAdLoadFailed( ON_REWARDED_AD_LOAD_FAILED_EVENT, adUnitId, null );
             return;
         }
 
@@ -1049,19 +1049,19 @@ public class AppLovinMAXModule
         String name;
         if ( mAdViews.containsKey( adUnitId ) )
         {
-            name = ( MaxAdFormat.MREC == mAdViewAdFormats.get( adUnitId ) ) ? ON_MREC_AD_LOADFAILED_EVENT : ON_BANNER_AD_LOADFAILED_EVENT;
+            name = ( MaxAdFormat.MREC == mAdViewAdFormats.get( adUnitId ) ) ? ON_MREC_AD_LOAD_FAILED_EVENT : ON_BANNER_AD_LOAD_FAILED_EVENT;
         }
         else if ( mInterstitials.containsKey( adUnitId ) )
         {
-            name = ON_INTERSTITIAL_LOADFAILED_EVENT;
+            name = ON_INTERSTITIAL_LOAD_FAILED_EVENT;
         }
         else if ( mRewardedAds.containsKey( adUnitId ) )
         {
-            name = ON_REWARDED_AD_LOADFAILED_EVENT;
+            name = ON_REWARDED_AD_LOAD_FAILED_EVENT;
         }
         else if ( mAppOpenAds.containsKey( adUnitId ) )
         {
-            name = ON_APPOPEN_AD_LOADFAILED_EVENT;
+            name = ON_APPOPEN_AD_LOAD_FAILED_EVENT;
         }
         else
         {
@@ -1145,15 +1145,15 @@ public class AppLovinMAXModule
         final String name;
         if ( MaxAdFormat.INTERSTITIAL == adFormat )
         {
-            name = ON_INTERSTITIAL_AD_FAILEDTODISPLAY_EVENT;
+            name = ON_INTERSTITIAL_AD_FAILED_TO_DISPLAY_EVENT;
         }
         else if ( MaxAdFormat.REWARDED == adFormat )
         {
-            name = ON_REWARDED_AD_FAILEDTODISPLAY_EVENT;
+            name = ON_REWARDED_AD_FAILED_TO_DISPLAY_EVENT;
         }
         else // APP OPEN
         {
-            name = ON_APPOPEN_AD_FAILEDTODISPLAY_EVENT;
+            name = ON_APPOPEN_AD_FAILED_TO_DISPLAY_EVENT;
         }
 
         sendReactNativeEvent( name, getAdDisplayFailedInfo( ad, error ) );
@@ -2148,41 +2148,41 @@ public class AppLovinMAXModule
         final Map<String, Object> constants = new HashMap<>();
 
         constants.put( "ON_MREC_AD_LOADED_EVENT", ON_MREC_AD_LOADED_EVENT );
-        constants.put( "ON_MREC_AD_LOADFAILED_EVENT", ON_MREC_AD_LOADFAILED_EVENT );
+        constants.put( "ON_MREC_AD_LOAD_FAILED_EVENT", ON_MREC_AD_LOAD_FAILED_EVENT );
         constants.put( "ON_MREC_AD_CLICKED_EVENT", ON_MREC_AD_CLICKED_EVENT );
         constants.put( "ON_MREC_AD_COLLAPSED_EVENT", ON_MREC_AD_COLLAPSED_EVENT );
         constants.put( "ON_MREC_AD_EXPANDED_EVENT", ON_MREC_AD_EXPANDED_EVENT );
         constants.put( "ON_MREC_AD_REVENUE_PAID", ON_MREC_AD_REVENUE_PAID );
 
         constants.put( "ON_BANNER_AD_LOADED_EVENT", ON_BANNER_AD_LOADED_EVENT );
-        constants.put( "ON_BANNER_AD_LOADFAILED_EVENT", ON_BANNER_AD_LOADFAILED_EVENT );
+        constants.put( "ON_BANNER_AD_LOAD_FAILED_EVENT", ON_BANNER_AD_LOAD_FAILED_EVENT );
         constants.put( "ON_BANNER_AD_CLICKED_EVENT", ON_BANNER_AD_CLICKED_EVENT );
         constants.put( "ON_BANNER_AD_COLLAPSED_EVENT", ON_BANNER_AD_COLLAPSED_EVENT );
         constants.put( "ON_BANNER_AD_EXPANDED_EVENT", ON_BANNER_AD_EXPANDED_EVENT );
         constants.put( "ON_BANNER_AD_REVENUE_PAID", ON_BANNER_AD_REVENUE_PAID );
 
         constants.put( "ON_INTERSTITIAL_LOADED_EVENT", ON_INTERSTITIAL_LOADED_EVENT );
-        constants.put( "ON_INTERSTITIAL_LOADFAILED_EVENT", ON_INTERSTITIAL_LOADFAILED_EVENT );
+        constants.put( "ON_INTERSTITIAL_LOAD_FAILED_EVENT", ON_INTERSTITIAL_LOAD_FAILED_EVENT );
         constants.put( "ON_INTERSTITIAL_CLICKED_EVENT", ON_INTERSTITIAL_CLICKED_EVENT );
         constants.put( "ON_INTERSTITIAL_DISPLAYED_EVENT", ON_INTERSTITIAL_DISPLAYED_EVENT );
-        constants.put( "ON_INTERSTITIAL_AD_FAILEDTODISPLAY_EVENT", ON_INTERSTITIAL_AD_FAILEDTODISPLAY_EVENT );
+        constants.put( "ON_INTERSTITIAL_AD_FAILED_TO_DISPLAY_EVENT", ON_INTERSTITIAL_AD_FAILED_TO_DISPLAY_EVENT );
         constants.put( "ON_INTERSTITIAL_HIDDEN_EVENT", ON_INTERSTITIAL_HIDDEN_EVENT );
         constants.put( "ON_INTERSTITIAL_AD_REVENUE_PAID", ON_INTERSTITIAL_AD_REVENUE_PAID );
 
         constants.put( "ON_REWARDED_AD_LOADED_EVENT", ON_REWARDED_AD_LOADED_EVENT );
-        constants.put( "ON_REWARDED_AD_LOADFAILED_EVENT", ON_REWARDED_AD_LOADFAILED_EVENT );
+        constants.put( "ON_REWARDED_AD_LOAD_FAILED_EVENT", ON_REWARDED_AD_LOAD_FAILED_EVENT );
         constants.put( "ON_REWARDED_AD_CLICKED_EVENT", ON_REWARDED_AD_CLICKED_EVENT );
         constants.put( "ON_REWARDED_AD_DISPLAYED_EVENT", ON_REWARDED_AD_DISPLAYED_EVENT );
-        constants.put( "ON_REWARDED_AD_FAILEDTODISPLAY_EVENT", ON_REWARDED_AD_FAILEDTODISPLAY_EVENT );
+        constants.put( "ON_REWARDED_AD_FAILED_TO_DISPLAY_EVENT", ON_REWARDED_AD_FAILED_TO_DISPLAY_EVENT );
         constants.put( "ON_REWARDED_AD_HIDDEN_EVENT", ON_REWARDED_AD_HIDDEN_EVENT );
-        constants.put( "ON_REWARDED_AD_RECEIVEDREWARD_EVENT", ON_REWARDED_AD_RECEIVEDREWARD_EVENT );
+        constants.put( "ON_REWARDED_AD_RECEIVED_REWARD_EVENT", ON_REWARDED_AD_RECEIVED_REWARD_EVENT );
         constants.put( "ON_REWARDED_AD_REVENUE_PAID", ON_REWARDED_AD_REVENUE_PAID );
 
         constants.put( "ON_APPOPEN_AD_LOADED_EVENT", ON_APPOPEN_AD_LOADED_EVENT );
-        constants.put( "ON_APPOPEN_AD_LOADFAILED_EVENT", ON_APPOPEN_AD_LOADFAILED_EVENT );
+        constants.put( "ON_APPOPEN_AD_LOAD_FAILED_EVENT", ON_APPOPEN_AD_LOAD_FAILED_EVENT );
         constants.put( "ON_APPOPEN_AD_CLICKED_EVENT", ON_APPOPEN_AD_CLICKED_EVENT );
         constants.put( "ON_APPOPEN_AD_DISPLAYED_EVENT", ON_APPOPEN_AD_DISPLAYED_EVENT );
-        constants.put( "ON_APPOPEN_AD_FAILEDTODISPLAY_EVENT", ON_APPOPEN_AD_FAILEDTODISPLAY_EVENT );
+        constants.put( "ON_APPOPEN_AD_FAILED_TO_DISPLAY_EVENT", ON_APPOPEN_AD_FAILED_TO_DISPLAY_EVENT );
         constants.put( "ON_APPOPEN_AD_HIDDEN_EVENT", ON_APPOPEN_AD_HIDDEN_EVENT );
         constants.put( "ON_APPOPEN_AD_REVENUE_PAID", ON_APPOPEN_AD_REVENUE_PAID );
 

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -109,7 +109,7 @@ const App = () => {
 
   const attachAdListeners = () => {
     // Interstitial Listeners
-    AppLovinMAX.addEventListener('OnInterstitialLoadedEvent', (adInfo) => {
+    AppLovinMAX.addInterstitialLoadedEventListener((adInfo) => {
       setInterstitialAdLoadState(adLoadState.loaded);
 
       // Interstitial ad is ready to be shown. AppLovinMAX.isInterstitialReady(INTERSTITIAL_AD_UNIT_ID) will now return 'true'
@@ -118,7 +118,7 @@ const App = () => {
       // Reset retry attempt
       setInterstitialRetryAttempt(0)
     });
-    AppLovinMAX.addEventListener('OnInterstitialLoadFailedEvent', (errorInfo) => {
+    AppLovinMAX.addInterstitialLoadFailedEventListener((errorInfo) => {
       // Interstitial ad failed to load
       // We recommend retrying with exponentially higher delays up to a maximum delay (in this case 64 seconds)
       setInterstitialRetryAttempt(interstitialRetryAttempt + 1);
@@ -130,26 +130,26 @@ const App = () => {
         AppLovinMAX.loadInterstitial(INTERSTITIAL_AD_UNIT_ID);
       }, retryDelay * 1000);
     });
-    AppLovinMAX.addEventListener('OnInterstitialClickedEvent', (adInfo) => {
+    AppLovinMAX.addInterstitialClickedEventListener((adInfo) => {
       setStatusText('Interstitial ad clicked');
     });
-    AppLovinMAX.addEventListener('OnInterstitialDisplayedEvent', (adInfo) => {
+    AppLovinMAX.addInterstitialDisplayedEventListener((adInfo) => {
       setStatusText('Interstitial ad displayed');
     });
-    AppLovinMAX.addEventListener('OnInterstitialAdFailedToDisplayEvent', (adInfo) => {
+    AppLovinMAX.addInterstitialAdFailedToDisplayEventListener((adInfo) => {
       setInterstitialAdLoadState(adLoadState.notLoaded);
       setStatusText('Interstitial ad failed to display');
     });
-    AppLovinMAX.addEventListener('OnInterstitialHiddenEvent', (adInfo) => {
+    AppLovinMAX.addInterstitialHiddenEventListener((adInfo) => {
       setInterstitialAdLoadState(adLoadState.notLoaded);
       setStatusText('Interstitial ad hidden');
     });
-    AppLovinMAX.addEventListener('OnInterstitialAdRevenuePaid', (adInfo) => {
+    AppLovinMAX.addInterstitialAdRevenuePaidListener((adInfo) => {
       setStatusText('Interstitial ad revenue paid: ' + adInfo.revenue);
     });
 
     // Rewarded Ad Listeners
-    AppLovinMAX.addEventListener('OnRewardedAdLoadedEvent', (adInfo) => {
+    AppLovinMAX.addRewardedAdLoadedEventListener((adInfo) => {
       setRewardedAdLoadState(adLoadState.loaded);
 
       // Rewarded ad is ready to be shown. AppLovinMAX.isRewardedAdReady(REWARDED_AD_UNIT_ID) will now return 'true'
@@ -158,7 +158,7 @@ const App = () => {
       // Reset retry attempt
       setRewardedAdRetryAttempt(0);
     });
-    AppLovinMAX.addEventListener('OnRewardedAdLoadFailedEvent', (errorInfo) => {
+    AppLovinMAX.addRewardedAdLoadFailedEventListener((errorInfo) => {
       setRewardedAdLoadState(adLoadState.notLoaded);
 
       // Rewarded ad failed to load
@@ -172,64 +172,64 @@ const App = () => {
         AppLovinMAX.loadRewardedAd(REWARDED_AD_UNIT_ID);
       }, retryDelay * 1000);
     });
-    AppLovinMAX.addEventListener('OnRewardedAdClickedEvent', (adInfo) => {
+    AppLovinMAX.addRewardedAdClickedEventListener((adInfo) => {
       setStatusText('Rewarded ad clicked');
     });
-    AppLovinMAX.addEventListener('OnRewardedAdDisplayedEvent', (adInfo) => {
+    AppLovinMAX.addRewardedAdDisplayedEventListener((adInfo) => {
       setStatusText('Rewarded ad displayed');
     });
-    AppLovinMAX.addEventListener('OnRewardedAdFailedToDisplayEvent', (adInfo) => {
+    AppLovinMAX.addRewardedAdFailedToDisplayEventListener((adInfo) => {
       setRewardedAdLoadState(adLoadState.notLoaded);
       setStatusText('Rewarded ad failed to display');
     });
-    AppLovinMAX.addEventListener('OnRewardedAdHiddenEvent', (adInfo) => {
+    AppLovinMAX.addRewardedAdHiddenEventListener((adInfo) => {
       setRewardedAdLoadState(adLoadState.notLoaded);
       setStatusText('Rewarded ad hidden');
     });
-    AppLovinMAX.addEventListener('OnRewardedAdReceivedRewardEvent', (adInfo) => {
+    AppLovinMAX.addRewardedAdReceivedRewardEventListener((adInfo) => {
       setStatusText('Rewarded ad granted reward');
     });
-    AppLovinMAX.addEventListener('OnRewardedAdRevenuePaid', (adInfo) => {
+    AppLovinMAX.addRewardedAdRevenuePaidListener((adInfo) => {
       setStatusText('Rewarded ad revenue paid: ' + adInfo.revenue);
     });
 
     // Banner Ad Listeners
-    AppLovinMAX.addEventListener('OnBannerAdLoadedEvent', (adInfo) => {
+    AppLovinMAX.addBannerAdLoadedEventListener((adInfo) => {
       setStatusText('Banner ad loaded from ' + adInfo.networkName);
     });
-    AppLovinMAX.addEventListener('OnBannerAdLoadFailedEvent', (errorInfo) => {
+    AppLovinMAX.addBannerAdLoadFailedEventListener((errorInfo) => {
       setStatusText('Banner ad failed to load with error code ' + errorInfo.code + ' and message: ' + errorInfo.message);
     });
-    AppLovinMAX.addEventListener('OnBannerAdClickedEvent', (adInfo) => {
+    AppLovinMAX.addBannerAdClickedEventListener((adInfo) => {
       setStatusText('Banner ad clicked');
     });
-    AppLovinMAX.addEventListener('OnBannerAdExpandedEvent', (adInfo) => {
+    AppLovinMAX.addBannerAdExpandedEventListener((adInfo) => {
       setStatusText('Banner ad expanded')
     });
-    AppLovinMAX.addEventListener('OnBannerAdCollapsedEvent', (adInfo) => {
+    AppLovinMAX.addBannerAdCollapsedEventListener((adInfo) => {
       setStatusText('Banner ad collapsed')
     });
-    AppLovinMAX.addEventListener('OnBannerAdRevenuePaid', (adInfo) => {
+    AppLovinMAX.addBannerAdRevenuePaidListener((adInfo) => {
       setStatusText('Banner ad revenue paid: ' + adInfo.revenue);
     });
 
     // MREC Ad Listeners
-    AppLovinMAX.addEventListener('OnMRecAdLoadedEvent', (adInfo) => {
+    AppLovinMAX.addMRecAdLoadedEventListener((adInfo) => {
       setStatusText('MREC ad loaded from ' + adInfo.networkName);
     });
-    AppLovinMAX.addEventListener('OnMRecAdLoadFailedEvent', (errorInfo) => {
+    AppLovinMAX.addMRecAdLoadFailedEventListener((errorInfo) => {
       setStatusText('MREC ad failed to load with error code ' + errorInfo.code + ' and message: ' + errorInfo.message);
     });
-    AppLovinMAX.addEventListener('OnMRecAdClickedEvent', (adInfo) => {
+    AppLovinMAX.addMRecAdClickedEventListener((adInfo) => {
       setStatusText('MREC ad clicked');
     });
-    AppLovinMAX.addEventListener('OnMRecAdExpandedEvent', (adInfo) => {
+    AppLovinMAX.addMRecAdExpandedEventListener((adInfo) => {
       setStatusText('MREC ad expanded')
     });
-    AppLovinMAX.addEventListener('OnMRecAdCollapsedEvent', (adInfo) => {
+    AppLovinMAX.addMRecAdCollapsedEventListener((adInfo) => {
       setStatusText('MREC ad collapsed')
     });
-    AppLovinMAX.addEventListener('OnMRecAdRevenuePaid', (adInfo) => {
+    AppLovinMAX.addMRecAdRevenuePaidListener((adInfo) => {
       setStatusText('MREC ad revenue paid: ' + adInfo.revenue);
     });
   }

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -85,21 +85,6 @@ const App = () => {
       setIsInitialized(true);
       setStatusText('SDK Initialized');
 
-      if (Platform.OS === 'android') {
-        if (configuration.consentDialogState == AppLovinMAX.ConsentDialogState.APPLIES) {
-          // Show user consent dialog
-          AppLovinMAX.showConsentDialog(() => {
-            setStatusText('Consent dialog closed');
-          });
-        } else if (configuration.consentDialogState == AppLovinMAX.ConsentDialogState.DOES_NOT_APPLY) {
-          // No need to show consent dialog, proceed with initialization
-        } else {
-          // Consent dialog state is unknown. Proceed with initialization, but check if the consent
-          // dialog should be shown on the next application initialization
-          // No need to show consent dialog, proceed with initialization
-        }
-      }
-
       // Attach ad listeners for interstitial ads, rewarded ads, and banner ads
       attachAdListeners();
     }).catch(error => {

--- a/ios/AppLovinMAX.m
+++ b/ios/AppLovinMAX.m
@@ -311,8 +311,7 @@ RCT_EXPORT_METHOD(initialize:(NSString *)pluginVersion :(NSString *)sdkKey :(RCT
         self.sdkConfiguration = configuration;
         self.sdkInitialized = YES;
         
-        resolve(@[@{@"consentDialogState" : @(configuration.consentDialogState),
-                    @"countryCode" : self.sdk.configuration.countryCode}]);
+        resolve(@[@{@"countryCode" : self.sdk.configuration.countryCode}]);
     }];
 }
 
@@ -337,11 +336,6 @@ RCT_EXPORT_METHOD(showMediationDebugger)
 RCT_EXPORT_METHOD(showConsentDialog:(RCTPromiseResolveBlock)resolve :(RCTPromiseRejectBlock)reject)
 {
     reject(RCTErrorUnspecified, @"Failed to show consent dialog - Unavailable on iOS, please use the consent flow: https://dash.applovin.com/documentation/mediation/react-native/getting-started/consent-flow", nil);
-}
-
-RCT_EXPORT_METHOD(getConsentDialogState:(RCTPromiseResolveBlock)resolve :(RCTPromiseRejectBlock)reject)
-{
-    resolve([self isSDKInitialized] ? @(self.sdkConfiguration.consentDialogState) : @(ALConsentDialogStateUnknown));
 }
 
 RCT_EXPORT_METHOD(setHasUserConsent:(BOOL)hasUserConsent)
@@ -1832,11 +1826,7 @@ RCT_EXPORT_METHOD(setAppOpenAdExtraParameter:(NSString *)adUnitIdentifier key:(N
              @"BOTTOM_RIGHT_POSITION" : BOTTOM_RIGHT,
              
              @"BANNER_AD_FORMAT_LABEL" : MAAdFormat.banner.label,
-             @"MREC_AD_FORMAT_LABEL" : MAAdFormat.mrec.label,
-             
-             @"CONSENT_DIALOG_STATE_UNKNOWN" : @(ALConsentDialogStateUnknown),
-             @"CONSENT_DIALOG_STATE_APPLIES" : @(ALConsentDialogStateApplies),
-             @"CONSENT_DIALOG_STATE_DOES_NOT_APPLY" : @(ALConsentDialogStateDoesNotApply)};
+             @"MREC_AD_FORMAT_LABEL" : MAAdFormat.mrec.label};
 }
 
 - (void)startObserving

--- a/ios/AppLovinMAX.m
+++ b/ios/AppLovinMAX.m
@@ -82,6 +82,55 @@
 static NSString *const SDK_TAG = @"AppLovinSdk";
 static NSString *const TAG = @"AppLovinMAX";
 
+static NSString *const ON_BANNER_AD_LOADED_EVENT = @"OnBannerAdLoadedEvent";
+static NSString *const ON_BANNER_AD_LOADFAILED_EVENT = @"OnBannerAdLoadFailedEvent";
+static NSString *const ON_BANNER_AD_CLICKED_EVENT = @"OnBannerAdClickedEvent";
+static NSString *const ON_BANNER_AD_COLLAPSED_EVENT = @"OnBannerAdCollapsedEvent";
+static NSString *const ON_BANNER_AD_EXPANDED_EVENT = @"OnBannerAdExpandedEvent";
+static NSString *const ON_BANNER_AD_REVENUE_PAID = @"OnBannerAdRevenuePaid";
+
+static NSString *const ON_MREC_AD_LOADED_EVENT = @"OnMRecAdLoadedEvent";
+static NSString *const ON_MREC_AD_LOADFAILED_EVENT = @"OnMRecAdLoadFailedEvent";
+static NSString *const ON_MREC_AD_CLICKED_EVENT= @"OnMRecAdClickedEvent";
+static NSString *const ON_MREC_AD_COLLAPSED_EVENT = @"OnMRecAdCollapsedEvent";
+static NSString *const ON_MREC_AD_EXPANDED_EVENT = @"OnMRecAdExpandedEvent";
+static NSString *const ON_MREC_AD_REVENUE_PAID = @"OnMRecAdRevenuePaid";
+
+static NSString *const ON_INTERSTITIAL_LOADED_EVENT = @"OnInterstitialLoadedEvent";
+static NSString *const ON_INTERSTITIAL_LOADFAILED_EVENT = @"OnInterstitialLoadFailedEvent";
+static NSString *const ON_INTERSTITIAL_CLICKED_EVENT = @"OnInterstitialClickedEvent";
+static NSString *const ON_INTERSTITIAL_DISPLAYED_EVENT = @"OnInterstitialDisplayedEvent";
+static NSString *const ON_INTERSTITIAL_AD_FAILEDTODISPLAY_EVENT = @"OnInterstitialAdFailedToDisplayEvent";
+static NSString *const ON_INTERSTITIAL_HIDDEN_EVENT = @"OnInterstitialHiddenEvent";
+static NSString *const ON_INTERSTITIAL_AD_REVENUE_PAID = @"OnInterstitialAdRevenuePaid";
+
+static NSString *const ON_REWARDED_AD_LOADED_EVENT = @"OnRewardedAdLoadedEvent";
+static NSString *const ON_REWARDED_AD_LOADFAILED_EVENT = @"OnRewardedAdLoadFailedEvent";
+static NSString *const ON_REWARDED_AD_CLICKED_EVENT = @"OnRewardedAdClickedEvent";
+static NSString *const ON_REWARDED_AD_DISPLAYED_EVENT = @"OnRewardedAdDisplayedEvent";
+static NSString *const ON_REWARDED_AD_FAILEDTODISPLAY_EVENT = @"OnRewardedAdFailedToDisplayEvent";
+static NSString *const ON_REWARDED_AD_HIDDEN_EVENT = @"OnRewardedAdHiddenEvent";
+static NSString *const ON_REWARDED_AD_RECEIVEDREWARD_EVENT = @"OnRewardedAdReceivedRewardEvent";
+static NSString *const ON_REWARDED_AD_REVENUE_PAID = @"OnRewardedAdRevenuePaid";
+
+static NSString *const ON_APPOPEN_AD_LOADED_EVENT = @"OnAppOpenAdLoadedEvent";
+static NSString *const ON_APPOPEN_AD_LOADFAILED_EVENT = @"OnAppOpenAdLoadFailedEvent";
+static NSString *const ON_APPOPEN_AD_CLICKED_EVENT = @"OnAppOpenAdClickedEvent";
+static NSString *const ON_APPOPEN_AD_DISPLAYED_EVENT = @"OnAppOpenAdDisplayedEvent";
+static NSString *const ON_APPOPEN_AD_FAILEDTODISPLAY_EVENT = @"OnAppOpenAdFailedToDisplayEvent";
+static NSString *const ON_APPOPEN_AD_HIDDEN_EVENT = @"OnAppOpenAdHiddenEvent";
+static NSString *const ON_APPOPEN_AD_REVENUE_PAID = @"OnAppOpenAdRevenuePaid";
+
+static NSString *const TOP_CENTER = @"top_center";
+static NSString *const TOP_LEFT = @"top_left";
+static NSString *const TOP_RIGHT = @"top_right";
+static NSString *const CENTERED = @"centered";
+static NSString *const CENTER_LEFT = @"center_left";
+static NSString *const CENTER_RIGHT = @"center_right";
+static NSString *const BOTTOM_LEFT = @"bottom_left";
+static NSString *const BOTTOM_CENTER = @"bottom_center";
+static NSString *const BOTTOM_RIGHT = @"bottom_right";
+
 static AppLovinMAX *AppLovinMAXShared; // Shared instance of this bridge module.
 
 // To export a module named AppLovinMAX ("RCT" automatically removed)
@@ -755,7 +804,7 @@ RCT_EXPORT_METHOD(setAppOpenAdExtraParameter:(NSString *)adUnitIdentifier key:(N
         // An ad is now being shown, enable user interaction.
         adView.userInteractionEnabled = YES;
         
-        name = ( MAAdFormat.mrec == adFormat ) ? @"OnMRecAdLoadedEvent" : @"OnBannerAdLoadedEvent";
+        name = ( MAAdFormat.mrec == adFormat ) ? ON_MREC_AD_LOADED_EVENT : ON_BANNER_AD_LOADED_EVENT;
         [self positionAdViewForAd: ad];
         
         // Do not auto-refresh by default if the ad view is not showing yet (e.g. first load during app launch and publisher does not automatically show banner upon load success)
@@ -767,15 +816,15 @@ RCT_EXPORT_METHOD(setAppOpenAdExtraParameter:(NSString *)adUnitIdentifier key:(N
     }
     else if ( MAAdFormat.interstitial == adFormat )
     {
-        name = @"OnInterstitialLoadedEvent";
+        name = ON_INTERSTITIAL_LOADED_EVENT;
     }
     else if ( MAAdFormat.rewarded == adFormat )
     {
-        name = @"OnRewardedAdLoadedEvent";
+        name = ON_REWARDED_AD_LOADED_EVENT;
     }
     else if ( MAAdFormat.appOpen == adFormat )
     {
-        name = @"OnAppOpenAdLoadedEvent";
+        name = ON_APPOPEN_AD_LOADED_EVENT;
     }
     else
     {
@@ -801,15 +850,15 @@ RCT_EXPORT_METHOD(setAppOpenAdExtraParameter:(NSString *)adUnitIdentifier key:(N
     }
     else if ( self.interstitials[adUnitIdentifier] )
     {
-        name = @"OnInterstitialLoadFailedEvent";
+        name = ON_INTERSTITIAL_LOADFAILED_EVENT;
     }
     else if ( self.rewardedAds[adUnitIdentifier] )
     {
-        name = @"OnRewardedAdLoadFailedEvent";
+        name = ON_REWARDED_AD_LOADFAILED_EVENT;
     }
     else if ( self.appOpenAds[adUnitIdentifier] )
     {
-        name = @"OnAppOpenAdLoadFailedEvent";
+        name = ON_APPOPEN_AD_LOADFAILED_EVENT;
     }
     else
     {
@@ -826,23 +875,23 @@ RCT_EXPORT_METHOD(setAppOpenAdExtraParameter:(NSString *)adUnitIdentifier key:(N
     MAAdFormat *adFormat = ad.format;
     if ( MAAdFormat.banner == adFormat || MAAdFormat.leader == adFormat )
     {
-        name = @"OnBannerAdClickedEvent";
+        name = ON_BANNER_AD_CLICKED_EVENT;
     }
     else if ( MAAdFormat.mrec == adFormat )
     {
-        name = @"OnMRecAdClickedEvent";
+        name = ON_MREC_AD_CLICKED_EVENT;
     }
     else if ( MAAdFormat.interstitial == adFormat )
     {
-        name = @"OnInterstitialClickedEvent";
+        name = ON_INTERSTITIAL_CLICKED_EVENT;
     }
     else if ( MAAdFormat.rewarded == adFormat )
     {
-        name = @"OnRewardedAdClickedEvent";
+        name = ON_REWARDED_AD_CLICKED_EVENT;
     }
     else if ( MAAdFormat.appOpen == adFormat )
     {
-        name = @"OnAppOpenAdClickedEvent";
+        name = ON_APPOPEN_AD_CLICKED_EVENT;
     }
     else
     {
@@ -862,15 +911,15 @@ RCT_EXPORT_METHOD(setAppOpenAdExtraParameter:(NSString *)adUnitIdentifier key:(N
     NSString *name;
     if ( MAAdFormat.interstitial == adFormat )
     {
-        name = @"OnInterstitialDisplayedEvent";
+        name = ON_INTERSTITIAL_DISPLAYED_EVENT;
     }
     else if ( MAAdFormat.rewarded == adFormat )
     {
-        name = @"OnRewardedAdDisplayedEvent";
+        name = ON_REWARDED_AD_DISPLAYED_EVENT;
     }
     else // APP OPEN
     {
-        name = @"OnAppOpenAdDisplayedEvent";
+        name = ON_APPOPEN_AD_DISPLAYED_EVENT;
     }
     
     [self sendReactNativeEventWithName: name body: [self adInfoForAd: ad]];
@@ -885,15 +934,15 @@ RCT_EXPORT_METHOD(setAppOpenAdExtraParameter:(NSString *)adUnitIdentifier key:(N
     NSString *name;
     if ( MAAdFormat.interstitial == adFormat )
     {
-        name = @"OnInterstitialAdFailedToDisplayEvent";
+        name = ON_INTERSTITIAL_AD_FAILEDTODISPLAY_EVENT;
     }
     else if ( MAAdFormat.rewarded == adFormat )
     {
-        name = @"OnRewardedAdFailedToDisplayEvent";
+        name = ON_REWARDED_AD_FAILEDTODISPLAY_EVENT;
     }
     else // APP OPEN
     {
-        name = @"OnAppOpenAdFailedToDisplayEvent";
+        name = ON_APPOPEN_AD_FAILEDTODISPLAY_EVENT;
     }
     
     [self sendReactNativeEventWithName: name body: [self adDisplayFailedInfoForAd: ad withError: error]];
@@ -908,15 +957,15 @@ RCT_EXPORT_METHOD(setAppOpenAdExtraParameter:(NSString *)adUnitIdentifier key:(N
     NSString *name;
     if ( MAAdFormat.interstitial == adFormat )
     {
-        name = @"OnInterstitialHiddenEvent";
+        name = ON_INTERSTITIAL_HIDDEN_EVENT;
     }
     else if ( MAAdFormat.rewarded == adFormat )
     {
-        name = @"OnRewardedAdHiddenEvent";
+        name = ON_REWARDED_AD_HIDDEN_EVENT;
     }
     else // APP OPEN
     {
-        name = @"OnAppOpenAdHiddenEvent";
+        name = ON_APPOPEN_AD_HIDDEN_EVENT;
     }
     
     [self sendReactNativeEventWithName: name body: [self adInfoForAd: ad]];
@@ -931,7 +980,7 @@ RCT_EXPORT_METHOD(setAppOpenAdExtraParameter:(NSString *)adUnitIdentifier key:(N
         return;
     }
     
-    [self sendReactNativeEventWithName: ( MAAdFormat.mrec == adFormat ) ? @"OnMRecAdExpandedEvent" : @"OnBannerAdExpandedEvent"
+    [self sendReactNativeEventWithName: ( MAAdFormat.mrec == adFormat ) ? ON_MREC_AD_EXPANDED_EVENT : ON_BANNER_AD_EXPANDED_EVENT
                                   body: [self adInfoForAd: ad]];
 }
 
@@ -944,7 +993,7 @@ RCT_EXPORT_METHOD(setAppOpenAdExtraParameter:(NSString *)adUnitIdentifier key:(N
         return;
     }
     
-    [self sendReactNativeEventWithName: ( MAAdFormat.mrec == adFormat ) ? @"OnMRecAdCollapsedEvent" : @"OnBannerAdCollapsedEvent"
+    [self sendReactNativeEventWithName: ( MAAdFormat.mrec == adFormat ) ? ON_MREC_AD_COLLAPSED_EVENT : ON_BANNER_AD_COLLAPSED_EVENT
                                   body: [self adInfoForAd: ad]];
 }
 
@@ -954,23 +1003,23 @@ RCT_EXPORT_METHOD(setAppOpenAdExtraParameter:(NSString *)adUnitIdentifier key:(N
     MAAdFormat *adFormat = ad.format;
     if ( MAAdFormat.banner == adFormat || MAAdFormat.leader == adFormat )
     {
-        name = @"OnBannerAdRevenuePaid";
+        name = ON_BANNER_AD_REVENUE_PAID;
     }
     else if ( MAAdFormat.mrec == adFormat )
     {
-        name = @"OnMRecAdRevenuePaid";
+        name = ON_MREC_AD_REVENUE_PAID;
     }
     else if ( MAAdFormat.interstitial == adFormat )
     {
-        name = @"OnInterstitialAdRevenuePaid";
+        name = ON_INTERSTITIAL_AD_REVENUE_PAID;
     }
     else if ( MAAdFormat.rewarded == adFormat )
     {
-        name = @"OnRewardedAdRevenuePaid";
+        name = ON_REWARDED_AD_REVENUE_PAID;
     }
     else if ( MAAdFormat.appOpen == adFormat )
     {
-        name = @"OnAppOpenAdRevenuePaid";
+        name = ON_APPOPEN_AD_REVENUE_PAID;
     }
     else
     {
@@ -1008,7 +1057,7 @@ RCT_EXPORT_METHOD(setAppOpenAdExtraParameter:(NSString *)adUnitIdentifier key:(N
                                    @"rewardAmount": rewardAmount} mutableCopy];
     [body addEntriesFromDictionary: [self adInfoForAd: ad]];
     
-    [self sendReactNativeEventWithName: @"OnRewardedAdReceivedRewardEvent" body: body];
+    [self sendReactNativeEventWithName: ON_REWARDED_AD_RECEIVEDREWARD_EVENT body: body];
 }
 
 #pragma mark - Internal Methods
@@ -1363,7 +1412,7 @@ RCT_EXPORT_METHOD(setAppOpenAdExtraParameter:(NSString *)adUnitIdentifier key:(N
         adViewWidth = self.adViewWidths[adUnitIdentifier].floatValue;
     }
     // Top center / bottom center stretches full screen
-    else if ( [adViewPosition isEqual: @"top_center"] || [adViewPosition isEqual: @"bottom_center"] )
+    else if ( [adViewPosition isEqual: TOP_CENTER] || [adViewPosition isEqual: BOTTOM_CENTER] )
     {
         adViewWidth = CGRectGetWidth(KEY_WINDOW.bounds);
     }
@@ -1403,14 +1452,14 @@ RCT_EXPORT_METHOD(setAppOpenAdExtraParameter:(NSString *)adUnitIdentifier key:(N
     }
     
     // If top of bottom center, stretch width of screen
-    if ( [adViewPosition isEqual: @"top_center"] || [adViewPosition isEqual: @"bottom_center"] )
+    if ( [adViewPosition isEqual: TOP_CENTER] || [adViewPosition isEqual: BOTTOM_CENTER] )
     {
         // Non AdMob banners will still be of 50/90 points tall. Set the auto sizing mask such that the inner ad view is pinned to the bottom or top according to the ad view position.
         if ( !isAdaptiveBannerDisabled )
         {
             adView.autoresizingMask = UIViewAutoresizingFlexibleWidth;
             
-            if ( [@"top_center" isEqual: adViewPosition] )
+            if ( [TOP_CENTER isEqual: adViewPosition] )
             {
                 adView.autoresizingMask |= UIViewAutoresizingFlexibleBottomMargin;
             }
@@ -1428,7 +1477,7 @@ RCT_EXPORT_METHOD(setAppOpenAdExtraParameter:(NSString *)adUnitIdentifier key:(N
                                                 [self.safeAreaBackground.widthAnchor constraintEqualToConstant: adViewWidth],
                                                 [self.safeAreaBackground.centerXAnchor constraintEqualToAnchor: layoutGuide.centerXAnchor]]];
             
-            if ( [adViewPosition isEqual: @"top_center"] )
+            if ( [adViewPosition isEqual: TOP_CENTER] )
             {
                 [constraints addObjectsFromArray: @[[adView.topAnchor constraintEqualToAnchor: layoutGuide.topAnchor],
                                                     [self.safeAreaBackground.topAnchor constraintEqualToAnchor: superview.topAnchor],
@@ -1450,7 +1499,7 @@ RCT_EXPORT_METHOD(setAppOpenAdExtraParameter:(NSString *)adUnitIdentifier key:(N
             [constraints addObjectsFromArray: @[[adView.widthAnchor constraintEqualToConstant: adViewWidth],
                                                 [adView.centerXAnchor constraintEqualToAnchor: layoutGuide.centerXAnchor]]];
             
-            if ( [adViewPosition isEqual: @"top_center"] )
+            if ( [adViewPosition isEqual: TOP_CENTER] )
             {
                 [constraints addObject: [adView.topAnchor constraintEqualToAnchor: layoutGuide.topAnchor constant: yOffset]];
             }
@@ -1468,27 +1517,27 @@ RCT_EXPORT_METHOD(setAppOpenAdExtraParameter:(NSString *)adUnitIdentifier key:(N
         // Assign constant width of 320 or 728
         [constraints addObject: [adView.widthAnchor constraintEqualToConstant: adViewWidth]];
         
-        if ( [adViewPosition isEqual: @"top_left"] )
+        if ( [adViewPosition isEqual: TOP_LEFT] )
         {
             [constraints addObjectsFromArray: @[[adView.topAnchor constraintEqualToAnchor: layoutGuide.topAnchor constant: yOffset],
                                                 [adView.leftAnchor constraintEqualToAnchor: superview.leftAnchor constant: xOffset]]];
         }
-        else if ( [adViewPosition isEqual: @"top_right"] )
+        else if ( [adViewPosition isEqual: TOP_RIGHT] )
         {
             [constraints addObjectsFromArray: @[[adView.topAnchor constraintEqualToAnchor: layoutGuide.topAnchor constant: yOffset],
                                                 [adView.rightAnchor constraintEqualToAnchor: superview.rightAnchor constant: xOffset]]];
         }
-        else if ( [adViewPosition isEqual: @"centered"] )
+        else if ( [adViewPosition isEqual: CENTERED] )
         {
             [constraints addObjectsFromArray: @[[adView.centerXAnchor constraintEqualToAnchor: layoutGuide.centerXAnchor],
                                                 [adView.centerYAnchor constraintEqualToAnchor: layoutGuide.centerYAnchor]]];
         }
-        else if ( [adViewPosition isEqual: @"bottom_left"] )
+        else if ( [adViewPosition isEqual: BOTTOM_LEFT] )
         {
             [constraints addObjectsFromArray: @[[adView.bottomAnchor constraintEqualToAnchor: layoutGuide.bottomAnchor constant: yOffset],
                                                 [adView.leftAnchor constraintEqualToAnchor: superview.leftAnchor constant: xOffset]]];
         }
-        else if ( [adViewPosition isEqual: @"bottom_right"] )
+        else if ( [adViewPosition isEqual: BOTTOM_RIGHT] )
         {
             [constraints addObjectsFromArray: @[[adView.bottomAnchor constraintEqualToAnchor: layoutGuide.bottomAnchor constant: yOffset],
                                                 [adView.rightAnchor constraintEqualToAnchor: superview.rightAnchor constant: xOffset]]];
@@ -1691,44 +1740,103 @@ RCT_EXPORT_METHOD(setAppOpenAdExtraParameter:(NSString *)adUnitIdentifier key:(N
 // From RCTBridgeModule protocol
 - (NSArray<NSString *> *)supportedEvents
 {
-    return @[@"OnMRecAdLoadedEvent",
-             @"OnMRecAdLoadFailedEvent",
-             @"OnMRecAdClickedEvent",
-             @"OnMRecAdCollapsedEvent",
-             @"OnMRecAdExpandedEvent",
-             @"OnMRecAdRevenuePaid",
+    return @[ON_MREC_AD_LOADED_EVENT,
+             ON_MREC_AD_LOADFAILED_EVENT,
+             ON_MREC_AD_CLICKED_EVENT,
+             ON_MREC_AD_COLLAPSED_EVENT,
+             ON_MREC_AD_EXPANDED_EVENT,
+             ON_MREC_AD_REVENUE_PAID,
              
-             @"OnBannerAdLoadedEvent",
-             @"OnBannerAdLoadFailedEvent",
-             @"OnBannerAdClickedEvent",
-             @"OnBannerAdCollapsedEvent",
-             @"OnBannerAdExpandedEvent",
-             @"OnBannerAdRevenuePaid",
+             ON_BANNER_AD_LOADED_EVENT,
+             ON_BANNER_AD_LOADFAILED_EVENT,
+             ON_BANNER_AD_CLICKED_EVENT,
+             ON_BANNER_AD_COLLAPSED_EVENT,
+             ON_BANNER_AD_EXPANDED_EVENT,
+             ON_BANNER_AD_REVENUE_PAID,
              
-             @"OnInterstitialLoadedEvent",
-             @"OnInterstitialLoadFailedEvent",
-             @"OnInterstitialClickedEvent",
-             @"OnInterstitialDisplayedEvent",
-             @"OnInterstitialAdFailedToDisplayEvent",
-             @"OnInterstitialHiddenEvent",
-             @"OnInterstitialAdRevenuePaid",
+             ON_INTERSTITIAL_LOADED_EVENT,
+             ON_INTERSTITIAL_LOADFAILED_EVENT,
+             ON_INTERSTITIAL_CLICKED_EVENT,
+             ON_INTERSTITIAL_DISPLAYED_EVENT,
+             ON_INTERSTITIAL_AD_FAILEDTODISPLAY_EVENT,
+             ON_INTERSTITIAL_HIDDEN_EVENT,
+             ON_INTERSTITIAL_AD_REVENUE_PAID,
              
-             @"OnRewardedAdLoadedEvent",
-             @"OnRewardedAdLoadFailedEvent",
-             @"OnRewardedAdClickedEvent",
-             @"OnRewardedAdDisplayedEvent",
-             @"OnRewardedAdFailedToDisplayEvent",
-             @"OnRewardedAdHiddenEvent",
-             @"OnRewardedAdReceivedRewardEvent",
-             @"OnRewardedAdRevenuePaid",
+             ON_REWARDED_AD_LOADED_EVENT,
+             ON_REWARDED_AD_LOADFAILED_EVENT,
+             ON_REWARDED_AD_CLICKED_EVENT,
+             ON_REWARDED_AD_DISPLAYED_EVENT,
+             ON_REWARDED_AD_FAILEDTODISPLAY_EVENT,
+             ON_REWARDED_AD_HIDDEN_EVENT,
+             ON_REWARDED_AD_RECEIVEDREWARD_EVENT,
+             ON_REWARDED_AD_REVENUE_PAID,
              
-             @"OnAppOpenAdLoadedEvent",
-             @"OnAppOpenAdLoadFailedEvent",
-             @"OnAppOpenAdClickedEvent",
-             @"OnAppOpenAdDisplayedEvent",
-             @"OnAppOpenAdFailedToDisplayEvent",
-             @"OnAppOpenAdHiddenEvent",
-             @"OnAppOpenAdRevenuePaid"];
+             ON_APPOPEN_AD_LOADED_EVENT,
+             ON_APPOPEN_AD_LOADFAILED_EVENT,
+             ON_APPOPEN_AD_CLICKED_EVENT,
+             ON_APPOPEN_AD_DISPLAYED_EVENT,
+             ON_APPOPEN_AD_FAILEDTODISPLAY_EVENT,
+             ON_APPOPEN_AD_HIDDEN_EVENT,
+             ON_APPOPEN_AD_REVENUE_PAID];
+}
+
+- (NSDictionary *)constantsToExport
+{
+    return @{@"ON_MREC_AD_LOADED_EVENT": ON_MREC_AD_LOADED_EVENT,
+             @"ON_MREC_AD_LOADFAILED_EVENT" : ON_MREC_AD_LOADFAILED_EVENT,
+             @"ON_MREC_AD_CLICKED_EVENT" : ON_MREC_AD_CLICKED_EVENT,
+             @"ON_MREC_AD_COLLAPSED_EVENT" : ON_MREC_AD_COLLAPSED_EVENT,
+             @"ON_MREC_AD_EXPANDED_EVENT" : ON_MREC_AD_EXPANDED_EVENT,
+             @"ON_MREC_AD_REVENUE_PAID" : ON_MREC_AD_REVENUE_PAID,
+             
+             @"ON_BANNER_AD_LOADED_EVENT" : ON_BANNER_AD_LOADED_EVENT,
+             @"ON_BANNER_AD_LOADFAILED_EVENT" : ON_BANNER_AD_LOADFAILED_EVENT,
+             @"ON_BANNER_AD_CLICKED_EVENT" : ON_BANNER_AD_CLICKED_EVENT,
+             @"ON_BANNER_AD_COLLAPSED_EVENT" : ON_BANNER_AD_COLLAPSED_EVENT,
+             @"ON_BANNER_AD_EXPANDED_EVENT" : ON_BANNER_AD_EXPANDED_EVENT,
+             @"ON_BANNER_AD_REVENUE_PAID" : ON_BANNER_AD_REVENUE_PAID,
+             
+             @"ON_INTERSTITIAL_LOADED_EVENT" : ON_INTERSTITIAL_LOADED_EVENT,
+             @"ON_INTERSTITIAL_LOADFAILED_EVENT" : ON_INTERSTITIAL_LOADFAILED_EVENT,
+             @"ON_INTERSTITIAL_CLICKED_EVENT" : ON_INTERSTITIAL_CLICKED_EVENT,
+             @"ON_INTERSTITIAL_DISPLAYED_EVENT" : ON_INTERSTITIAL_DISPLAYED_EVENT,
+             @"ON_INTERSTITIAL_AD_FAILEDTODISPLAY_EVENT" : ON_INTERSTITIAL_AD_FAILEDTODISPLAY_EVENT,
+             @"ON_INTERSTITIAL_HIDDEN_EVENT" : ON_INTERSTITIAL_HIDDEN_EVENT,
+             @"ON_INTERSTITIAL_AD_REVENUE_PAID" : ON_INTERSTITIAL_AD_REVENUE_PAID,
+             
+             @"ON_REWARDED_AD_LOADED_EVENT" : ON_REWARDED_AD_LOADED_EVENT,
+             @"ON_REWARDED_AD_LOADFAILED_EVENT" : ON_REWARDED_AD_LOADFAILED_EVENT,
+             @"ON_REWARDED_AD_CLICKED_EVENT" : ON_REWARDED_AD_CLICKED_EVENT,
+             @"ON_REWARDED_AD_DISPLAYED_EVENT" : ON_REWARDED_AD_DISPLAYED_EVENT,
+             @"ON_REWARDED_AD_FAILEDTODISPLAY_EVENT" : ON_REWARDED_AD_FAILEDTODISPLAY_EVENT,
+             @"ON_REWARDED_AD_HIDDEN_EVENT" : ON_REWARDED_AD_HIDDEN_EVENT,
+             @"ON_REWARDED_AD_RECEIVEDREWARD_EVENT" : ON_REWARDED_AD_RECEIVEDREWARD_EVENT,
+             @"ON_REWARDED_AD_REVENUE_PAID" : ON_REWARDED_AD_REVENUE_PAID,
+             
+             @"ON_APPOPEN_AD_LOADED_EVENT" : ON_APPOPEN_AD_LOADED_EVENT,
+             @"ON_APPOPEN_AD_LOADFAILED_EVENT" : ON_APPOPEN_AD_LOADFAILED_EVENT,
+             @"ON_APPOPEN_AD_CLICKED_EVENT" : ON_APPOPEN_AD_CLICKED_EVENT,
+             @"ON_APPOPEN_AD_DISPLAYED_EVENT" : ON_APPOPEN_AD_DISPLAYED_EVENT,
+             @"ON_APPOPEN_AD_FAILEDTODISPLAY_EVENT" : ON_APPOPEN_AD_FAILEDTODISPLAY_EVENT,
+             @"ON_APPOPEN_AD_HIDDEN_EVENT" : ON_APPOPEN_AD_HIDDEN_EVENT,
+             @"ON_APPOPEN_AD_REVENUE_PAID" : ON_APPOPEN_AD_REVENUE_PAID,
+             
+             @"TOP_CENTER_POSITION" : TOP_CENTER,
+             @"TOP_LEFT_POSITION" : TOP_LEFT,
+             @"TOP_RIGHT_POSITION" : TOP_RIGHT,
+             @"CENTERED_POSITION" : CENTERED,
+             @"CENTER_LEFT_POSITION" : CENTER_LEFT,
+             @"CENTER_RIGHT_POSITION" : CENTER_RIGHT,
+             @"BOTTOM_LEFT_POSITION" : BOTTOM_LEFT,
+             @"BOTTOM_CENTER_POSITION" : BOTTOM_CENTER,
+             @"BOTTOM_RIGHT_POSITION" : BOTTOM_RIGHT,
+             
+             @"BANNER_AD_FORMAT_LABEL" : MAAdFormat.banner.label,
+             @"MREC_AD_FORMAT_LABEL" : MAAdFormat.mrec.label,
+             
+             @"CONSENT_DIALOG_STATE_UNKNOWN" : @(ALConsentDialogStateUnknown),
+             @"CONSENT_DIALOG_STATE_APPLIES" : @(ALConsentDialogStateApplies),
+             @"CONSENT_DIALOG_STATE_DOES_NOT_APPLY" : @(ALConsentDialogStateDoesNotApply)};
 }
 
 - (void)startObserving

--- a/ios/AppLovinMAX.m
+++ b/ios/AppLovinMAX.m
@@ -83,41 +83,41 @@ static NSString *const SDK_TAG = @"AppLovinSdk";
 static NSString *const TAG = @"AppLovinMAX";
 
 static NSString *const ON_BANNER_AD_LOADED_EVENT = @"OnBannerAdLoadedEvent";
-static NSString *const ON_BANNER_AD_LOADFAILED_EVENT = @"OnBannerAdLoadFailedEvent";
+static NSString *const ON_BANNER_AD_LOAD_FAILED_EVENT = @"OnBannerAdLoadFailedEvent";
 static NSString *const ON_BANNER_AD_CLICKED_EVENT = @"OnBannerAdClickedEvent";
 static NSString *const ON_BANNER_AD_COLLAPSED_EVENT = @"OnBannerAdCollapsedEvent";
 static NSString *const ON_BANNER_AD_EXPANDED_EVENT = @"OnBannerAdExpandedEvent";
 static NSString *const ON_BANNER_AD_REVENUE_PAID = @"OnBannerAdRevenuePaid";
 
 static NSString *const ON_MREC_AD_LOADED_EVENT = @"OnMRecAdLoadedEvent";
-static NSString *const ON_MREC_AD_LOADFAILED_EVENT = @"OnMRecAdLoadFailedEvent";
+static NSString *const ON_MREC_AD_LOAD_FAILED_EVENT = @"OnMRecAdLoadFailedEvent";
 static NSString *const ON_MREC_AD_CLICKED_EVENT= @"OnMRecAdClickedEvent";
 static NSString *const ON_MREC_AD_COLLAPSED_EVENT = @"OnMRecAdCollapsedEvent";
 static NSString *const ON_MREC_AD_EXPANDED_EVENT = @"OnMRecAdExpandedEvent";
 static NSString *const ON_MREC_AD_REVENUE_PAID = @"OnMRecAdRevenuePaid";
 
 static NSString *const ON_INTERSTITIAL_LOADED_EVENT = @"OnInterstitialLoadedEvent";
-static NSString *const ON_INTERSTITIAL_LOADFAILED_EVENT = @"OnInterstitialLoadFailedEvent";
+static NSString *const ON_INTERSTITIAL_LOAD_FAILED_EVENT = @"OnInterstitialLoadFailedEvent";
 static NSString *const ON_INTERSTITIAL_CLICKED_EVENT = @"OnInterstitialClickedEvent";
 static NSString *const ON_INTERSTITIAL_DISPLAYED_EVENT = @"OnInterstitialDisplayedEvent";
-static NSString *const ON_INTERSTITIAL_AD_FAILEDTODISPLAY_EVENT = @"OnInterstitialAdFailedToDisplayEvent";
+static NSString *const ON_INTERSTITIAL_AD_FAILED_TO_DISPLAY_EVENT = @"OnInterstitialAdFailedToDisplayEvent";
 static NSString *const ON_INTERSTITIAL_HIDDEN_EVENT = @"OnInterstitialHiddenEvent";
 static NSString *const ON_INTERSTITIAL_AD_REVENUE_PAID = @"OnInterstitialAdRevenuePaid";
 
 static NSString *const ON_REWARDED_AD_LOADED_EVENT = @"OnRewardedAdLoadedEvent";
-static NSString *const ON_REWARDED_AD_LOADFAILED_EVENT = @"OnRewardedAdLoadFailedEvent";
+static NSString *const ON_REWARDED_AD_LOAD_FAILED_EVENT = @"OnRewardedAdLoadFailedEvent";
 static NSString *const ON_REWARDED_AD_CLICKED_EVENT = @"OnRewardedAdClickedEvent";
 static NSString *const ON_REWARDED_AD_DISPLAYED_EVENT = @"OnRewardedAdDisplayedEvent";
-static NSString *const ON_REWARDED_AD_FAILEDTODISPLAY_EVENT = @"OnRewardedAdFailedToDisplayEvent";
+static NSString *const ON_REWARDED_AD_FAILED_TO_DISPLAY_EVENT = @"OnRewardedAdFailedToDisplayEvent";
 static NSString *const ON_REWARDED_AD_HIDDEN_EVENT = @"OnRewardedAdHiddenEvent";
-static NSString *const ON_REWARDED_AD_RECEIVEDREWARD_EVENT = @"OnRewardedAdReceivedRewardEvent";
+static NSString *const ON_REWARDED_AD_RECEIVED_REWARD_EVENT = @"OnRewardedAdReceivedRewardEvent";
 static NSString *const ON_REWARDED_AD_REVENUE_PAID = @"OnRewardedAdRevenuePaid";
 
 static NSString *const ON_APPOPEN_AD_LOADED_EVENT = @"OnAppOpenAdLoadedEvent";
-static NSString *const ON_APPOPEN_AD_LOADFAILED_EVENT = @"OnAppOpenAdLoadFailedEvent";
+static NSString *const ON_APPOPEN_AD_LOAD_FAILED_EVENT = @"OnAppOpenAdLoadFailedEvent";
 static NSString *const ON_APPOPEN_AD_CLICKED_EVENT = @"OnAppOpenAdClickedEvent";
 static NSString *const ON_APPOPEN_AD_DISPLAYED_EVENT = @"OnAppOpenAdDisplayedEvent";
-static NSString *const ON_APPOPEN_AD_FAILEDTODISPLAY_EVENT = @"OnAppOpenAdFailedToDisplayEvent";
+static NSString *const ON_APPOPEN_AD_FAILED_TO_DISPLAY_EVENT = @"OnAppOpenAdFailedToDisplayEvent";
 static NSString *const ON_APPOPEN_AD_HIDDEN_EVENT = @"OnAppOpenAdHiddenEvent";
 static NSString *const ON_APPOPEN_AD_REVENUE_PAID = @"OnAppOpenAdRevenuePaid";
 
@@ -850,15 +850,15 @@ RCT_EXPORT_METHOD(setAppOpenAdExtraParameter:(NSString *)adUnitIdentifier key:(N
     }
     else if ( self.interstitials[adUnitIdentifier] )
     {
-        name = ON_INTERSTITIAL_LOADFAILED_EVENT;
+        name = ON_INTERSTITIAL_LOAD_FAILED_EVENT;
     }
     else if ( self.rewardedAds[adUnitIdentifier] )
     {
-        name = ON_REWARDED_AD_LOADFAILED_EVENT;
+        name = ON_REWARDED_AD_LOAD_FAILED_EVENT;
     }
     else if ( self.appOpenAds[adUnitIdentifier] )
     {
-        name = ON_APPOPEN_AD_LOADFAILED_EVENT;
+        name = ON_APPOPEN_AD_LOAD_FAILED_EVENT;
     }
     else
     {
@@ -934,15 +934,15 @@ RCT_EXPORT_METHOD(setAppOpenAdExtraParameter:(NSString *)adUnitIdentifier key:(N
     NSString *name;
     if ( MAAdFormat.interstitial == adFormat )
     {
-        name = ON_INTERSTITIAL_AD_FAILEDTODISPLAY_EVENT;
+        name = ON_INTERSTITIAL_AD_FAILED_TO_DISPLAY_EVENT;
     }
     else if ( MAAdFormat.rewarded == adFormat )
     {
-        name = ON_REWARDED_AD_FAILEDTODISPLAY_EVENT;
+        name = ON_REWARDED_AD_FAILED_TO_DISPLAY_EVENT;
     }
     else // APP OPEN
     {
-        name = ON_APPOPEN_AD_FAILEDTODISPLAY_EVENT;
+        name = ON_APPOPEN_AD_FAILED_TO_DISPLAY_EVENT;
     }
     
     [self sendReactNativeEventWithName: name body: [self adDisplayFailedInfoForAd: ad withError: error]];
@@ -1057,7 +1057,7 @@ RCT_EXPORT_METHOD(setAppOpenAdExtraParameter:(NSString *)adUnitIdentifier key:(N
                                    @"rewardAmount": rewardAmount} mutableCopy];
     [body addEntriesFromDictionary: [self adInfoForAd: ad]];
     
-    [self sendReactNativeEventWithName: ON_REWARDED_AD_RECEIVEDREWARD_EVENT body: body];
+    [self sendReactNativeEventWithName: ON_REWARDED_AD_RECEIVED_REWARD_EVENT body: body];
 }
 
 #pragma mark - Internal Methods
@@ -1741,41 +1741,41 @@ RCT_EXPORT_METHOD(setAppOpenAdExtraParameter:(NSString *)adUnitIdentifier key:(N
 - (NSArray<NSString *> *)supportedEvents
 {
     return @[ON_MREC_AD_LOADED_EVENT,
-             ON_MREC_AD_LOADFAILED_EVENT,
+             ON_MREC_AD_LOAD_FAILED_EVENT,
              ON_MREC_AD_CLICKED_EVENT,
              ON_MREC_AD_COLLAPSED_EVENT,
              ON_MREC_AD_EXPANDED_EVENT,
              ON_MREC_AD_REVENUE_PAID,
              
              ON_BANNER_AD_LOADED_EVENT,
-             ON_BANNER_AD_LOADFAILED_EVENT,
+             ON_BANNER_AD_LOAD_FAILED_EVENT,
              ON_BANNER_AD_CLICKED_EVENT,
              ON_BANNER_AD_COLLAPSED_EVENT,
              ON_BANNER_AD_EXPANDED_EVENT,
              ON_BANNER_AD_REVENUE_PAID,
              
              ON_INTERSTITIAL_LOADED_EVENT,
-             ON_INTERSTITIAL_LOADFAILED_EVENT,
+             ON_INTERSTITIAL_LOAD_FAILED_EVENT,
              ON_INTERSTITIAL_CLICKED_EVENT,
              ON_INTERSTITIAL_DISPLAYED_EVENT,
-             ON_INTERSTITIAL_AD_FAILEDTODISPLAY_EVENT,
+             ON_INTERSTITIAL_AD_FAILED_TO_DISPLAY_EVENT,
              ON_INTERSTITIAL_HIDDEN_EVENT,
              ON_INTERSTITIAL_AD_REVENUE_PAID,
              
              ON_REWARDED_AD_LOADED_EVENT,
-             ON_REWARDED_AD_LOADFAILED_EVENT,
+             ON_REWARDED_AD_LOAD_FAILED_EVENT,
              ON_REWARDED_AD_CLICKED_EVENT,
              ON_REWARDED_AD_DISPLAYED_EVENT,
-             ON_REWARDED_AD_FAILEDTODISPLAY_EVENT,
+             ON_REWARDED_AD_FAILED_TO_DISPLAY_EVENT,
              ON_REWARDED_AD_HIDDEN_EVENT,
-             ON_REWARDED_AD_RECEIVEDREWARD_EVENT,
+             ON_REWARDED_AD_RECEIVED_REWARD_EVENT,
              ON_REWARDED_AD_REVENUE_PAID,
              
              ON_APPOPEN_AD_LOADED_EVENT,
-             ON_APPOPEN_AD_LOADFAILED_EVENT,
+             ON_APPOPEN_AD_LOAD_FAILED_EVENT,
              ON_APPOPEN_AD_CLICKED_EVENT,
              ON_APPOPEN_AD_DISPLAYED_EVENT,
-             ON_APPOPEN_AD_FAILEDTODISPLAY_EVENT,
+             ON_APPOPEN_AD_FAILED_TO_DISPLAY_EVENT,
              ON_APPOPEN_AD_HIDDEN_EVENT,
              ON_APPOPEN_AD_REVENUE_PAID];
 }
@@ -1783,41 +1783,41 @@ RCT_EXPORT_METHOD(setAppOpenAdExtraParameter:(NSString *)adUnitIdentifier key:(N
 - (NSDictionary *)constantsToExport
 {
     return @{@"ON_MREC_AD_LOADED_EVENT": ON_MREC_AD_LOADED_EVENT,
-             @"ON_MREC_AD_LOADFAILED_EVENT" : ON_MREC_AD_LOADFAILED_EVENT,
+             @"ON_MREC_AD_LOAD_FAILED_EVENT" : ON_MREC_AD_LOAD_FAILED_EVENT,
              @"ON_MREC_AD_CLICKED_EVENT" : ON_MREC_AD_CLICKED_EVENT,
              @"ON_MREC_AD_COLLAPSED_EVENT" : ON_MREC_AD_COLLAPSED_EVENT,
              @"ON_MREC_AD_EXPANDED_EVENT" : ON_MREC_AD_EXPANDED_EVENT,
              @"ON_MREC_AD_REVENUE_PAID" : ON_MREC_AD_REVENUE_PAID,
              
              @"ON_BANNER_AD_LOADED_EVENT" : ON_BANNER_AD_LOADED_EVENT,
-             @"ON_BANNER_AD_LOADFAILED_EVENT" : ON_BANNER_AD_LOADFAILED_EVENT,
+             @"ON_BANNER_AD_LOAD_FAILED_EVENT" : ON_BANNER_AD_LOAD_FAILED_EVENT,
              @"ON_BANNER_AD_CLICKED_EVENT" : ON_BANNER_AD_CLICKED_EVENT,
              @"ON_BANNER_AD_COLLAPSED_EVENT" : ON_BANNER_AD_COLLAPSED_EVENT,
              @"ON_BANNER_AD_EXPANDED_EVENT" : ON_BANNER_AD_EXPANDED_EVENT,
              @"ON_BANNER_AD_REVENUE_PAID" : ON_BANNER_AD_REVENUE_PAID,
              
              @"ON_INTERSTITIAL_LOADED_EVENT" : ON_INTERSTITIAL_LOADED_EVENT,
-             @"ON_INTERSTITIAL_LOADFAILED_EVENT" : ON_INTERSTITIAL_LOADFAILED_EVENT,
+             @"ON_INTERSTITIAL_LOAD_FAILED_EVENT" : ON_INTERSTITIAL_LOAD_FAILED_EVENT,
              @"ON_INTERSTITIAL_CLICKED_EVENT" : ON_INTERSTITIAL_CLICKED_EVENT,
              @"ON_INTERSTITIAL_DISPLAYED_EVENT" : ON_INTERSTITIAL_DISPLAYED_EVENT,
-             @"ON_INTERSTITIAL_AD_FAILEDTODISPLAY_EVENT" : ON_INTERSTITIAL_AD_FAILEDTODISPLAY_EVENT,
+             @"ON_INTERSTITIAL_AD_FAILED_TO_DISPLAY_EVENT" : ON_INTERSTITIAL_AD_FAILED_TO_DISPLAY_EVENT,
              @"ON_INTERSTITIAL_HIDDEN_EVENT" : ON_INTERSTITIAL_HIDDEN_EVENT,
              @"ON_INTERSTITIAL_AD_REVENUE_PAID" : ON_INTERSTITIAL_AD_REVENUE_PAID,
              
              @"ON_REWARDED_AD_LOADED_EVENT" : ON_REWARDED_AD_LOADED_EVENT,
-             @"ON_REWARDED_AD_LOADFAILED_EVENT" : ON_REWARDED_AD_LOADFAILED_EVENT,
+             @"ON_REWARDED_AD_LOAD_FAILED_EVENT" : ON_REWARDED_AD_LOAD_FAILED_EVENT,
              @"ON_REWARDED_AD_CLICKED_EVENT" : ON_REWARDED_AD_CLICKED_EVENT,
              @"ON_REWARDED_AD_DISPLAYED_EVENT" : ON_REWARDED_AD_DISPLAYED_EVENT,
-             @"ON_REWARDED_AD_FAILEDTODISPLAY_EVENT" : ON_REWARDED_AD_FAILEDTODISPLAY_EVENT,
+             @"ON_REWARDED_AD_FAILED_TO_DISPLAY_EVENT" : ON_REWARDED_AD_FAILED_TO_DISPLAY_EVENT,
              @"ON_REWARDED_AD_HIDDEN_EVENT" : ON_REWARDED_AD_HIDDEN_EVENT,
-             @"ON_REWARDED_AD_RECEIVEDREWARD_EVENT" : ON_REWARDED_AD_RECEIVEDREWARD_EVENT,
+             @"ON_REWARDED_AD_RECEIVED_REWARD_EVENT" : ON_REWARDED_AD_RECEIVED_REWARD_EVENT,
              @"ON_REWARDED_AD_REVENUE_PAID" : ON_REWARDED_AD_REVENUE_PAID,
              
              @"ON_APPOPEN_AD_LOADED_EVENT" : ON_APPOPEN_AD_LOADED_EVENT,
-             @"ON_APPOPEN_AD_LOADFAILED_EVENT" : ON_APPOPEN_AD_LOADFAILED_EVENT,
+             @"ON_APPOPEN_AD_LOAD_FAILED_EVENT" : ON_APPOPEN_AD_LOAD_FAILED_EVENT,
              @"ON_APPOPEN_AD_CLICKED_EVENT" : ON_APPOPEN_AD_CLICKED_EVENT,
              @"ON_APPOPEN_AD_DISPLAYED_EVENT" : ON_APPOPEN_AD_DISPLAYED_EVENT,
-             @"ON_APPOPEN_AD_FAILEDTODISPLAY_EVENT" : ON_APPOPEN_AD_FAILEDTODISPLAY_EVENT,
+             @"ON_APPOPEN_AD_FAILED_TO_DISPLAY_EVENT" : ON_APPOPEN_AD_FAILED_TO_DISPLAY_EVENT,
              @"ON_APPOPEN_AD_HIDDEN_EVENT" : ON_APPOPEN_AD_HIDDEN_EVENT,
              @"ON_APPOPEN_AD_REVENUE_PAID" : ON_APPOPEN_AD_REVENUE_PAID,
              

--- a/ios/AppLovinMAXAdView.m
+++ b/ios/AppLovinMAXAdView.m
@@ -56,11 +56,11 @@
         return;
     }
     
-    if ( [@"banner" isEqualToString: adFormat] )
+    if ( [MAAdFormat.banner.label isEqualToString: adFormat] )
     {
         _adFormat = DEVICE_SPECIFIC_ADVIEW_AD_FORMAT;
     }
-    else if ( [@"mrec" isEqualToString: adFormat] )
+    else if ( [MAAdFormat.mrec.label isEqualToString: adFormat] )
     {
         _adFormat = MAAdFormat.mrec;
     }

--- a/src/AppLovinMAXAdView.js
+++ b/src/AppLovinMAXAdView.js
@@ -1,24 +1,39 @@
-import { NativeModules, requireNativeComponent, UIManager, findNodeHandle, View, Text, StyleSheet } from "react-native";
+import { NativeModules, requireNativeComponent } from "react-native";
 import PropTypes from "prop-types";
 import React, { useEffect, useState } from "react";
 
 const { AppLovinMAX } = NativeModules;
 
+const {
+  TOP_CENTER_POSITION,
+  TOP_LEFT_POSITION,
+  TOP_RIGHT_POSITION,
+  CENTERED_POSITION,
+  CENTER_LEFT_POSITION,
+  CENTER_RIGHT_POSITION,
+  BOTTOM_LEFT_POSITION,
+  BOTTOM_CENTER_POSITION,
+  BOTTOM_RIGHT_POSITION,
+
+  BANNER_AD_FORMAT_LABEL,
+  MREC_AD_FORMAT_LABEL,      
+} = AppLovinMAX.getConstants();
+
 export const AdFormat = {
-  BANNER: "banner",
-  MREC: "mrec",
+  BANNER: BANNER_AD_FORMAT_LABEL,
+  MREC: MREC_AD_FORMAT_LABEL,
 };
 
 export const AdViewPosition = {
-  TOP_CENTER: "top_center",
-  TOP_LEFT: "top_left",
-  TOP_RIGHT: "top_right",
-  CENTERED: "centered",
-  CENTER_LEFT: "center_left",
-  CENTER_RIGHT: "center_right",
-  BOTTOM_LEFT: "bottom_left",
-  BOTTOM_CENTER: "bottom_center",
-  BOTTOM_RIGHT: "bottom_right",
+  TOP_CENTER : TOP_CENTER_POSITION,
+  TOP_LEFT : TOP_LEFT_POSITION,
+  TOP_RIGHT : TOP_RIGHT_POSITION,
+  CENTERED : CENTERED_POSITION,
+  CENTER_LEFT : CENTER_LEFT_POSITION,
+  CENTER_RIGHT : CENTER_RIGHT_POSITION,
+  BOTTOM_LEFT : BOTTOM_LEFT_POSITION,
+  BOTTOM_CENTER : BOTTOM_CENTER_POSITION,
+  BOTTOM_RIGHT : BOTTOM_RIGHT_POSITION,
 };
 
 const AdView = (props) => {

--- a/src/AppLovinMAXEventListeners.js
+++ b/src/AppLovinMAXEventListeners.js
@@ -1,0 +1,419 @@
+import { NativeModules, NativeEventEmitter } from "react-native";
+
+const { AppLovinMAX } = NativeModules;
+
+const {
+  ON_MREC_AD_LOADED_EVENT,
+  ON_MREC_AD_LOADFAILED_EVENT,
+  ON_MREC_AD_CLICKED_EVENT,
+  ON_MREC_AD_COLLAPSED_EVENT,
+  ON_MREC_AD_EXPANDED_EVENT,
+  ON_MREC_AD_REVENUE_PAID,
+
+  ON_BANNER_AD_LOADED_EVENT,
+  ON_BANNER_AD_LOADFAILED_EVENT,
+  ON_BANNER_AD_CLICKED_EVENT,
+  ON_BANNER_AD_COLLAPSED_EVENT,
+  ON_BANNER_AD_EXPANDED_EVENT,
+  ON_BANNER_AD_REVENUE_PAID,
+
+  ON_INTERSTITIAL_LOADED_EVENT,
+  ON_INTERSTITIAL_LOADFAILED_EVENT,
+  ON_INTERSTITIAL_CLICKED_EVENT,
+  ON_INTERSTITIAL_DISPLAYED_EVENT,
+  ON_INTERSTITIAL_AD_FAILEDTODISPLAY_EVENT,
+  ON_INTERSTITIAL_HIDDEN_EVENT,
+  ON_INTERSTITIAL_AD_REVENUE_PAID,
+  
+  ON_REWARDED_AD_LOADED_EVENT,
+  ON_REWARDED_AD_LOADFAILED_EVENT,
+  ON_REWARDED_AD_CLICKED_EVENT,
+  ON_REWARDED_AD_DISPLAYED_EVENT,
+  ON_REWARDED_AD_FAILEDTODISPLAY_EVENT,
+  ON_REWARDED_AD_HIDDEN_EVENT,
+  ON_REWARDED_AD_RECEIVEDREWARD_EVENT,
+  ON_REWARDED_AD_REVENUE_PAID,
+  
+  ON_APPOPEN_AD_LOADED_EVENT,
+  ON_APPOPEN_AD_LOADFAILED_EVENT,
+  ON_APPOPEN_AD_CLICKED_EVENT,
+  ON_APPOPEN_AD_DISPLAYED_EVENT,
+  ON_APPOPEN_AD_FAILEDTODISPLAY_EVENT,
+  ON_APPOPEN_AD_HIDDEN_EVENT,
+  ON_APPOPEN_AD_REVENUE_PAID,
+} = AppLovinMAX.getConstants();
+
+const emitter = new NativeEventEmitter(AppLovinMAX);
+const subscriptions = {};
+
+const addEventListener = (event, handler) => {
+  let subscription = emitter.addListener(event, handler);
+  let currentSubscription = subscriptions[event];
+  if (currentSubscription) {
+    currentSubscription.remove();
+  }
+  subscriptions[event] = subscription;
+};
+
+const removeEventListener = (event) => {
+  let currentSubscription = subscriptions[event];
+  if (currentSubscription) {
+    currentSubscription.remove();
+    delete subscriptions[event];
+  }
+};
+
+const addMRecAdLoadedEventListener = (listener) => {
+  addEventListener(ON_MREC_AD_LOADED_EVENT, (adInfo) => listener(adInfo));
+};
+
+const removeMRecAdLoadedEventListener = () => {
+  removeEventListener(ON_MREC_AD_LOADED_EVENT);  
+};
+
+const addMRecAdLoadFailedEventListener = (listener) => {
+  addEventListener(ON_MREC_AD_LOADFAILED_EVENT, (errorInfo) => listener(errorInfo));
+};
+
+const removeMRecAdLoadFailedEventListener = () => {
+  removeEventListener(ON_MREC_AD_LOADFAILED_EVENT);  
+};
+
+const addMRecAdClickedEventListener = (listener) => {
+  addEventListener(ON_MREC_AD_CLICKED_EVENT, (adInfo) => listener(adInfo));
+};
+
+const removeMRecAdClickedEventListener = () => {
+  removeEventListener(ON_MREC_AD_CLICKED_EVENT);  
+};
+
+const addMRecAdCollapsedEventListener = (listener) => {
+  addEventListener(ON_MREC_AD_COLLAPSED_EVENT, (adInfo) => listener(adInfo));
+};
+
+const removeMRecAdCollapsedEventListener = () => {
+  removeEventListener(ON_MREC_AD_COLLAPSED_EVENT);  
+};
+
+const addMRecAdExpandedEventListener = (listener) => {
+  addEventListener(ON_MREC_AD_EXPANDED_EVENT, (adInfo) => listener(adInfo));
+};
+
+const removeMRecAdExpandedEventListener = () => {
+  removeEventListener(ON_MREC_AD_EXPANDED_EVENT);  
+};
+
+const addMRecAdRevenuePaidListener = (listener) => {
+  addEventListener(ON_MREC_AD_REVENUE_PAID, (adInfo) => listener(adInfo));
+};
+
+const removeMRecAdRevenuePaidListener = () => {
+  removeEventListener(ON_MREC_AD_REVENUE_PAID);  
+};
+
+const addBannerAdLoadedEventListener = (listener) => {
+  addEventListener(ON_BANNER_AD_LOADED_EVENT, (adInfo) => listener(adInfo));
+};
+
+const removeBannerAdLoadedEventListener = () => {
+  removeEventListener(ON_BANNER_AD_LOADED_EVENT);  
+};
+
+const addBannerAdLoadFailedEventListener = (listener) => {
+  addEventListener(ON_BANNER_AD_LOADFAILED_EVENT, (errorInfo) => listener(errorInfo));
+};
+
+const removeBannerAdLoadFailedEventListener = () => {
+  removeEventListener(ON_BANNER_AD_LOADFAILED_EVENT);  
+};
+
+const addBannerAdClickedEventListener = (listener) => {
+  addEventListener(ON_BANNER_AD_CLICKED_EVENT, (adInfo) => listener(adInfo));
+};
+
+const removeBannerAdClickedEventListener = () => {
+  removeEventListener(ON_BANNER_AD_CLICKED_EVENT);  
+};
+
+const addBannerAdCollapsedEventListener = (listener) => {
+  addEventListener(ON_BANNER_AD_COLLAPSED_EVENT, (adInfo) => listener(adInfo));
+};
+
+const removeBannerAdCollapsedEventListener = () => {
+  removeEventListener(ON_BANNER_AD_COLLAPSED_EVENT);  
+};
+
+const addBannerAdExpandedEventListener = (listener) => {
+  addEventListener(ON_BANNER_AD_EXPANDED_EVENT, (adInfo) => listener(adInfo));
+};
+
+const removeBannerAdExpandedEventListener = () => {
+  removeEventListener(ON_BANNER_AD_EXPANDED_EVENT);  
+};
+
+const addBannerAdRevenuePaidListener = (listener) => {
+  addEventListener(ON_BANNER_AD_REVENUE_PAID, (adInfo) => listener(adInfo));
+};
+
+const removeBannerAdRevenuePaidListener = () => {
+  removeEventListener(ON_BANNER_AD_REVENUE_PAID);  
+};
+
+const addInterstitialLoadedEventListener = (listener) => {
+  addEventListener(ON_INTERSTITIAL_LOADED_EVENT, (adInfo) => listener(adInfo));
+};
+
+const removeInterstitialLoadedEventListener = () => {
+  removeEventListener(ON_INTERSTITIAL_LOADED_EVENT);  
+};
+
+const addInterstitialLoadFailedEventListener = (listener) => {
+  addEventListener(ON_INTERSTITIAL_LOADFAILED_EVENT, (errorInfo) => listener(errorInfo));
+};
+
+const removeInterstitialLoadFailedEventListener = () => {
+  removeEventListener(ON_INTERSTITIAL_LOADFAILED_EVENT);  
+};
+
+const addInterstitialClickedEventListener = (listener) => {
+  addEventListener(ON_INTERSTITIAL_CLICKED_EVENT, (adInfo) => listener(adInfo));
+};
+
+const removeInterstitialClickedEventListener = () => {
+  removeEventListener(ON_INTERSTITIAL_CLICKED_EVENT);  
+};
+
+const addInterstitialDisplayedEventListener = (listener) => {
+  addEventListener(ON_INTERSTITIAL_DISPLAYED_EVENT, (adInfo) => listener(adInfo));
+};
+
+const removeInterstitialDisplayedEventListener = () => {
+  removeEventListener(ON_INTERSTITIAL_DISPLAYED_EVENT);  
+};
+
+const addInterstitialAdFailedToDisplayEventListener = (listener) => {
+  addEventListener(ON_INTERSTITIAL_AD_FAILEDTODISPLAY_EVENT, (adInfo) => listener(adInfo));
+};
+
+const removeInterstitialAdFailedToDisplayEventListener = () => {
+  removeEventListener(ON_INTERSTITIAL_AD_FAILEDTODISPLAY_EVENT);  
+};
+
+const addInterstitialHiddenEventListener = (listener) => {
+  addEventListener(ON_INTERSTITIAL_HIDDEN_EVENT, (adInfo) => listener(adInfo));
+};
+
+const removeInterstitialHiddenEventListener = () => {
+  removeEventListener(ON_INTERSTITIAL_HIDDEN_EVENT);  
+};
+
+const addInterstitialAdRevenuePaidListener = (listener) => {
+  addEventListener(ON_INTERSTITIAL_AD_REVENUE_PAID, (adInfo) => listener(adInfo));
+};
+
+const removeInterstitialAdRevenuePaidListener = () => {
+  removeEventListener(ON_INTERSTITIAL_AD_REVENUE_PAID);  
+};
+
+const addRewardedAdLoadedEventListener = (listener) => {
+  addEventListener(ON_REWARDED_AD_LOADED_EVENT, (adInfo) => listener(adInfo));
+};
+
+const removeRewardedAdLoadedEventListener = () => {
+  removeEventListener(ON_REWARDED_AD_LOADED_EVENT);  
+};
+
+const addRewardedAdLoadFailedEventListener = (listener) => {
+  addEventListener(ON_REWARDED_AD_LOADFAILED_EVENT, (errorInfo) => listener(errorInfo));
+};
+
+const removeRewardedAdLoadFailedEventListener = () => {
+  removeEventListener(ON_REWARDED_AD_LOADFAILED_EVENT);  
+};
+
+const addRewardedAdClickedEventListener = (listener) => {
+  addEventListener(ON_REWARDED_AD_CLICKED_EVENT, (adInfo) => listener(adInfo));
+};
+
+const removeRewardedAdClickedEventListener = () => {
+  removeEventListener(ON_REWARDED_AD_CLICKED_EVENT);  
+};
+
+const addRewardedAdDisplayedEventListener = (listener) => {
+  addEventListener(ON_REWARDED_AD_DISPLAYED_EVENT, (adInfo) => listener(adInfo));
+};
+
+const removeRewardedAdDisplayedEventListener = () => {
+  removeEventListener(ON_REWARDED_AD_DISPLAYED_EVENT);  
+};
+
+const addRewardedAdFailedToDisplayEventListener = (listener) => {
+  addEventListener(ON_REWARDED_AD_FAILEDTODISPLAY_EVENT, (adInfo) => listener(adInfo));
+};
+
+const removeRewardedAdFailedToDisplayEventListener = () => {
+  removeEventListener(ON_REWARDED_AD_FAILEDTODISPLAY_EVENT);  
+};
+
+const addRewardedAdHiddenEventListener = (listener) => {
+  addEventListener(ON_REWARDED_AD_HIDDEN_EVENT, (adInfo) => listener(adInfo));
+};
+
+const removeRewardedAdHiddenEventListener = () => {
+  removeEventListener(ON_REWARDED_AD_HIDDEN_EVENT);  
+};
+
+const addRewardedAdReceivedRewardEventListener = (listener) => {
+  addEventListener(ON_REWARDED_AD_RECEIVEDREWARD_EVENT, (adInfo) => listener(adInfo));
+};
+
+const removeRewardedAdReceivedRewardEventListener = () => {
+  removeEventListener(ON_REWARDED_AD_RECEIVEDREWARD_EVENT);  
+};
+
+const addRewardedAdRevenuePaidListener = (listener) => {
+  addEventListener(ON_REWARDED_AD_REVENUE_PAID, (adInfo) => listener(adInfo));
+};
+
+const removeRewardedAdRevenuePaidListener = () => {
+  removeEventListener(ON_REWARDED_AD_REVENUE_PAID);  
+};
+
+const addAppOpenAdLoadedEventListener = (listener) => {
+  addEventListener(ON_APPOPEN_AD_LOADED_EVENT, (adInfo) => listener(adInfo));
+};
+
+const removeAppOpenAdLoadedEventListener = () => {
+  removeEventListener(ON_APPOPEN_AD_LOADED_EVENT);  
+};
+
+const addAppOpenAdLoadFailedEventListener = (listener) => {
+  addEventListener(ON_APPOPEN_AD_LOADFAILED_EVENT, (errorInfo) => listener(errorInfo));
+};
+
+const removeAppOpenAdLoadFailedEventListener = () => {
+  removeEventListener(ON_APPOPEN_AD_LOADFAILED_EVENT);  
+};
+
+const addAppOpenAdClickedEventListener = (listener) => {
+  addEventListener(ON_APPOPEN_AD_CLICKED_EVENT, (adInfo) => listener(adInfo));
+};
+
+const removeAppOpenAdClickedEventListener = () => {
+  removeEventListener(ON_APPOPEN_AD_CLICKED_EVENT);  
+};
+
+const addAppOpenAdDisplayedEventListener = (listener) => {
+  addEventListener(ON_APPOPEN_AD_DISPLAYED_EVENT, (adInfo) => listener(adInfo));
+};
+
+const removeAppOpenAdDisplayedEventListener = () => {
+  removeEventListener(ON_APPOPEN_AD_DISPLAYED_EVENT);  
+};
+
+const addAppOpenAdFailedToDisplayEventListener = (listener) => {
+  addEventListener(ON_APPOPEN_AD_FAILEDTODISPLAY_EVENT, (adInfo) => listener(adInfo));
+};
+
+const removeAppOpenAdFailedToDisplayEventListener = () => {
+  removeEventListener(ON_APPOPEN_AD_FAILEDTODISPLAY_EVENT);  
+};
+
+const addAppOpenAdHiddenEventListener = (listener) => {
+  addEventListener(ON_APPOPEN_AD_HIDDEN_EVENT, (adInfo) => listener(adInfo));
+};
+
+const removeAppOpenAdHiddenEventListener = () => {
+  removeEventListener(ON_APPOPEN_AD_HIDDEN_EVENT);  
+};
+
+const addAppOpenAdRevenuePaidListener = (listener) => {
+  addEventListener(ON_APPOPEN_AD_REVENUE_PAID, (adInfo) => listener(adInfo));
+};
+
+const removeAppOpenAdRevenuePaidListener = () => {
+  removeEventListener(ON_APPOPEN_AD_REVENUE_PAID);  
+};
+
+export default {
+  addEventListener,
+  removeEventListener,
+
+  addMRecAdLoadedEventListener,
+  addMRecAdLoadFailedEventListener,
+  addMRecAdClickedEventListener,
+  addMRecAdCollapsedEventListener,
+  addMRecAdExpandedEventListener,
+  addMRecAdRevenuePaidListener,
+
+  removeMRecAdLoadedEventListener,
+  removeMRecAdLoadFailedEventListener,
+  removeMRecAdClickedEventListener,
+  removeMRecAdCollapsedEventListener,
+  removeMRecAdExpandedEventListener,
+  removeMRecAdRevenuePaidListener,
+
+  addBannerAdLoadedEventListener,
+  addBannerAdLoadFailedEventListener,
+  addBannerAdClickedEventListener,
+  addBannerAdCollapsedEventListener,
+  addBannerAdExpandedEventListener,
+  addBannerAdRevenuePaidListener,
+
+  removeBannerAdLoadedEventListener,
+  removeBannerAdLoadFailedEventListener,
+  removeBannerAdClickedEventListener,
+  removeBannerAdCollapsedEventListener,
+  removeBannerAdExpandedEventListener,
+  removeBannerAdRevenuePaidListener,
+
+  addInterstitialLoadedEventListener,
+  addInterstitialLoadFailedEventListener,
+  addInterstitialClickedEventListener,
+  addInterstitialDisplayedEventListener,
+  addInterstitialAdFailedToDisplayEventListener,
+  addInterstitialHiddenEventListener,
+  addInterstitialAdRevenuePaidListener,
+
+  removeInterstitialLoadedEventListener,
+  removeInterstitialLoadFailedEventListener,
+  removeInterstitialClickedEventListener,
+  removeInterstitialDisplayedEventListener,
+  removeInterstitialAdFailedToDisplayEventListener,
+  removeInterstitialHiddenEventListener,
+  removeInterstitialAdRevenuePaidListener,
+
+  addRewardedAdLoadedEventListener,
+  addRewardedAdLoadFailedEventListener,
+  addRewardedAdClickedEventListener,
+  addRewardedAdDisplayedEventListener,
+  addRewardedAdFailedToDisplayEventListener,
+  addRewardedAdHiddenEventListener,
+  addRewardedAdReceivedRewardEventListener,
+  addRewardedAdRevenuePaidListener,
+
+  removeRewardedAdLoadedEventListener,
+  removeRewardedAdLoadFailedEventListener,
+  removeRewardedAdClickedEventListener,
+  removeRewardedAdDisplayedEventListener,
+  removeRewardedAdFailedToDisplayEventListener,
+  removeRewardedAdHiddenEventListener,
+  removeRewardedAdReceivedRewardEventListener,
+  removeRewardedAdRevenuePaidListener,
+
+  addAppOpenAdLoadedEventListener,
+  addAppOpenAdLoadFailedEventListener,
+  addAppOpenAdClickedEventListener,
+  addAppOpenAdDisplayedEventListener,
+  addAppOpenAdFailedToDisplayEventListener,
+  addAppOpenAdHiddenEventListener,
+  addAppOpenAdRevenuePaidListener,
+
+  removeAppOpenAdLoadedEventListener,
+  removeAppOpenAdLoadFailedEventListener,
+  removeAppOpenAdClickedEventListener,
+  removeAppOpenAdDisplayedEventListener,
+  removeAppOpenAdFailedToDisplayEventListener,
+  removeAppOpenAdHiddenEventListener,
+  removeAppOpenAdRevenuePaidListener,
+};

--- a/src/AppLovinMAXEventListeners.js
+++ b/src/AppLovinMAXEventListeners.js
@@ -4,41 +4,41 @@ const { AppLovinMAX } = NativeModules;
 
 const {
   ON_MREC_AD_LOADED_EVENT,
-  ON_MREC_AD_LOADFAILED_EVENT,
+  ON_MREC_AD_LOAD_FAILED_EVENT,
   ON_MREC_AD_CLICKED_EVENT,
   ON_MREC_AD_COLLAPSED_EVENT,
   ON_MREC_AD_EXPANDED_EVENT,
   ON_MREC_AD_REVENUE_PAID,
 
   ON_BANNER_AD_LOADED_EVENT,
-  ON_BANNER_AD_LOADFAILED_EVENT,
+  ON_BANNER_AD_LOAD_FAILED_EVENT,
   ON_BANNER_AD_CLICKED_EVENT,
   ON_BANNER_AD_COLLAPSED_EVENT,
   ON_BANNER_AD_EXPANDED_EVENT,
   ON_BANNER_AD_REVENUE_PAID,
 
   ON_INTERSTITIAL_LOADED_EVENT,
-  ON_INTERSTITIAL_LOADFAILED_EVENT,
+  ON_INTERSTITIAL_LOAD_FAILED_EVENT,
   ON_INTERSTITIAL_CLICKED_EVENT,
   ON_INTERSTITIAL_DISPLAYED_EVENT,
-  ON_INTERSTITIAL_AD_FAILEDTODISPLAY_EVENT,
+  ON_INTERSTITIAL_AD_FAILED_TO_DISPLAY_EVENT,
   ON_INTERSTITIAL_HIDDEN_EVENT,
   ON_INTERSTITIAL_AD_REVENUE_PAID,
   
   ON_REWARDED_AD_LOADED_EVENT,
-  ON_REWARDED_AD_LOADFAILED_EVENT,
+  ON_REWARDED_AD_LOAD_FAILED_EVENT,
   ON_REWARDED_AD_CLICKED_EVENT,
   ON_REWARDED_AD_DISPLAYED_EVENT,
-  ON_REWARDED_AD_FAILEDTODISPLAY_EVENT,
+  ON_REWARDED_AD_FAILED_TO_DISPLAY_EVENT,
   ON_REWARDED_AD_HIDDEN_EVENT,
-  ON_REWARDED_AD_RECEIVEDREWARD_EVENT,
+  ON_REWARDED_AD_RECEIVED_REWARD_EVENT,
   ON_REWARDED_AD_REVENUE_PAID,
   
   ON_APPOPEN_AD_LOADED_EVENT,
-  ON_APPOPEN_AD_LOADFAILED_EVENT,
+  ON_APPOPEN_AD_LOAD_FAILED_EVENT,
   ON_APPOPEN_AD_CLICKED_EVENT,
   ON_APPOPEN_AD_DISPLAYED_EVENT,
-  ON_APPOPEN_AD_FAILEDTODISPLAY_EVENT,
+  ON_APPOPEN_AD_FAILED_TO_DISPLAY_EVENT,
   ON_APPOPEN_AD_HIDDEN_EVENT,
   ON_APPOPEN_AD_REVENUE_PAID,
 } = AppLovinMAX.getConstants();
@@ -72,11 +72,11 @@ const removeMRecAdLoadedEventListener = () => {
 };
 
 const addMRecAdLoadFailedEventListener = (listener) => {
-  addEventListener(ON_MREC_AD_LOADFAILED_EVENT, (errorInfo) => listener(errorInfo));
+  addEventListener(ON_MREC_AD_LOAD_FAILED_EVENT, (errorInfo) => listener(errorInfo));
 };
 
 const removeMRecAdLoadFailedEventListener = () => {
-  removeEventListener(ON_MREC_AD_LOADFAILED_EVENT);  
+  removeEventListener(ON_MREC_AD_LOAD_FAILED_EVENT);  
 };
 
 const addMRecAdClickedEventListener = (listener) => {
@@ -120,11 +120,11 @@ const removeBannerAdLoadedEventListener = () => {
 };
 
 const addBannerAdLoadFailedEventListener = (listener) => {
-  addEventListener(ON_BANNER_AD_LOADFAILED_EVENT, (errorInfo) => listener(errorInfo));
+  addEventListener(ON_BANNER_AD_LOAD_FAILED_EVENT, (errorInfo) => listener(errorInfo));
 };
 
 const removeBannerAdLoadFailedEventListener = () => {
-  removeEventListener(ON_BANNER_AD_LOADFAILED_EVENT);  
+  removeEventListener(ON_BANNER_AD_LOAD_FAILED_EVENT);  
 };
 
 const addBannerAdClickedEventListener = (listener) => {
@@ -168,11 +168,11 @@ const removeInterstitialLoadedEventListener = () => {
 };
 
 const addInterstitialLoadFailedEventListener = (listener) => {
-  addEventListener(ON_INTERSTITIAL_LOADFAILED_EVENT, (errorInfo) => listener(errorInfo));
+  addEventListener(ON_INTERSTITIAL_LOAD_FAILED_EVENT, (errorInfo) => listener(errorInfo));
 };
 
 const removeInterstitialLoadFailedEventListener = () => {
-  removeEventListener(ON_INTERSTITIAL_LOADFAILED_EVENT);  
+  removeEventListener(ON_INTERSTITIAL_LOAD_FAILED_EVENT);  
 };
 
 const addInterstitialClickedEventListener = (listener) => {
@@ -192,11 +192,11 @@ const removeInterstitialDisplayedEventListener = () => {
 };
 
 const addInterstitialAdFailedToDisplayEventListener = (listener) => {
-  addEventListener(ON_INTERSTITIAL_AD_FAILEDTODISPLAY_EVENT, (adInfo) => listener(adInfo));
+  addEventListener(ON_INTERSTITIAL_AD_FAILED_TO_DISPLAY_EVENT, (adInfo) => listener(adInfo));
 };
 
 const removeInterstitialAdFailedToDisplayEventListener = () => {
-  removeEventListener(ON_INTERSTITIAL_AD_FAILEDTODISPLAY_EVENT);  
+  removeEventListener(ON_INTERSTITIAL_AD_FAILED_TO_DISPLAY_EVENT);  
 };
 
 const addInterstitialHiddenEventListener = (listener) => {
@@ -224,11 +224,11 @@ const removeRewardedAdLoadedEventListener = () => {
 };
 
 const addRewardedAdLoadFailedEventListener = (listener) => {
-  addEventListener(ON_REWARDED_AD_LOADFAILED_EVENT, (errorInfo) => listener(errorInfo));
+  addEventListener(ON_REWARDED_AD_LOAD_FAILED_EVENT, (errorInfo) => listener(errorInfo));
 };
 
 const removeRewardedAdLoadFailedEventListener = () => {
-  removeEventListener(ON_REWARDED_AD_LOADFAILED_EVENT);  
+  removeEventListener(ON_REWARDED_AD_LOAD_FAILED_EVENT);  
 };
 
 const addRewardedAdClickedEventListener = (listener) => {
@@ -248,11 +248,11 @@ const removeRewardedAdDisplayedEventListener = () => {
 };
 
 const addRewardedAdFailedToDisplayEventListener = (listener) => {
-  addEventListener(ON_REWARDED_AD_FAILEDTODISPLAY_EVENT, (adInfo) => listener(adInfo));
+  addEventListener(ON_REWARDED_AD_FAILED_TO_DISPLAY_EVENT, (adInfo) => listener(adInfo));
 };
 
 const removeRewardedAdFailedToDisplayEventListener = () => {
-  removeEventListener(ON_REWARDED_AD_FAILEDTODISPLAY_EVENT);  
+  removeEventListener(ON_REWARDED_AD_FAILED_TO_DISPLAY_EVENT);  
 };
 
 const addRewardedAdHiddenEventListener = (listener) => {
@@ -264,11 +264,11 @@ const removeRewardedAdHiddenEventListener = () => {
 };
 
 const addRewardedAdReceivedRewardEventListener = (listener) => {
-  addEventListener(ON_REWARDED_AD_RECEIVEDREWARD_EVENT, (adInfo) => listener(adInfo));
+  addEventListener(ON_REWARDED_AD_RECEIVED_REWARD_EVENT, (adInfo) => listener(adInfo));
 };
 
 const removeRewardedAdReceivedRewardEventListener = () => {
-  removeEventListener(ON_REWARDED_AD_RECEIVEDREWARD_EVENT);  
+  removeEventListener(ON_REWARDED_AD_RECEIVED_REWARD_EVENT);  
 };
 
 const addRewardedAdRevenuePaidListener = (listener) => {
@@ -288,11 +288,11 @@ const removeAppOpenAdLoadedEventListener = () => {
 };
 
 const addAppOpenAdLoadFailedEventListener = (listener) => {
-  addEventListener(ON_APPOPEN_AD_LOADFAILED_EVENT, (errorInfo) => listener(errorInfo));
+  addEventListener(ON_APPOPEN_AD_LOAD_FAILED_EVENT, (errorInfo) => listener(errorInfo));
 };
 
 const removeAppOpenAdLoadFailedEventListener = () => {
-  removeEventListener(ON_APPOPEN_AD_LOADFAILED_EVENT);  
+  removeEventListener(ON_APPOPEN_AD_LOAD_FAILED_EVENT);  
 };
 
 const addAppOpenAdClickedEventListener = (listener) => {
@@ -312,11 +312,11 @@ const removeAppOpenAdDisplayedEventListener = () => {
 };
 
 const addAppOpenAdFailedToDisplayEventListener = (listener) => {
-  addEventListener(ON_APPOPEN_AD_FAILEDTODISPLAY_EVENT, (adInfo) => listener(adInfo));
+  addEventListener(ON_APPOPEN_AD_FAILED_TO_DISPLAY_EVENT, (adInfo) => listener(adInfo));
 };
 
 const removeAppOpenAdFailedToDisplayEventListener = () => {
-  removeEventListener(ON_APPOPEN_AD_FAILEDTODISPLAY_EVENT);  
+  removeEventListener(ON_APPOPEN_AD_FAILED_TO_DISPLAY_EVENT);  
 };
 
 const addAppOpenAdHiddenEventListener = (listener) => {

--- a/src/NativeAdComponents.js
+++ b/src/NativeAdComponents.js
@@ -1,5 +1,5 @@
 import React, {useContext, useRef, useEffect} from "react";
-import {findNodeHandle, UIManager, Text, Image, View, TouchableOpacity} from "react-native";
+import {findNodeHandle, Text, Image, View, TouchableOpacity} from "react-native";
 import {NativeAdViewContext} from "./NativeAdViewProvider";
 
 export const TitleView = (props) => {

--- a/src/NativeAdView.js
+++ b/src/NativeAdView.js
@@ -1,6 +1,6 @@
-import React, { forwardRef, useContext, useImperativeHandle, useRef, useCallback, useState, useEffect } from "react";
+import React, { forwardRef, useContext, useImperativeHandle, useRef, useState, useEffect } from "react";
 import PropTypes from "prop-types";
-import { NativeModules, requireNativeComponent, UIManager, findNodeHandle, View, StyleSheet } from "react-native";
+import { NativeModules, requireNativeComponent, UIManager, findNodeHandle } from "react-native";
 import { NativeAdViewContext, NativeAdViewProvider } from "./NativeAdViewProvider";
 import { TitleView, AdvertiserView, BodyView, CallToActionView, IconView, OptionsView, MediaView } from "./NativeAdComponents";
 

--- a/src/index.js
+++ b/src/index.js
@@ -8,33 +8,6 @@ const { AppLovinMAX } = NativeModules;
 
 const VERSION = "4.1.5";
 
-const {
-  CONSENT_DIALOG_STATE_UNKNOWN,
-  CONSENT_DIALOG_STATE_APPLIES,
-  CONSENT_DIALOG_STATE_DOES_NOT_APPLY,
-} = AppLovinMAX.getConstants();
-
-/**
- * This enum represents whether or not the consent dialog should be shown for this user.
- * The state where no such determination could be made is represented by `Unknown`.
- */
-const ConsentDialogState = {
-  /**
-   * The consent dialog state could not be determined. This is likely due to SDK failing to initialize.
-   */
-  UNKNOWN: CONSENT_DIALOG_STATE_UNKNOWN,
-
-  /**
-   * This user should be shown a consent dialog.
-   */
-  APPLIES: CONSENT_DIALOG_STATE_APPLIES,
-
-  /**
-   * This user should not be shown a consent dialog.
-   */
-  DOES_NOT_APPLY: CONSENT_DIALOG_STATE_DOES_NOT_APPLY,
-};
-
 const runIfInitialized = (callingMethodName, callingMethod, ...params) => {
   return AppLovinMAX.isInitialized().then(isInitialized => {
     if (isInitialized) {
@@ -281,11 +254,6 @@ const setAppOpenAdExtraParameter = (adUnitId, key, value) => {
                           adUnitId, key, value);
 }
 
-const getConsentDialogState = () => {
-  console.warn("getConsentDialogState() has been deprecated and will be removed in a future release.");
-  return AppLovinMAX.getConsentDialogState();
-};
-
 export default {
   ...AppLovinMAX,
   ...EventListeners,
@@ -295,7 +263,6 @@ export default {
   },
   AdContentRating,
   UserGender,
-  ConsentDialogState,
   AdViewPosition,
   AdFormat,
   NativeAdView,
@@ -358,11 +325,6 @@ export default {
   isAppOpenAdReady,
   showAppOpenAd,
   setAppOpenAdExtraParameter,
-
-  /*--------------------------------------------------*/
-  /* DEPRECATED (will be removed in a future release) */
-  /*--------------------------------------------------*/
-  getConsentDialogState,
 
   /*----------------------*/
   /** AUTO-DECLARED APIs **/

--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,18 @@
-import { NativeModules, NativeEventEmitter } from "react-native";
+import { NativeModules } from "react-native";
 import AdView, { AdFormat, AdViewPosition } from "./AppLovinMAXAdView";
 import { TargetingData, AdContentRating, UserGender } from "./TargetingData";
 import NativeAdView from "./NativeAdView";
+import EventListeners from "./AppLovinMAXEventListeners";
 
 const { AppLovinMAX } = NativeModules;
 
 const VERSION = "4.1.5";
+
+const {
+  CONSENT_DIALOG_STATE_UNKNOWN,
+  CONSENT_DIALOG_STATE_APPLIES,
+  CONSENT_DIALOG_STATE_DOES_NOT_APPLY,
+} = AppLovinMAX.getConstants();
 
 /**
  * This enum represents whether or not the consent dialog should be shown for this user.
@@ -15,37 +22,17 @@ const ConsentDialogState = {
   /**
    * The consent dialog state could not be determined. This is likely due to SDK failing to initialize.
    */
-  UNKNOWN: 0,
+  UNKNOWN: CONSENT_DIALOG_STATE_UNKNOWN,
 
   /**
    * This user should be shown a consent dialog.
    */
-  APPLIES: 1,
+  APPLIES: CONSENT_DIALOG_STATE_APPLIES,
 
   /**
    * This user should not be shown a consent dialog.
    */
-  DOES_NOT_APPLY: 2,
-};
-
-const emitter = new NativeEventEmitter(AppLovinMAX);
-const subscriptions = {};
-
-const addEventListener = (event, handler) => {
-  let subscription = emitter.addListener(event, handler);
-  let currentSubscription = subscriptions[event];
-  if (currentSubscription) {
-    currentSubscription.remove();
-  }
-  subscriptions[event] = subscription;
-};
-
-const removeEventListener = (event) => {
-  let currentSubscription = subscriptions[event];
-  if (currentSubscription) {
-    currentSubscription.remove();
-    delete subscriptions[event];
-  }
+  DOES_NOT_APPLY: CONSENT_DIALOG_STATE_DOES_NOT_APPLY,
 };
 
 const runIfInitialized = (callingMethodName, callingMethod, ...params) => {
@@ -301,6 +288,7 @@ const getConsentDialogState = () => {
 
 export default {
   ...AppLovinMAX,
+  ...EventListeners,
   AdView,
   get targetingData() {
     return TargetingData;
@@ -311,8 +299,6 @@ export default {
   AdViewPosition,
   AdFormat,
   NativeAdView,
-  addEventListener,
-  removeEventListener,
   initialize(sdkKey) {
     return AppLovinMAX.initialize(VERSION, sdkKey);
   },


### PR DESCRIPTION
Add event listeners using event names.   The new event listeners are defined in a new file at [src/AppLovinMAXEventListeners.js](https://github.com/AppLovin/AppLovin-MAX-React-Native/compare/ref/add_event_listeners_using_event_names?expand=1#diff-bb476dcdf4b5ea3df4b07282a10c7b22ae17675805c6e958e77b829dcb408118).  

Also, the constants are replaced with those exposed from the native modules.

