### PR TITLE
fix/displaying_iconview_before_dom_node_becomes_available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Versions
 
+## x.x.x
+* Fix IconView not being displayed when setting it up with an empty DOM node.
 ## 5.2.3
 * Fix banner/MREC crashes related to previous release.
 * Fix privacy states potentially not setting if called without an active `Activity`.

--- a/src/NativeAdComponents.js
+++ b/src/NativeAdComponents.js
@@ -94,12 +94,12 @@ export const IconView = (props) => {
   const {nativeAd, nativeAdView} = useContext(NativeAdViewContext);
 
   useEffect(() => {
-    if (!nativeAdView || !nativeAd.image) return;
+    if (!nativeAdView || !nativeAd.image || !imageRef.current) return;
 
     nativeAdView.setNativeProps({
       iconView: findNodeHandle(imageRef.current),
     });
-  }, [nativeAd, nativeAdView]);
+  }, [nativeAd, nativeAdView, imageRef.current]);
 
   if (!nativeAdView) return null;
 


### PR DESCRIPTION
IconView is sometimes not displayed when its property is a drawable image which the native module will set.   The reason is the DOM node i.e. `imageRef` is still unavailable when JS hands it over to the native module.  `imageRef` should be checked before calling `nativeAdView.setNativeProps()`.