### PR TITLE
fixed NullPointerException MaxInterstitialAd.isReady

### DIFF
--- a/android/src/main/java/com/applovin/reactnative/AppLovinMAXModule.java
+++ b/android/src/main/java/com/applovin/reactnative/AppLovinMAXModule.java
@@ -1178,6 +1178,11 @@ public class AppLovinMAXModule
         }
 
         MaxInterstitialAd interstitial = retrieveInterstitial( adUnitId );
+        if ( interstitial == null )
+        {
+            promise.resolve( false );
+            return;
+        }
         promise.resolve( interstitial.isReady() );
     }
 
@@ -1246,6 +1251,11 @@ public class AppLovinMAXModule
         }
 
         MaxRewardedAd rewardedAd = retrieveRewardedAd( adUnitId );
+        if ( rewardedAd == null )
+        {
+            promise.resolve( false );
+            return;
+        }
         promise.resolve( rewardedAd.isReady() );
     }
 
@@ -1308,6 +1318,11 @@ public class AppLovinMAXModule
         }
 
         MaxAppOpenAd appOpenAd = retrieveAppOpenAd( adUnitId );
+        if ( appOpenAd == null )
+        {
+            promise.resolve( false );
+            return;
+        }
         promise.resolve( appOpenAd.isReady() );
     }
 

--- a/ios/AppLovinMAX.m
+++ b/ios/AppLovinMAX.m
@@ -929,6 +929,11 @@ RCT_EXPORT_METHOD(isInterstitialReady:(NSString *)adUnitIdentifier :(RCTPromiseR
     }
 
     MAInterstitialAd *interstitial = [self retrieveInterstitialForAdUnitIdentifier: adUnitIdentifier];
+    if ( !interstitial ) 
+    {
+        resolve(@(NO));
+        return;
+    }
     resolve(@([interstitial isReady]));
 }
 
@@ -986,6 +991,11 @@ RCT_EXPORT_METHOD(isRewardedAdReady:(NSString *)adUnitIdentifier :(RCTPromiseRes
     }
 
     MARewardedAd *rewardedAd = [self retrieveRewardedAdForAdUnitIdentifier: adUnitIdentifier];
+    if ( !rewardedAd ) 
+    {
+        resolve(@(NO));
+        return;
+    }
     resolve(@([rewardedAd isReady]));
 }
 
@@ -1043,6 +1053,11 @@ RCT_EXPORT_METHOD(isAppOpenAdReady:(NSString *)adUnitIdentifier :(RCTPromiseReso
     }
 
     MAAppOpenAd *appOpenAd = [self retrieveAppOpenAdForAdUnitIdentifier: adUnitIdentifier];
+    if ( !appOpenAd ) 
+    {
+        resolve(@(NO));
+        return;
+    }
     resolve(@([appOpenAd isReady]));
 }
 


### PR DESCRIPTION
### Fixed bugs NullPointerException
```
java.lang.NullPointerException: Attempt to invoke virtual method 'boolean com.applovin.mediation.ads.MaxInterstitialAd.isReady()' on a null object reference
    at com.applovin.reactnative.AppLovinMAXModule.isInterstitialReady(AppLovinMAXModule.java:1181)
    at java.lang.reflect.Method.invoke(Method.java)
    at java.lang.reflect.Method.invoke(Method.java:372)
    at com.facebook.react.bridge.JavaMethodWrapper.invoke(JavaMethodWrapper.java:372)
    at com.facebook.react.bridge.JavaModuleWrapper.invoke(JavaModuleWrapper.java:188)
    at com.facebook.jni.NativeRunnable.run(NativeRunnable.java)
    at android.os.Handler.handleCallback(Handler.java:815)
    at android.os.Handler.dispatchMessage(Handler.java:104)
    at com.facebook.react.bridge.queue.MessageQueueThreadHandler.dispatchMessage(MessageQueueThreadHandler.java:27)
    at android.os.Looper.loop(Looper.java:224)
    at com.facebook.react.bridge.queue.MessageQueueThreadImpl$4.run(MessageQueueThreadImpl.java:228)
    at java.lang.Thread.run(Thread.java:818)
```