### PR TITLE
feat/add_support_for_star_rating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Versions
 
+## x.x.x
+* Add Star Rating support for native ads with `AppLovinMAX.NativeAdView.StarRatingView` and `adInfo.nativeAd.starRating` via `onAdLoaded(adInfo)`.
 ## 5.1.0
 * Add back Terms flow.
 * Add `title`, `advertiser`, `body`, `callToAction`, `isIconImageAvailable`, `isOptionsViewAvailable`, and `isMediaViewAvailable`  to ad object of native ad UI callbacks.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Versions
 
 ## x.x.x
-* Add Star Rating support for native ads with `AppLovinMAX.NativeAdView.StarRatingView` and `adInfo.nativeAd.starRating` via `onAdLoaded(adInfo)`.
+* Add support for Star Ratings in native ads through `AppLovinMAX.NativeAdView.StarRatingView` and `adInfo.nativeAd.starRating` accessible via `onAdLoaded(adInfo)`.
 ## 5.1.0
 * Add back Terms flow.
 * Add `title`, `advertiser`, `body`, `callToAction`, `isIconImageAvailable`, `isOptionsViewAvailable`, and `isMediaViewAvailable`  to ad object of native ad UI callbacks.

--- a/android/src/main/java/com/applovin/reactnative/AppLovinMAXNativeAdView.java
+++ b/android/src/main/java/com/applovin/reactnative/AppLovinMAXNativeAdView.java
@@ -390,6 +390,7 @@ public class AppLovinMAXNativeAdView
         nativeAdInfo.putString( "advertiser", ad.getAdvertiser() );
         nativeAdInfo.putString( "body", ad.getBody() );
         nativeAdInfo.putString( "callToAction", ad.getCallToAction() );
+        nativeAdInfo.putDouble( "starRating", ad.getStarRating() );
 
         float aspectRatio = ad.getMediaContentAspectRatio();
         if ( !Float.isNaN( aspectRatio ) )
@@ -423,6 +424,7 @@ public class AppLovinMAXNativeAdView
         jsNativeAd.putString( "advertiser", ad.getAdvertiser() );
         jsNativeAd.putString( "body", ad.getBody() );
         jsNativeAd.putString( "callToAction", ad.getCallToAction() );
+        jsNativeAd.putDouble( "starRating", ad.getStarRating() );
 
         MaxNativeAdImage icon = ad.getIcon();
         if ( icon != null )

