### PR TITLE
feat/add_apis_for_local_extra_parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Versions
 
 ## x.x.x
+* Add APIs for setting SDK local extra parameters.
 * Remove kotlin dependency from build.
 * Add support for callback functions to  `AppLovinAdView` and `AppLovinNativeAdView` native UI components.
 * Update synchronous APIs to use `Promise`s.

--- a/android/src/main/java/com/applovin/reactnative/AppLovinMAXAdView.java
+++ b/android/src/main/java/com/applovin/reactnative/AppLovinMAXAdView.java
@@ -11,10 +11,13 @@ import com.applovin.mediation.MaxAdRevenueListener;
 import com.applovin.mediation.MaxAdViewAdListener;
 import com.applovin.mediation.MaxError;
 import com.applovin.mediation.ads.MaxAdView;
+import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.events.RCTEventEmitter;
 import com.facebook.react.views.view.ReactViewGroup;
+
+import java.util.Map;
 
 import androidx.annotation.Nullable;
 
@@ -27,14 +30,21 @@ class AppLovinMAXAdView
 {
     private final ThemedReactContext reactContext;
 
-    private @Nullable MaxAdView adView;
+    @Nullable
+    private MaxAdView adView;
 
-    private           String      adUnitId;
-    private           MaxAdFormat adFormat;
-    private @Nullable String      placement;
-    private @Nullable String      customData;
-    private           boolean     adaptiveBannerEnabled;
-    private           boolean     autoRefresh;
+    private String              adUnitId;
+    private MaxAdFormat         adFormat;
+    @Nullable
+    private String              placement;
+    @Nullable
+    private String              customData;
+    private boolean             adaptiveBannerEnabled;
+    private boolean             autoRefresh;
+    @Nullable
+    private Map<String, Object> extraParameters;
+    @Nullable
+    private Map<String, Object> localExtraParameters;
 
     public AppLovinMAXAdView(final Context context)
     {
@@ -129,6 +139,22 @@ class AppLovinMAXAdView
         }
     }
 
