### PR TITLE
fix/image_source_null_warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Versions
 
+## x.x.x
+* Fix a warning of `image source of null` with `AppLovinMAX.NativeAdView.IconView`.
 ## 5.0.2
 * Gracefully handle inter and rewarded ad calls when current `Activity` is null.
 ## 5.0.1

--- a/src/NativeAdComponents.js
+++ b/src/NativeAdComponents.js
@@ -94,7 +94,7 @@ export const IconView = (props) => {
   const {nativeAd, nativeAdView} = useContext(NativeAdViewContext);
 
   useEffect(() => {
-    if (!nativeAdView || !(nativeAd.url || nativeAd.image)) return;
+    if (!nativeAdView || !nativeAd.image) return;
 
     nativeAdView.setNativeProps({
       iconView: findNodeHandle(imageRef.current),
@@ -104,7 +104,8 @@ export const IconView = (props) => {
   if (!nativeAdView) return null;
 
   return (
-    <Image {...props} ref={imageRef} source={{uri: nativeAd.url || null}}/>
+    nativeAd?.url ? <Image {...props} source={{uri: nativeAd.url}} /> :
+      nativeAd?.image ? <Image {...props} ref={imageRef} /> : <Image {...props} />
   );
 };
 

--- a/src/NativeAdComponents.js
+++ b/src/NativeAdComponents.js
@@ -105,7 +105,8 @@ export const IconView = (props) => {
 
   return (
     nativeAd?.url ? <Image {...props} source={{uri: nativeAd.url}} /> :
-      nativeAd?.image ? <Image {...props} ref={imageRef} /> : <Image {...props} />
+      nativeAd?.image ? <Image {...props} ref={imageRef} /> : 
+      <Image {...props} />
   );
 };
 


### PR DESCRIPTION
Fix a warning of `image source of null` with `AppLovinMAX.NativeAdView.IconView`.