### PR TITLE
Fix NPE for accessing a null options/media view in onLayoutChange().

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Versions
 
 ## x.x.x
+* Fix NPE in `onLayoutChange()` for accessing a null options/media view of the native ads.
 * Add back Terms flow.
 * Add `title`, `advertiser`, `body`, `callToAction`, `isIconImageAvailable`, `isOptionsViewAvailable`, and `isMediaViewAvailable`  to ad object of native ad UI callbacks.
 * Fix a warning of `image source of null` with `AppLovinMAX.NativeAdView.IconView`.

--- a/android/src/main/java/com/applovin/reactnative/AppLovinMAXNativeAdView.java
+++ b/android/src/main/java/com/applovin/reactnative/AppLovinMAXNativeAdView.java
@@ -289,11 +289,11 @@ public class AppLovinMAXNativeAdView
     @Override
     public void onLayoutChange(View view, int left, int top, int right, int bottom, int oldLeft, int oldTop, int oldRight, int oldBottom)
     {
-        if ( view == mediaView.getParent() )
+        if ( mediaView != null && view == mediaView.getParent() )
         {
             sizeToFit( mediaView, view );
         }
-        else if ( view == optionsView.getParent() )
+        else if ( optionsView != null && view == optionsView.getParent() )
         {
             sizeToFit( optionsView, view );
         }


### PR DESCRIPTION
Fixed an issue from https://github.com/AppLovin/AppLovin-MAX-React-Native/issues/196.   I can't reproduce it but it might happen when rotated during initialization or destruction.

```
Fatal Exception: java.lang.NullPointerException: Attempt to invoke virtual method 'android.view.ViewParent android.view.View.getParent()' on a null object reference
at com.applovin.reactnative.AppLovinMAXNativeAdView.onLayoutChange(:2)
at android.view.View.layout(View.java:24992)
at android.view.ViewGroup.layout(ViewGroup.java:6784)
at com.facebook.react.uimanager.NativeViewHierarchyManager.updateLayout(NativeViewHierarchyManager.java:25)
at com.facebook.react.uimanager.NativeViewHierarchyManager.updateLayout(NativeViewHierarchyManager.java:90)
at com.facebook.react.uimanager.UIViewOperationQueue$UpdateLayoutOperation.execute(UIViewOperationQueue.java:27)
at com.facebook.react.uimanager.UIViewOperationQueue$1.run(UIViewOperationQueue.java:135)
at com.facebook.react.uimanager.UIViewOperationQueue.flushPendingBatches(UIViewOperationQueue.java:53)
at com.facebook.react.uimanager.UIViewOperationQueue.access$2600(UIViewOperationQueue.java)
at com.facebook.react.uimanager.UIViewOperationQueue$2.runGuarded(UIViewOperationQueue.java:2)
at com.facebook.react.bridge.GuardedRunnable.run()
at android.os.Handler.handleCallback(Handler.java:942)
at android.os.Handler.dispatchMessage(Handler.java:99)
at android.os.Looper.loopOnce(Looper.java:226)
at android.os.Looper.loop(Looper.java:313)
at android.app.ActivityThread.main(ActivityThread.java:8757)
at java.lang.reflect.Method.invoke(Method.java)
at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:571)
at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1067)
```