+    public void setExtraParameters(@Nullable final ReadableMap readableMap)
+    {
+        if ( readableMap != null )
+        {
+            extraParameters = readableMap.toHashMap();
+        }
+    }
+
+    public void setLocalExtraParameters(@Nullable final ReadableMap readableMap)
+    {
+        if ( readableMap != null )
+        {
+            localExtraParameters = readableMap.toHashMap();
+        }
+    }
+
     @Override
     public void requestLayout()
     {
@@ -215,6 +241,22 @@ class AppLovinMAXAdView
             adView.setExtraParameter( "adaptive_banner", Boolean.toString( adaptiveBannerEnabled ) );
             // Set this extra parameter to work around a SDK bug that ignores calls to stopAutoRefresh()
             adView.setExtraParameter( "allow_pause_auto_refresh_immediately", "true" );
+
+            if ( extraParameters != null )
+            {
+                for ( Map.Entry<String, Object> entry : extraParameters.entrySet() )
+                {
+                    adView.setExtraParameter( entry.getKey(), (String) entry.getValue() );
+                }
+            }
+
+            if ( localExtraParameters != null )
+            {
+                for ( Map.Entry<String, Object> entry : localExtraParameters.entrySet() )
+                {
+                    adView.setLocalExtraParameter( entry.getKey(), (String) entry.getValue() );
+                }
+            }
 
             if ( autoRefresh )
             {

--- a/android/src/main/java/com/applovin/reactnative/AppLovinMAXAdViewManager.java
+++ b/android/src/main/java/com/applovin/reactnative/AppLovinMAXAdViewManager.java
@@ -1,11 +1,11 @@
 package com.applovin.reactnative;
 
 import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.common.MapBuilder;
 import com.facebook.react.uimanager.SimpleViewManager;
 import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.annotations.ReactProp;
-
 
 import java.util.Map;
 
@@ -82,6 +82,18 @@ class AppLovinMAXAdViewManager
     public void setAdFormat(final AppLovinMAXAdView view, final String adFormatStr)
     {
         view.setAdFormat( adFormatStr );
+    }
+
+    @ReactProp(name = "extraParameters")
+    public void setExtraParameters(final AppLovinMAXAdView view, @Nullable final ReadableMap value)
+    {
+        view.setExtraParameters( value );
+    }
+
+    @ReactProp(name = "localExtraParameters")
+    public void setLocalExtraParameters(final AppLovinMAXAdView view, @Nullable final ReadableMap value)
+    {
+        view.setLocalExtraParameters( value );
     }
 
     @Override

--- a/android/src/main/java/com/applovin/reactnative/AppLovinMAXModule.java
+++ b/android/src/main/java/com/applovin/reactnative/AppLovinMAXModule.java
@@ -768,6 +768,12 @@ public class AppLovinMAXModule
     }
 
     @ReactMethod
+    public void setBannerLocalExtraParameter(final String adUnitId, final String key, final String value)
+    {
+        setAdViewLocalExtraParameters( adUnitId, getDeviceSpecificBannerAdViewAdFormat(), key, value );
+    }
+
+    @ReactMethod
     public void startBannerAutoRefresh(final String adUnitId)
     {
         startAutoRefresh( adUnitId, getDeviceSpecificBannerAdViewAdFormat() );
@@ -827,6 +833,18 @@ public class AppLovinMAXModule
     public void updateMRecPosition(final String adUnitId, final String mrecPosition)
     {
         updateAdViewPosition( adUnitId, mrecPosition, DEFAULT_AD_VIEW_OFFSET, MaxAdFormat.MREC );
+    }
+
+    @ReactMethod
+    public void setMRecExtraParameter(final String adUnitId, final String key, final String value)
+    {
+        setAdViewExtraParameters( adUnitId, MaxAdFormat.MREC, key, value );
+    }
+
+    @ReactMethod
+    public void setMRecLocalExtraParameter(final String adUnitId, final String key, final String value)
+    {
+        setAdViewLocalExtraParameters( adUnitId, MaxAdFormat.MREC, key, value );
     }
 
     @ReactMethod
@@ -895,6 +913,13 @@ public class AppLovinMAXModule
         interstitial.setExtraParameter( key, value );
     }
 
+    @ReactMethod
+    public void setInterstitialLocalExtraParameter(final String adUnitId, final String key, final String value)
+    {
+        MaxInterstitialAd interstitial = retrieveInterstitial( adUnitId );
+        interstitial.setLocalExtraParameter( key, value );
+    }
+
     // REWARDED
 
     @ReactMethod
@@ -931,6 +956,13 @@ public class AppLovinMAXModule
         rewardedAd.setExtraParameter( key, value );
     }
 
+    @ReactMethod
+    public void setRewardedAdLocalExtraParameter(final String adUnitId, final String key, final String value)
+    {
+        MaxRewardedAd rewardedAd = retrieveRewardedAd( adUnitId );
+        rewardedAd.setLocalExtraParameter( key, value );
+    }
+
     // APP OPEN AD
 
     @ReactMethod
@@ -959,6 +991,13 @@ public class AppLovinMAXModule
     {
         MaxAppOpenAd appOpenAd = retrieveAppOpenAd( adUnitId );
         appOpenAd.setExtraParameter( key, value );
+    }
+
+    @ReactMethod
+    public void setAppOpenAdLocalExtraParameter(final String adUnitId, final String key, final String value)
+    {
+        MaxAppOpenAd appOpenAd = retrieveAppOpenAd( adUnitId );
+        appOpenAd.setLocalExtraParameter( key, value );
     }
 
     // AD CALLBACKS
@@ -1534,6 +1573,28 @@ public class AppLovinMAXModule
 
                     positionAdView( adUnitId, adFormat );
                 }
+            }
+        } );
+    }
+
+    private void setAdViewLocalExtraParameters(final String adUnitId, final MaxAdFormat adFormat, final String key, final String value)
+    {
+        getReactApplicationContext().runOnUiQueueThread( new Runnable()
+        {
+            @Override
+            public void run()
+            {
+                d( "Setting " + adFormat.getLabel() + " local extra with key: \"" + key + "\" value: " + value );
+
+                // Retrieve ad view from the map
+                final MaxAdView adView = retrieveAdView( adUnitId, adFormat );
+                if ( adView == null )
+                {
+                    e( adFormat.getLabel() + " does not exist" );
+                    return;
+                }
+
+                adView.setLocalExtraParameter( key, value );
             }
         } );
     }

