### PR TITLE
fix/image_source_null_warning

### DIFF
--- a/src/NativeAdComponents.js
+++ b/src/NativeAdComponents.js
@@ -106,7 +106,7 @@ export const IconView = (props) => {
   return (
     nativeAd.url ? <Image {...props} source={{uri: nativeAd.url}} /> :
       nativeAd.image ? <Image {...props} ref={imageRef} /> : 
-      <Image {...props} />
+      <View {...props} />
   );
 };
 


### PR DESCRIPTION
This is the 2nd attempt to fix issue #184.

The 1st attempt is to fix when `nativeAd.url` is null or undefined.  But, after the 1st change, `<Image {...props} />` is mounted before `nativeAd` becomes available, which again generates a warning of `image source of null`.

The root cause of this warning message is `source` is not provided.  `<View {...props} />` should be the best component as a placeholder.
