### PR TITLE
fix/configuration_type_in_initialize

### DIFF
--- a/ios/AppLovinMAX.m
+++ b/ios/AppLovinMAX.m
@@ -311,7 +311,7 @@ RCT_EXPORT_METHOD(initialize:(NSString *)pluginVersion :(NSString *)sdkKey :(RCT
         self.sdkConfiguration = configuration;
         self.sdkInitialized = YES;
         
-        resolve(@[@{@"countryCode" : self.sdk.configuration.countryCode}]);
+        resolve(@{@"countryCode" : self.sdk.configuration.countryCode});
     }];
 }
 


### PR DESCRIPTION
Fix the configuration type in initialize from an array of maps to a single map in iOS.

There is a discrepancy in accessing the output of the `initialize()` configuration between iOS and Android. 

iOS: `configuration[0].countryCode`
Android: `configuration.countryCode`

Somehow, iOS has an array of values.