--- a/android/src/main/java/com/applovin/reactnative/AppLovinMAXNativeAdView.java
+++ b/android/src/main/java/com/applovin/reactnative/AppLovinMAXNativeAdView.java
@@ -54,6 +54,8 @@ public class AppLovinMAXNativeAdView
     private String              customData;
     @Nullable
     private Map<String, Object> extraParameters;
+    @Nullable
+    private Map<String, Object> localExtraParameters;
 
     // TODO: Allow publisher to select which views are clickable and which isn't via prop
     private final List<View> clickableViews = new ArrayList<>();
@@ -103,6 +105,14 @@ public class AppLovinMAXNativeAdView
         }
     }
 
+    public void setLocalExtraParameters(@Nullable final ReadableMap readableMap)
+    {
+        if ( readableMap != null )
+        {
+            localExtraParameters = readableMap.toHashMap();
+        }
+    }
+
     public void loadAd()
     {
         if ( isLoading.compareAndSet( false, true ) )
@@ -124,6 +134,14 @@ public class AppLovinMAXNativeAdView
                 for ( Map.Entry<String, Object> entry : extraParameters.entrySet() )
                 {
                     adLoader.setExtraParameter( entry.getKey(), (String) entry.getValue() );
+                }
+            }
+
+            if ( localExtraParameters != null )
+            {
+                for ( Map.Entry<String, Object> entry : localExtraParameters.entrySet() )
+                {
+                    adLoader.setLocalExtraParameter( entry.getKey(), (String) entry.getValue() );
                 }
             }
 
@@ -366,7 +384,7 @@ public class AppLovinMAXNativeAdView
         if ( !Float.isNaN( aspectRatio ) )
         {
             // The aspect ratio can be 0.0f when it is not provided by the network.
-            if ( Math.signum( aspectRatio )  == 0 )
+            if ( Math.signum( aspectRatio ) == 0 )
             {
                 nativeAdInfo.putDouble( "mediaContentAspectRatio", 1.0 );
             }

--- a/android/src/main/java/com/applovin/reactnative/AppLovinMAXNativeAdViewManager.java
+++ b/android/src/main/java/com/applovin/reactnative/AppLovinMAXNativeAdViewManager.java
@@ -100,6 +100,12 @@ public class AppLovinMAXNativeAdViewManager
         view.setExtraParameters( value );
     }
 
