### PR TITLE
ref/increase_minsdkversion_android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Versions
 
+## x.x.x
+* Increase minSDKversion in Android from 16 to 21 to support `gradlew build`.
 ## 5.2.0
 * Depend on Android SDK 11.9.0 and iOS SDK 11.9.0.
 * Add support for Star Ratings in native ads through `AppLovinMAX.NativeAdView.StarRatingView` and `adInfo.nativeAd.starRating` accessible via `onAdLoaded(adInfo)`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Versions
 
 ## x.x.x
-* Increase minSDKversion in Android from 16 to 21 to support `gradlew build`.
+* Increase the `minSdk` required to build the project's build script (e.g. `./gradlew build`) from 16 to 21.
 ## 5.2.0
 * Depend on Android SDK 11.9.0 and iOS SDK 11.9.0.
 * Add support for Star Ratings in native ads through `AppLovinMAX.NativeAdView.StarRatingView` and `adInfo.nativeAd.starRating` accessible via `onAdLoaded(adInfo)`.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -33,7 +33,7 @@ android {
   compileSdkVersion getExtOrIntegerDefault('compileSdkVersion')
   buildToolsVersion getExtOrDefault('buildToolsVersion')
   defaultConfig {
-    minSdkVersion 21
+    minSdkVersion 16
     targetSdkVersion getExtOrIntegerDefault('targetSdkVersion')
     versionCode 5020000
     versionName "5.2.0"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
   ext.versions = [
-          'minSdk'                : 16,
+          'minSdk'                : 21,
           'compileSdk'            : 29,
           'targetSdk'             : 29,
           'playServicesIdentifier': "16.0.0",
@@ -33,7 +33,7 @@ android {
   compileSdkVersion getExtOrIntegerDefault('compileSdkVersion')
   buildToolsVersion getExtOrDefault('buildToolsVersion')
   defaultConfig {
-    minSdkVersion 16
+    minSdkVersion 21
     targetSdkVersion getExtOrIntegerDefault('targetSdkVersion')
     versionCode 5020000
     versionName "5.2.0"


### PR DESCRIPTION
Increase `minSdkVersion` in Android from 16 to 21 to support `gradlew build`.    #204 reported.

When `gradlew build` is issued,  one of the gradle tasks, `processDebugAndroidTestManifest`, fails with RN 0.71 because it requires `minSdkVersion` to be 21.


But, `processDebugAndroidTestManifest` won't be invoked with either `gradlew installDebug` or `gradlew assembleRelease`. 

It seems to me that we can stay with 16, and those who need to run `gradlew build` can manually update `minSdkVersion`.    Please review.