--- a/example/src/NativeAdViewExample.js
+++ b/example/src/NativeAdViewExample.js
@@ -44,6 +44,7 @@ export const NativeAdViewExample = forwardRef((props, ref) => {
                     <AppLovinMAX.NativeAdView.IconView style={styles.icon}/>
                     <View style={{flexDirection: 'column', flexGrow: 1}}>
                         <AppLovinMAX.NativeAdView.TitleView style={styles.title}/>
+                        <AppLovinMAX.NativeAdView.StarRatingView style={styles.starRatingView}/>
                         <AppLovinMAX.NativeAdView.AdvertiserView style={styles.advertiser}/>
                     </View>
                     <AppLovinMAX.NativeAdView.OptionsView style={styles.optionsView}/>
@@ -63,7 +64,7 @@ const styles = StyleSheet.create({
         backgroundColor: '#EFEFEF',
     },
     title: {
-        fontSize: 20,
+        fontSize: 16,
         marginTop: 4,
         marginHorizontal: 5,
         textAlign: 'left',
@@ -72,7 +73,7 @@ const styles = StyleSheet.create({
     },
     icon: {
         margin: 5,
-        height: 40,
+        height: 48,
         aspectRatio: 1,
         borderRadius: 5,
     },
@@ -81,17 +82,22 @@ const styles = StyleSheet.create({
         width: 20,
         backgroundColor: '#EFEFEF',
     },
+    starRatingView: {
+        marginHorizontal: 5,
+        fontSize: 10, // size of each star as unicode symbol
+        color: '#ffe234',
+        backgroundColor: '#EFEFEF',
+    },
     advertiser: {
         marginHorizontal: 5,
-        marginTop: 2,
         textAlign: 'left',
-        fontSize: 16,
+        fontSize: 12,
         fontWeight: '400',
         color: 'gray',
     },
     body: {
         fontSize: 14,
-        marginVertical: 8,
+        marginVertical: 4,
     },
     mediaView: {
         alignSelf: 'center',

--- a/ios/AppLovinMAXNativeAdView.m
+++ b/ios/AppLovinMAXNativeAdView.m
@@ -284,6 +284,7 @@
     nativeAdInfo[@"advertiser"] = ad.advertiser;
     nativeAdInfo[@"body"] = ad.body;
     nativeAdInfo[@"callToAction"] = ad.callToAction;
+    nativeAdInfo[@"starRating"] = ad.starRating;
 
     if ( !isnan(ad.mediaContentAspectRatio) )
     {
@@ -316,6 +317,7 @@
     jsNativeAd[@"advertiser"] = ad.advertiser;
     jsNativeAd[@"body"] = ad.body;
     jsNativeAd[@"callToAction"] = ad.callToAction;
+    jsNativeAd[@"starRating"] = ad.starRating;
 
     if ( ad.icon )
     {

--- a/src/NativeAdComponents.js
+++ b/src/NativeAdComponents.js
@@ -1,4 +1,4 @@
-import React, {useContext, useRef, useEffect} from "react";
+import React, {useContext, useRef, useEffect, useCallback} from "react";
 import {findNodeHandle, Text, Image, View, TouchableOpacity} from "react-native";
 import {NativeAdViewContext} from "./NativeAdViewProvider";
 
@@ -126,7 +126,7 @@ export const OptionsView = (props) => {
   if (!nativeAdView) return null;
 
   return (
-    <View {...props} ref={viewRef}/>
+    <View {...props} ref={viewRef} />
   );
 };
 
@@ -146,6 +146,61 @@ export const MediaView = (props) => {
   if (!nativeAdView) return null;
 
   return (
-    <View {...props} ref={viewRef}/>
+    <View {...props} ref={viewRef} />
+  );
+};
+
+export const StarRatingView = (props) => {
+  const {style, ...otherProps} = props;
+
+  const maxStarCount = 5;
+  const starColor = style.color ?? "#ffe234";
+  const starSize = style.fontSize ?? 10;
+
+  const {nativeAd, nativeAdView} = useContext(NativeAdViewContext);
+
+  const FilledStar = useCallback(({size,color}) => {
+    return (
+      // black star in unicode
+      <Text style={{fontSize: size, color: color}}>{String.fromCodePoint(0x2605)}</Text>
+    );
+  });
+
+  const EmptyStar = useCallback(({size,color}) => {
+    return (
+      // white star in unicode
+      <Text style={{fontSize: size, color: color}}>{String.fromCodePoint(0x2606)}</Text>
+    );
+  });
+
+  const StarView = useCallback(({index, rating, size, color}) => {
+    const width = (rating - index) * size;
+    return (
+      <View>
+        <EmptyStar size={size} color={color} />
+        {
+          (rating > index) &&
+            <View style={{ width: width, overflow: 'hidden', position: 'absolute'}}>
+              <FilledStar style={{top:0, left:0}} size={size} color={color} />
+            </View>
+        }
+      </View>
+    );
+  });
+
+  if (!nativeAdView) return null;
+
+  return (
+    <View style={[style, {flexDirection: 'row', alignItems: 'center'}]}>
+    {
+      Array(maxStarCount).fill().map((j, i) => {
+        if (nativeAd.starRating) {
+          return (<StarView key={i} index={i} rating={nativeAd.starRating} size={starSize} color={starColor} />);
+        } else {
+          return (<Text key={i} style={{fontSize: starSize}}> </Text>);
+        }
+      })
+    }
+    </View>
   );
 };

--- a/src/NativeAdComponents.js
+++ b/src/NativeAdComponents.js
@@ -1,4 +1,4 @@
-import React, {useContext, useRef, useEffect, useCallback} from "react";
+import React, {useContext, useRef, useEffect} from "react";
 import {findNodeHandle, Text, Image, View, TouchableOpacity} from "react-native";
 import {NativeAdViewContext} from "./NativeAdViewProvider";
 
@@ -159,21 +159,21 @@ export const StarRatingView = (props) => {
 
   const {nativeAd, nativeAdView} = useContext(NativeAdViewContext);
 
-  const FilledStar = useCallback(({size,color}) => {
+  const FilledStar = ({size,color}) => {
     return (
       // black star in unicode
       <Text style={{fontSize: size, color: color}}>{String.fromCodePoint(0x2605)}</Text>
     );
-  });
+  };
 
-  const EmptyStar = useCallback(({size,color}) => {
+  const EmptyStar = ({size,color}) => {
     return (
       // white star in unicode
       <Text style={{fontSize: size, color: color}}>{String.fromCodePoint(0x2606)}</Text>
     );
-  });
+  };
 
-  const StarView = useCallback(({index, rating, size, color}) => {
+  const StarView = ({index, rating, size, color}) => {
     const width = (rating - index) * size;
     return (
       <View>
@@ -186,21 +186,23 @@ export const StarRatingView = (props) => {
         }
       </View>
     );
-  });
+  };
 
   if (!nativeAdView) return null;
 
   return (
     <View style={[style, {flexDirection: 'row', alignItems: 'center'}]}>
-    {
-      Array(maxStarCount).fill().map((j, i) => {
-        if (nativeAd.starRating) {
-          return (<StarView key={i} index={i} rating={nativeAd.starRating} size={starSize} color={starColor} />);
-        } else {
-          return (<Text key={i} style={{fontSize: starSize}}> </Text>);
+      {(() => {
+        let stars = [];
+        for (let index = 0; index < maxStarCount; index++) {
+          if (nativeAd.starRating) {
+            stars.push(<StarView key={index} index={index} rating={nativeAd.starRating} size={starSize} color={starColor} />);
+          } else {
+            stars.push(<Text key={index} style={{fontSize: starSize}}> </Text>);
+          }
         }
-      })
-    }
+        return stars;
+      })()}
     </View>
   );
 };

--- a/src/NativeAdView.js
+++ b/src/NativeAdView.js
@@ -2,7 +2,7 @@ import React, { forwardRef, useContext, useImperativeHandle, useRef, useState, u
 import PropTypes from "prop-types";
 import { NativeModules, requireNativeComponent, UIManager, findNodeHandle } from "react-native";
 import { NativeAdViewContext, NativeAdViewProvider } from "./NativeAdViewProvider";
-import { TitleView, AdvertiserView, BodyView, CallToActionView, IconView, OptionsView, MediaView } from "./NativeAdComponents";
+import { TitleView, AdvertiserView, BodyView, CallToActionView, IconView, OptionsView, MediaView, StarRatingView } from "./NativeAdComponents";
 
 const { AppLovinMAX } = NativeModules;
 
@@ -159,5 +159,6 @@ NativeAdViewWrapper.CallToActionView = CallToActionView;
 NativeAdViewWrapper.IconView = IconView;
 NativeAdViewWrapper.OptionsView = OptionsView;
 NativeAdViewWrapper.MediaView = MediaView;
+NativeAdViewWrapper.StarRatingView = StarRatingView;
 
 export default NativeAdViewWrapper;


### PR DESCRIPTION
Add support for Star Rating:

- `StarRatingView` UI component
- `adInfo.nativeAd.starRating` via `onAdLoaded(adInfo)`

Snapshot of star rating at 3.5:

<img width="374" alt="Screenshot 2023-04-11 at 11 16 19 AM" src="https://user-images.githubusercontent.com/100324169/231038222-f1b15f8e-2756-4506-b7e0-8c63511494d2.png">