+    @ReactProp(name = "localExtraParameters")
+    public void setLocalExtraParameters(final AppLovinMAXNativeAdView view, @Nullable final ReadableMap value)
+    {
+        view.setLocalExtraParameters( value );
+    }
+
     @ReactProp(name = "titleView")
     public void setTitleView(final AppLovinMAXNativeAdView view, final int value)
     {

--- a/ios/AppLovinMAX.m
+++ b/ios/AppLovinMAX.m
@@ -598,6 +598,11 @@ RCT_EXPORT_METHOD(setBannerExtraParameter:(NSString *)adUnitIdentifier :(NSStrin
     [self setAdViewExtraParameterForAdUnitIdentifier: adUnitIdentifier adFormat: DEVICE_SPECIFIC_ADVIEW_AD_FORMAT key: key value: value];
 }
 
+RCT_EXPORT_METHOD(setBannerLocalExtraParameter:(NSString *)adUnitIdentifier :(NSString *)key :(nullable NSString*)value)
+{
+    [self setAdViewLocalExtraParameterForAdUnitIdentifier: adUnitIdentifier adFormat: DEVICE_SPECIFIC_ADVIEW_AD_FORMAT key: key value: value];
+}
+
 RCT_EXPORT_METHOD(startBannerAutoRefresh:(NSString *)adUnitIdentifier)
 {
     [self startAutoRefresh: adUnitIdentifier adFormat: DEVICE_SPECIFIC_ADVIEW_AD_FORMAT];
@@ -648,6 +653,16 @@ RCT_EXPORT_METHOD(setMRecCustomData:(NSString *)adUnitIdentifier :(nullable NSSt
 RCT_EXPORT_METHOD(updateMRecPosition:(NSString *)mrecPosition :(NSString *)adUnitIdentifier)
 {
     [self updateAdViewPosition: mrecPosition withOffset: CGPointZero forAdUnitIdentifier: adUnitIdentifier adFormat: MAAdFormat.mrec];
+}
+
+RCT_EXPORT_METHOD(setMRecExtraParameter:(NSString *)adUnitIdentifier :(NSString *)key :(nullable NSString *)value)
+{
+    [self setAdViewExtraParameterForAdUnitIdentifier: adUnitIdentifier adFormat: MAAdFormat.mrec key: key value: value];
+}
+
+RCT_EXPORT_METHOD(setMRecLocalExtraParameter:(NSString *)adUnitIdentifier :(NSString *)key :(nullable NSString*)value)
+{
+    [self setAdViewLocalExtraParameterForAdUnitIdentifier: adUnitIdentifier adFormat: MAAdFormat.mrec key: key value: value];
 }
 
 RCT_EXPORT_METHOD(startMRecAutoRefresh:(NSString *)adUnitIdentifier)
@@ -701,6 +716,12 @@ RCT_EXPORT_METHOD(setInterstitialExtraParameter:(NSString *)adUnitIdentifier :(N
     [interstitial setExtraParameterForKey: key value: value];
 }
 
+RCT_EXPORT_METHOD(setInterstitialLocalExtraParameter:(NSString *)adUnitIdentifier :(NSString *)key :(nullable NSString *)value)
+{
+    MAInterstitialAd *interstitial = [self retrieveInterstitialForAdUnitIdentifier: adUnitIdentifier];
+    [interstitial setLocalExtraParameterForKey: key value: value];
+}
+
 #pragma mark - Rewarded
 
 RCT_EXPORT_METHOD(loadRewardedAd:(NSString *)adUnitIdentifier)
@@ -727,6 +748,12 @@ RCT_EXPORT_METHOD(setRewardedAdExtraParameter:(NSString *)adUnitIdentifier :(NSS
     [rewardedAd setExtraParameterForKey: key value: value];
 }
 
+RCT_EXPORT_METHOD(setRewardedAdLocalExtraParameter:(NSString *)adUnitIdentifier :(NSString *)key :(nullable NSString *)value)
+{
+    MARewardedAd *rewardedAd = [self retrieveRewardedAdForAdUnitIdentifier: adUnitIdentifier];
+    [rewardedAd setLocalExtraParameterForKey: key value: value];
+}
+
 #pragma mark - App Open Ad
 
 RCT_EXPORT_METHOD(loadAppOpenAd:(NSString *)adUnitIdentifier)
@@ -751,6 +778,12 @@ RCT_EXPORT_METHOD(setAppOpenAdExtraParameter:(NSString *)adUnitIdentifier key:(N
 {
     MAAppOpenAd *appOpenAd = [self retrieveAppOpenAdForAdUnitIdentifier: adUnitIdentifier];
     [appOpenAd setExtraParameterForKey: key value: value];
+}
+
+RCT_EXPORT_METHOD(setAppOpenAdLocalExtraParameter:(NSString *)adUnitIdentifier key:(NSString *)key value:(nullable NSString *)value)
+{
+    MAAppOpenAd *appOpenAd = [self retrieveAppOpenAdForAdUnitIdentifier: adUnitIdentifier];
+    [appOpenAd setLocalExtraParameterForKey: key value: value];
 }
 
 #pragma mark - Ad Callbacks
@@ -1160,6 +1193,17 @@ RCT_EXPORT_METHOD(setAppOpenAdExtraParameter:(NSString *)adUnitIdentifier key:(N
             
             [self positionAdViewForAdUnitIdentifier: adUnitIdentifier adFormat: adFormat];
         }
+    });
+}
+
+- (void)setAdViewLocalExtraParameterForAdUnitIdentifier:(NSString *)adUnitIdentifier adFormat:(MAAdFormat *)adFormat key:(NSString *)key value:(nullable NSString *)value
+{
+    dispatch_async(dispatch_get_main_queue(), ^{
+        
+        [self log: @"Setting %@ local extra with key: \"%@\" value: \"%@\"", adFormat, key, value];
+        
+        MAAdView *adView = [self retrieveAdViewForAdUnitIdentifier: adUnitIdentifier adFormat: adFormat];
+        [adView setLocalExtraParameterForKey: key value: value];
     });
 }
 

--- a/ios/AppLovinMAXAdView.m
+++ b/ios/AppLovinMAXAdView.m
@@ -20,6 +20,8 @@
 @property (nonatomic, copy, nullable) NSString *customData;
 @property (nonatomic, assign, readonly, getter=isAdaptiveBannerEnabled) BOOL adaptiveBannerEnabled;
 @property (nonatomic, assign, readonly, getter=isAutoRefresh) BOOL autoRefresh;
+@property (nonatomic, copy, nullable) NSDictionary *extraParameters;
+@property (nonatomic, copy, nullable) NSDictionary *localExtraParameters;
 
 @property (nonatomic, copy) RCTDirectEventBlock onAdLoadedEvent;
 @property (nonatomic, copy) RCTDirectEventBlock onAdLoadFailedEvent;
@@ -160,6 +162,16 @@
         [self.adView setExtraParameterForKey: @"adaptive_banner" value: [self isAdaptiveBannerEnabled] ? @"true" : @"false"];
         // Set this extra parameter to work around a SDK bug that ignores calls to stopAutoRefresh()
         [self.adView setExtraParameterForKey: @"allow_pause_auto_refresh_immediately" value: @"true"];
+        
+        for ( NSString *key in self.extraParameters )
+        {
+            [self.adView setExtraParameterForKey: key value: self.extraParameters[key]];
+        }
+        
+        for ( NSString *key in self.localExtraParameters )
+        {
+            [self.adView setLocalExtraParameterForKey: key value: self.localExtraParameters[key]];
+        }
         
         if ( [self isAutoRefresh] )
         {

--- a/ios/AppLovinMAXAdViewManager.m
+++ b/ios/AppLovinMAXAdViewManager.m
@@ -19,6 +19,8 @@ RCT_EXPORT_VIEW_PROPERTY(placement, NSString)
 RCT_EXPORT_VIEW_PROPERTY(customData, NSString)
 RCT_EXPORT_VIEW_PROPERTY(adaptiveBannerEnabled, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(autoRefresh, BOOL)
+RCT_EXPORT_VIEW_PROPERTY(extraParameters, NSDictionary)
+RCT_EXPORT_VIEW_PROPERTY(localExtraParameters, NSDictionary)
 
 RCT_EXPORT_VIEW_PROPERTY(onAdLoadedEvent, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onAdLoadFailedEvent, RCTDirectEventBlock)

--- a/ios/AppLovinMAXNativeAdView.m
+++ b/ios/AppLovinMAXNativeAdView.m
@@ -30,6 +30,7 @@
 @property (nonatomic, copy, nullable) NSString *placement;
 @property (nonatomic, copy, nullable) NSString *customData;
 @property (nonatomic, copy, nullable) NSDictionary *extraParameters;
+@property (nonatomic, copy, nullable) NSDictionary *localExtraParameters;
 
 // Callback to `AppLovinNativeAdView.js`
 @property (nonatomic, copy) RCTDirectEventBlock onAdLoadedEvent;
@@ -106,6 +107,11 @@
         for ( NSString *key in self.extraParameters )
         {
             [self.adLoader setExtraParameterForKey: key value: self.extraParameters[key]];
+        }
+        
+        for ( NSString *key in self.localExtraParameters )
+        {
+            [self.adLoader setLocalExtraParameterForKey: key value: self.localExtraParameters[key]];
         }
         
         [self.adLoader loadAd];

--- a/ios/AppLovinMAXNativeAdViewManager.m
+++ b/ios/AppLovinMAXNativeAdViewManager.m
@@ -18,6 +18,7 @@ RCT_EXPORT_VIEW_PROPERTY(adUnitId, NSString)
 RCT_EXPORT_VIEW_PROPERTY(placement, NSString)
 RCT_EXPORT_VIEW_PROPERTY(customData, NSString)
 RCT_EXPORT_VIEW_PROPERTY(extraParameters, NSDictionary)
+RCT_EXPORT_VIEW_PROPERTY(localExtraParameters, NSDictionary)
 
 // Callback
 RCT_EXPORT_VIEW_PROPERTY(onAdLoadedEvent, RCTDirectEventBlock)

--- a/src/AppLovinMAXAdView.js
+++ b/src/AppLovinMAXAdView.js
@@ -37,7 +37,7 @@ export const AdViewPosition = {
 };
 
 const AdView = (props) => {
-  const {style, ...otherProps} = props;
+  const {style, extraParameters, localExtraParameters, ...otherProps} = props;
   const [isInitialized, setIsInitialized] = useState(false);
   const [dimensions, setDimensions] = useState({});
 
@@ -111,6 +111,19 @@ const AdView = (props) => {
     if (props.onAdRevenuePaid) props.onAdRevenuePaid(event.nativeEvent);
   };
 
+  const checkExtraParameters = (name, params) => {
+    if (params) {
+      for (const key in params) {
+        const value = params[key];
+        if ((value != null) && (value != undefined) && (typeof value !== 'string')) {
+          console.warn(name + " in AdView supports only string values: " + key);
+          delete params[key];
+        }
+      }
+    }
+    return params;
+  };
+
   // Not initialized
   if (!isInitialized) {
     return null;
@@ -128,6 +141,8 @@ const AdView = (props) => {
   return (
     <AppLovinMAXAdView
       style={{...style, ...dimensions}}
+      extraParameters={checkExtraParameters('extraParameters', extraParameters)}
+      localExtraParameters={checkExtraParameters('localExtraParameters', localExtraParameters)}
       onAdLoadedEvent={onAdLoadedEvent}
       onAdLoadFailedEvent={onAdLoadFailedEvent}
       onAdDisplayFailedEvent={onAdDisplayFailedEvent}
@@ -170,6 +185,16 @@ AdView.propTypes = {
    * A boolean value representing whether or not to enable auto-refresh. Note that auto-refresh is enabled by default.
    */
   autoRefresh: PropTypes.bool,
+
+  /**
+   * A dictionary value representing the extra parameters to set a list of key-value string pairs.
+   */
+  extraParameters: PropTypes.object,
+
+  /**
+   * A dictionary value representing the local extra parameters to set a list of key-value string pairs.
+   */
+  localExtraParameters: PropTypes.object,
 
   /**
    * A callback fuction to be fired when a new ad has been loaded.

--- a/src/NativeAdView.js
+++ b/src/NativeAdView.js
@@ -40,6 +40,8 @@ const AppLovinMAXNativeAdView = requireNativeComponent('AppLovinMAXNativeAdView'
 // 3. update of the nativeAd context by onNativeAdLoaded, which renders the ad components with nativeAd
 const NativeAdView = forwardRef((props, ref) => {
 
+  const {extraParameters, localExtraParameters, ...otherProps} = props;
+
   // context from NativeAdViewProvider
   const {nativeAd, nativeAdView, setNativeAd, setNativeAdView} = useContext(NativeAdViewContext);
 
@@ -85,14 +87,29 @@ const NativeAdView = forwardRef((props, ref) => {
     if (props.onAdRevenuePaid) props.onAdRevenuePaid(event.nativeEvent);
   };
 
+  const checkExtraParameters = (name, params) => {
+    if (params) {
+      for (const key in params) {
+        const value = params[key];
+        if ((value != null) && (value != undefined) && (typeof value !== 'string')) {
+          console.warn(name + " in NativeAdView supports only string values: " + key);
+          delete params[key];
+        }
+      }
+    }
+    return params;
+  };
+
   return (
     <AppLovinMAXNativeAdView
       ref={saveElement}
+      extraParameters={checkExtraParameters('extraParameters', extraParameters)}
+      localExtraParameters={checkExtraParameters('localExtraParameters', localExtraParameters)}
       onAdLoadedEvent={onAdLoadedEvent}
       onAdLoadFailedEvent={onAdLoadFailedEvent}
       onAdClickedEvent={onAdClickedEvent}
       onAdRevenuePaidEvent={onAdRevenuePaidEvent}
-      {...props}
+      {...otherProps}
     >
       {props.children}
     </AppLovinMAXNativeAdView>
@@ -119,6 +136,11 @@ NativeAdView.propTypes = {
    * A dictionary value representing the extra parameters to set a list of key-value string pairs.
    */
   extraParameters: PropTypes.object,
+
+  /**
+   * A dictionary value representing the local extra parameters to set a list of key-value string pairs.
+   */
+  localExtraParameters: PropTypes.object,
 
   /**
    * A callback fuction to be fired when a new ad has been loaded.

--- a/src/index.js
+++ b/src/index.js
@@ -65,8 +65,22 @@ const updateBannerOffsets = (adUnitId, xOffset, yOffset) => {
 }
 
 const setBannerExtraParameter = (adUnitId, key, value) => {
+  if ((value != null) && (value != undefined) && (typeof value !== 'string')) {
+    console.warn(setBannerExtraParameter.name + " supports only string values: " + key);
+    return;
+  }
   return runIfInitialized(setBannerExtraParameter.name,
                           AppLovinMAX.setBannerExtraParameter,
+                          adUnitId, key, value);
+}
+
+const setBannerLocalExtraParameter = (adUnitId, key, value) => {
+  if ((value != null) && (value != undefined) && (typeof value !== 'string')) {
+    console.warn(setBannerLocalExtraParameter.name + " supports only string values: " + key);
+    return;
+  }
+  return runIfInitialized(setBannerLocalExtraParameter.name,
+                          AppLovinMAX.setBannerLocalExtraParameter,
                           adUnitId, key, value);
 }
 
@@ -110,12 +124,6 @@ const createMRec = (adUnitId, mrecPosition) => {
                           adUnitId, mrecPosition);
 }
 
-const setMRecBackgroundColor = (adUnitId, hexColorCode) => {
-  return runIfInitialized(setMRecBackgroundColor.name,
-                          AppLovinMAX.setMRecBackgroundColor,
-                          adUnitId, hexColorCode);
-}
-
 const setMRecPlacement = (adUnitId, placement) => {
   return runIfInitialized(setMRecPlacement.name,
                           AppLovinMAX.setMRecPlacement,
@@ -135,8 +143,22 @@ const updateMRecPosition = (adUnitId, mrecPosition) => {
 }
 
 const setMRecExtraParameter = (adUnitId, key, value) => {
+  if ((value != null) && (value != undefined) && (typeof value !== 'string')) {
+    console.warn(setMRecExtraParameter.name + " supports only string values: " + key);
+    return;
+  }
   return runIfInitialized(setMRecExtraParameter.name,
                           AppLovinMAX.setMRecExtraParameter,
+                          adUnitId, key, value);
+}
+
+const setMRecLocalExtraParameter = (adUnitId, key, value) => {
+  if ((value != null) && (value != undefined) && (typeof value !== 'string')) {
+    console.warn(setMRecLocalExtraParameter.name + " supports only string values: " + key);
+    return;
+  }
+  return runIfInitialized(setMRecLocalExtraParameter.name,
+                          AppLovinMAX.setMRecLocalExtraParameter,
                           adUnitId, key, value);
 }
 
@@ -193,8 +215,21 @@ const showInterstitial = (adUnitId, ...params) => {
 };
 
 const setInterstitialExtraParameter = (adUnitId, key, value) => {
+  if ((value != null) && (value != undefined) && (typeof value !== 'string')) {
+    console.warn(setInterstitialExtraParameter.name + " supports only string values: " + key);
+    return;
+  }
   return runIfInitialized(setInterstitialExtraParameter.name,
                           AppLovinMAX.setInterstitialExtraParameter,
+                          adUnitId, key, value);
+}
+const setInterstitialLocalExtraParameter = (adUnitId, key, value) => {
+  if ((value != null) && (value != undefined) && (typeof value !== 'string')) {
+    console.warn(setInterstitialLocalExtraParameter.name + " supports only string values: " + key);
+    return;
+  }
+  return runIfInitialized(setInterstitialLocalExtraParameter.name,
+                          AppLovinMAX.setInterstitialLocalExtraParameter,
                           adUnitId, key, value);
 }
 
@@ -221,8 +256,22 @@ const showRewardedAd = (adUnitId, ...params) => {
 };
 
 const setRewardedAdExtraParameter = (adUnitId, key, value) => {
+  if ((value != null) && (value != undefined) && (typeof value !== 'string')) {
+    console.warn(setRewardedAdExtraParameter.name + " supports only string values: " + key);
+    return;
+  }
   return runIfInitialized(setRewardedAdExtraParameter.name,
                           AppLovinMAX.setRewardedAdExtraParameter,
+                          adUnitId, key, value);
+}
+
+const setRewardedAdLocalExtraParameter = (adUnitId, key, value) => {
+  if ((value != null) && (value != undefined) && (typeof value !== 'string')) {
+    console.warn(setRewardedAdLocalExtraParameter.name + " supports only string values: " + key);
+    return;
+  }
+  return runIfInitialized(setRewardedAdLocalExtraParameter.name,
+                          AppLovinMAX.setRewardedAdLocalExtraParameter,
                           adUnitId, key, value);
 }
 
@@ -249,8 +298,22 @@ const showAppOpenAd = (adUnitId, ...params) => {
 };
 
 const setAppOpenAdExtraParameter = (adUnitId, key, value) => {
+  if ((value != null) && (value != undefined) && (typeof value !== 'string')) {
+    console.warn(setAppOpenAdExtraParameter.name + " supports only string values: " + key);
+    return;
+  }
   return runIfInitialized(setAppOpenAdExtraParameter.name,
                           AppLovinMAX.setAppOpenAdExtraParameter,
+                          adUnitId, key, value);
+}
+
+const setAppOpenAdLocalExtraParameter = (adUnitId, key, value) => {
+  if ((value != null) && (value != undefined) && (typeof value !== 'string')) {
+    console.warn(setAppOpenAdLocalExtraParameter.name + " supports only string values: " + key);
+    return;
+  }
+  return runIfInitialized(setAppOpenAdLocalExtraParameter.name,
+                          AppLovinMAX.setAppOpenAdLocalExtraParameter,
                           adUnitId, key, value);
 }
 
@@ -281,6 +344,7 @@ export default {
   updateBannerPosition,
   updateBannerOffsets,
   setBannerExtraParameter,
+  setBannerLocalExtraParameter,
   startBannerAutoRefresh,
   stopBannerAutoRefresh,
   showBanner,
@@ -291,11 +355,11 @@ export default {
   /* MRECS */
   /*-------*/
   createMRec,
-  setMRecBackgroundColor,
   setMRecPlacement,
   setMRecCustomData,
   updateMRecPosition,
   setMRecExtraParameter,
+  setMRecLocalExtraParameter,
   startMRecAutoRefresh,
   stopMRecAutoRefresh,
   showMRec,
@@ -309,6 +373,7 @@ export default {
   isInterstitialReady,
   showInterstitial,
   setInterstitialExtraParameter,
+  setInterstitialLocalExtraParameter,
 
   /*----------*/
   /* REWARDED */
@@ -317,6 +382,7 @@ export default {
   isRewardedAdReady,
   showRewardedAd,
   setRewardedAdExtraParameter,
+  setRewardedAdLocalExtraParameter,
 
   /*----------*/
   /* APP OPEN */
@@ -325,6 +391,7 @@ export default {
   isAppOpenAdReady,
   showAppOpenAd,
   setAppOpenAdExtraParameter,
+  setAppOpenAdLocalExtraParameter,
 
   /*----------------------*/
   /** AUTO-DECLARED APIs **/


### PR DESCRIPTION
Add APIs for setting SDK local extra parameters.

- Allows string values only for now.
- Check the value type before sending it to the platform.

Verified for the adaptor to receive local parameters by using Smaato.