### PR TITLE
feat/support_expo_plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,3 +113,6 @@ package-lock.json
 .vscode/settings.json
 .gitattributes
 .editorconfig
+
+# Expo Plugin
+!plugin/build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Versions
 
 ## x.x.x
+* Add support for Expo config.
 * Fix IconView not being displayed when setting it up with an empty DOM node.
 ## 5.2.3
 * Fix banner/MREC crashes related to previous release.

--- a/app.plugin.js
+++ b/app.plugin.js
@@ -1,0 +1,1 @@
+module.exports = require('./plugin/build/withAppLovinMAX');

--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
     "android",
     "ios",
     "react-native-applovin-max.podspec",
-    "package.json"
+    "package.json",
+    "app.plugin.js",
+    "plugin"
   ],
   "scripts": {},
   "keywords": [

--- a/plugin/build/withAppLovinMAX.d.ts
+++ b/plugin/build/withAppLovinMAX.d.ts
@@ -1,0 +1,3 @@
+import { ConfigPlugin } from '@expo/config-plugins';
+declare const _default: ConfigPlugin<void>;
+export default _default;

--- a/plugin/build/withAppLovinMAX.js
+++ b/plugin/build/withAppLovinMAX.js
@@ -1,0 +1,18 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const config_plugins_1 = require("@expo/config-plugins");
+const withAppLovinMAXAndroid_1 = require("./withAppLovinMAXAndroid");
+const withAppLovinMAXiOS_1 = require("./withAppLovinMAXiOS");
+const pkg = require('react-native-applovin-max/package.json');
+const withAppLovinMAX = (config, props) => {
+    if (props.android) {
+        config = (0, withAppLovinMAXAndroid_1.withAppLovinMAXManifest)(config, props.android);
+        config = (0, withAppLovinMAXAndroid_1.withAppLovinMAXBuildGradle)(config, props.android);
+    }
+    if (props.ios) {
+        config = (0, withAppLovinMAXiOS_1.withAppLovinMAXInfoPlist)(config, props.ios);
+        config = (0, withAppLovinMAXiOS_1.withAppLovinMAXPodFile)(config, props.ios);
+    }
+    return config;
+};
+exports.default = (0, config_plugins_1.createRunOncePlugin)(withAppLovinMAX, pkg.name, pkg.version);

--- a/plugin/build/withAppLovinMAXAndroid.d.ts
+++ b/plugin/build/withAppLovinMAXAndroid.d.ts
@@ -1,0 +1,3 @@
+import { ConfigPlugin } from '@expo/config-plugins';
+export declare const withAppLovinMAXManifest: ConfigPlugin;
+export declare const withAppLovinMAXBuildGradle: ConfigPlugin;

--- a/plugin/build/withAppLovinMAXAndroid.js
+++ b/plugin/build/withAppLovinMAXAndroid.js
@@ -1,0 +1,99 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.withAppLovinMAXBuildGradle = exports.withAppLovinMAXManifest = void 0;
+const config_plugins_1 = require("@expo/config-plugins");
+const { getMainApplicationOrThrow, addMetaDataItemToMainApplication, removeMetaDataItemFromMainApplication, } = config_plugins_1.AndroidConfig.Manifest;
+const withAppLovinMAXManifest = (config, props) => {
+    return (0, config_plugins_1.withAndroidManifest)(config, (config) => {
+        config.modResults = setAppLovinMAXConfig(config.modResults, props);
+        return config;
+    });
+};
+exports.withAppLovinMAXManifest = withAppLovinMAXManifest;
+const setAppLovinMAXConfig = (androidManifest, props) => {
+    if (!props.metaDataMainApplication)
+        return androidManifest;
+    let mainApplication = getMainApplicationOrThrow(androidManifest);
+    for (const item of props.metaDataMainApplication) {
+        addMetaDataItemToMainApplication(mainApplication, item.name, item.value);
+    }
+    return androidManifest;
+};
+const setAppLovinQualityServiceDependency = (rootBuildGradle, props) => {
+    const appLovinRepositories = `maven { url 'https://artifacts.applovin.com/android' }`;
+    const appLovinDependencies = `classpath ('com.applovin.quality:AppLovinQualityServiceGradlePlugin:+')`;
+    if (!rootBuildGradle.includes(appLovinRepositories)) {
+        rootBuildGradle = rootBuildGradle.replace(/repositories\s?{/, `repositories { \n        ${appLovinRepositories}`);
+    }
+    if (!rootBuildGradle.includes(appLovinDependencies)) {
+        rootBuildGradle = rootBuildGradle.replace(/dependencies\s?{/, `dependencies { \n        ${appLovinDependencies}`);
+    }
+    return rootBuildGradle;
+};
+const setAppLovinRepositories = (rootBuildGradle, props) => {
+    if (!props.dependencies)
+        return rootBuildGradle;
+    let repositories = [];
+    // check duplicates
+    for (const item of props.dependencies) {
+        if (!item.repository)
+            continue;
+        if (!rootBuildGradle.includes(item.repository)) {
+            repositories.push(item.repository);
+        }
+    }
+    let str = '\n';
+    for (const item of repositories) {
+        str += '        ' + item + '\n';
+    }
+    rootBuildGradle = rootBuildGradle.replace(/allprojects *{\n.*repositories\s?{/, `allprojects {\n    repositories {\n${str}`);
+    return rootBuildGradle;
+};
+const setAppLovinDependencies = (appBuildGradle, props) => {
+    if (!props.dependencies)
+        return appBuildGradle;
+    let implementations = [];
+    // check duplicates
+    for (const item of props.dependencies) {
+        if (!appBuildGradle.includes(item.dependency)) {
+            implementations.push(item.dependency);
+        }
+    }
+    // add the applovin sdk
+    implementations.push("implementation (\"com.applovin:applovin-sdk:+\")");
+    let str = '\n';
+    for (const item of implementations) {
+        str += '    ' + item + '\n';
+    }
+    appBuildGradle = appBuildGradle.replace(/dependencies\s?{/, `dependencies { ${str}`);
+    return appBuildGradle;
+};
+const setAppLovinQualityServicePluginAndAPIKey = (appBuildGradle, props) => {
+    if (!props.adReviewKey)
+        return appBuildGradle;
+    const appLovinPlugin = `\napply plugin: "applovin-quality-service"`;
+    const appLovinAPIKey = `\napplovin { apiKey "` + props.adReviewKey + `" }`;
+    if (!appBuildGradle.includes(appLovinPlugin)) {
+        appBuildGradle += appLovinPlugin;
+    }
+    if (!appBuildGradle.includes(appLovinAPIKey)) {
+        appBuildGradle += appLovinAPIKey;
+    }
+    return appBuildGradle;
+};
+const withAppLovinMAXBuildGradle = (config, props) => {
+    // root build gradle
+    config = (0, config_plugins_1.withProjectBuildGradle)(config, (config) => {
+        config.modResults.contents = setAppLovinQualityServiceDependency(config.modResults.contents, props);
+        config.modResults.contents = setAppLovinRepositories(config.modResults.contents, props);
+        return config;
+    });
+    // app build gradle
+    config = (0, config_plugins_1.withAppBuildGradle)(config, (config) => {
+        config.modResults.contents = setAppLovinQualityServicePluginAndAPIKey(config.modResults.contents, props);
+        config.modResults.contents = setAppLovinDependencies(config.modResults.contents, props);
+        return config;
+    });
+    return config;
+};
+exports.withAppLovinMAXBuildGradle = withAppLovinMAXBuildGradle;

--- a/plugin/build/withAppLovinMAXiOS.d.ts
+++ b/plugin/build/withAppLovinMAXiOS.d.ts
@@ -1,0 +1,3 @@
+import { ConfigPlugin } from '@expo/config-plugins';
+export declare const withAppLovinMAXInfoPlist: ConfigPlugin;
+export declare const withAppLovinMAXPodFile: ConfigPlugin;

--- a/plugin/build/withAppLovinMAXiOS.js
+++ b/plugin/build/withAppLovinMAXiOS.js
@@ -1,0 +1,93 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.withAppLovinMAXPodFile = exports.withAppLovinMAXInfoPlist = void 0;
+const config_plugins_1 = require("@expo/config-plugins");
+const path_1 = require("path");
+const fs_1 = require("fs");
+const withAppLovinMAXInfoPlist = (config, props) => {
+    return (0, config_plugins_1.withInfoPlist)(config, (config) => {
+        config.modResults = setAppLovinMAXConfig(config.modResults, props);
+        config.modResults = setSKAdNetworkIdentifiers(config.modResults, props);
+        return config;
+    });
+};
+exports.withAppLovinMAXInfoPlist = withAppLovinMAXInfoPlist;
+const setAppLovinMAXConfig = (infoPlist, props) => {
+    if (!props.infoPlist)
+        return infoPlist;
+    for (const item of props.infoPlist) {
+        infoPlist[item.key] = item.value;
+    }
+    return infoPlist;
+};
+const setSKAdNetworkIdentifiers = (infoPlist, props) => {
+    if (!props.skAdNetworkIdFile)
+        return infoPlist;
+    let skAdNetworkIdContent;
+    // console.log("Loading SKAdNetworkIds from " + props.skAdNetworkIdFile);
+    try {
+        skAdNetworkIdContent = (0, fs_1.readFileSync)(props.skAdNetworkIdFile, 'utf-8');
+    }
+    catch (err) {
+        console.error("Can't read " + props.skAdNetworkIdFile + " for SKAdNetworkIds");
+        return infoPlist;
+    }
+    // Use regexp to find a list of SKAdNetwork strings instead of using a DOM parser since there is
+    // no standard DOM parser in Node.js.
+    const regexp = new RegExp("<string>(.*?)</string>", "g");
+    const matchedStringList = skAdNetworkIdContent.match(regexp);
+    if (!matchedStringList) {
+        console.error("SKAdNetworkIdentifier not found in " + props.skAdNetworkIdFile);
+        return infoPlist;
+    }
+    // extract a string from the tagged string
+    const skAdNetworkIdList = matchedStringList.map(s => s.replace(/<string>|<\/string>/g, ""));
+    if (!skAdNetworkIdList) {
+        console.error("SKAdNetworkIdentifier not found in " + props.skAdNetworkIdFile);
+        return infoPlist;
+    }
+    if (!Array.isArray(infoPlist.SKAdNetworkItems)) {
+        infoPlist.SKAdNetworkItems = [];
+    }
+    // Get ids
+    let existingIds = infoPlist.SKAdNetworkItems.map((item) => item?.SKAdNetworkIdentifier ?? null).filter(Boolean);
+    // remove duplicates
+    existingIds = [...new Set(existingIds)];
+    for (let i = 0; i < skAdNetworkIdList.length; i++) {
+        const skAdNetworkId = skAdNetworkIdList[i];
+        if (!existingIds.includes(skAdNetworkId)) {
+            infoPlist.SKAdNetworkItems.push({
+                SKAdNetworkIdentifier: skAdNetworkId,
+            });
+        }
+    }
+    return infoPlist;
+};
+const updatePodfileContentsWithDependencies = (contents, props) => {
+    if (!props.dependencies)
+        return contents;
+    const patchKey = "post_install";
+    const slicedContent = contents.split(patchKey);
+    slicedContent[0] += '\n';
+    slicedContent[0] += "  pod 'AppLovinSDK'\n";
+    slicedContent[0] += '\n';
+    for (const item of props.dependencies) {
+        slicedContent[0] += "  " + item + "\n";
+    }
+    slicedContent[0] += '\n';
+    return slicedContent.join(patchKey);
+};
+const withAppLovinMAXPodFile = (config, props) => {
+    return (0, config_plugins_1.withDangerousMod)(config, [
+        'ios',
+        async (c) => {
+            const { platformProjectRoot } = c.modRequest;
+            const podfile = (0, path_1.resolve)(platformProjectRoot, 'Podfile');
+            const contents = (0, fs_1.readFileSync)(podfile, 'utf-8');
+            const updatedContents = updatePodfileContentsWithDependencies(contents, props);
+            (0, fs_1.writeFileSync)(podfile, updatedContents);
+            return c;
+        }
+    ]);
+};
+exports.withAppLovinMAXPodFile = withAppLovinMAXPodFile;

--- a/plugin/src/withAppLovinMAX.ts
+++ b/plugin/src/withAppLovinMAX.ts
@@ -1,0 +1,22 @@
+import { ConfigPlugin, createRunOncePlugin } from '@expo/config-plugins';
+import { withAppLovinMAXManifest, withAppLovinMAXBuildGradle } from './withAppLovinMAXAndroid';
+import { withAppLovinMAXInfoPlist, withAppLovinMAXPodFile } from './withAppLovinMAXiOS';
+
+const pkg = require('react-native-applovin-max/package.json');
+
+const withAppLovinMAX: ConfigPlugin = (config, props: any) => {
+
+    if (props.android) {
+        config = withAppLovinMAXManifest(config, props.android);
+        config = withAppLovinMAXBuildGradle(config, props.android);
+    }
+
+    if (props.ios) {
+        config = withAppLovinMAXInfoPlist(config, props.ios);
+        config = withAppLovinMAXPodFile(config, props.ios);
+    }
+
+    return config;
+};
+
+export default createRunOncePlugin(withAppLovinMAX, pkg.name, pkg.version);

--- a/plugin/src/withAppLovinMAXAndroid.ts
+++ b/plugin/src/withAppLovinMAXAndroid.ts
@@ -1,0 +1,147 @@
+import {
+    AndroidConfig,
+    ConfigPlugin,
+    withAndroidManifest,
+    withAppBuildGradle,
+    withProjectBuildGradle
+} from '@expo/config-plugins';
+
+const {
+    getMainApplicationOrThrow,
+    addMetaDataItemToMainApplication,
+    removeMetaDataItemFromMainApplication,
+} = AndroidConfig.Manifest;
+
+export const withAppLovinMAXManifest: ConfigPlugin = (config, props) => {
+    return withAndroidManifest(config, (config) => {
+        config.modResults = setAppLovinMAXConfig(config.modResults, props);
+        return config;
+    });
+};
+
+const setAppLovinMAXConfig = (androidManifest: AndroidConfig.Manifest.AndroidManifest, props: any) => {
+    if (!props.metaDataMainApplication) return androidManifest;
+
+    let mainApplication = getMainApplicationOrThrow(androidManifest);
+
+    for (const item of props.metaDataMainApplication) {
+        addMetaDataItemToMainApplication(
+            mainApplication,
+            item.name,
+            item.value
+        );
+    }
+
+    return androidManifest;
+};
+
+const setAppLovinQualityServiceDependency = (rootBuildGradle: string, props: any) => {
+    const appLovinRepositories = `maven { url 'https://artifacts.applovin.com/android' }`;
+    const appLovinDependencies = `classpath ('com.applovin.quality:AppLovinQualityServiceGradlePlugin:+')`;
+
+    if (!rootBuildGradle.includes(appLovinRepositories)) {
+        rootBuildGradle = rootBuildGradle.replace(
+            /repositories\s?{/,
+            `repositories { \n        ${appLovinRepositories}`
+        );
+    }
+
+    if (!rootBuildGradle.includes(appLovinDependencies)) {
+        rootBuildGradle = rootBuildGradle.replace(
+            /dependencies\s?{/,
+            `dependencies { \n        ${appLovinDependencies}`
+        );
+    }
+
+    return rootBuildGradle;
+};
+
+const setAppLovinRepositories = (rootBuildGradle: string, props: any) => {
+    if (!props.dependencies) return rootBuildGradle;
+
+    let repositories = [];
+
+    // check duplicates
+    for (const item of props.dependencies) {
+        if (!item.repository) continue;
+        if (!rootBuildGradle.includes(item.repository)) {
+            repositories.push(item.repository)
+        }
+    }
+
+    let str = '\n';
+    for (const item of repositories) {
+        str += '        ' + item + '\n';
+    }
+
+    rootBuildGradle = rootBuildGradle.replace(
+        /allprojects *{\n.*repositories\s?{/,
+        `allprojects {\n    repositories {\n${str}`
+    );
+
+    return rootBuildGradle;
+}
+
+const setAppLovinDependencies = (appBuildGradle: string, props: any) => {
+    if (!props.dependencies) return appBuildGradle;
+
+    let implementations = [];
+
+    // check duplicates
+    for (const item of props.dependencies) {
+        if (!appBuildGradle.includes(item.dependency)) {
+            implementations.push(item.dependency);
+        }
+    }
+
+    // add the applovin sdk
+    implementations.push("implementation (\"com.applovin:applovin-sdk:+\")");
+
+    let str = '\n';
+    for (const item of implementations) {
+        str += '    ' + item + '\n';
+    }
+
+    appBuildGradle = appBuildGradle.replace(
+        /dependencies\s?{/,
+        `dependencies { ${str}`
+    );
+
+    return appBuildGradle;
+};
+
+const setAppLovinQualityServicePluginAndAPIKey = (appBuildGradle: string, props: any) => {
+    if (!props.adReviewKey) return appBuildGradle;
+
+    const appLovinPlugin = `\napply plugin: "applovin-quality-service"`;
+    const appLovinAPIKey = `\napplovin { apiKey "` + props.adReviewKey + `" }`;
+
+    if (!appBuildGradle.includes(appLovinPlugin)) {
+        appBuildGradle += appLovinPlugin;
+    }
+
+    if (!appBuildGradle.includes(appLovinAPIKey)) {
+        appBuildGradle += appLovinAPIKey;
+    }
+
+    return appBuildGradle;
+};
+
+export const withAppLovinMAXBuildGradle: ConfigPlugin = (config, props) => {
+
+    // root build gradle
+    config = withProjectBuildGradle(config, (config) => {
+        config.modResults.contents = setAppLovinQualityServiceDependency(config.modResults.contents, props);
+        config.modResults.contents = setAppLovinRepositories(config.modResults.contents, props);
+        return config;
+    });
+
+    // app build gradle
+    config = withAppBuildGradle(config, (config) => {
+        config.modResults.contents = setAppLovinQualityServicePluginAndAPIKey(config.modResults.contents, props);
+        config.modResults.contents = setAppLovinDependencies(config.modResults.contents, props);
+        return config;
+    });
+
+    return config;
+};

--- a/plugin/src/withAppLovinMAXiOS.ts
+++ b/plugin/src/withAppLovinMAXiOS.ts
@@ -1,0 +1,114 @@
+import {
+    ConfigPlugin,
+    InfoPlist,
+    IOSConfig,
+    withInfoPlist,
+    withPlugins,
+    withDangerousMod,
+} from '@expo/config-plugins';
+
+import { resolve } from 'path';
+import { writeFileSync, readFileSync } from 'fs';
+
+export const withAppLovinMAXInfoPlist: ConfigPlugin = (config, props) => {
+    return withInfoPlist(config, (config) => {
+        config.modResults = setAppLovinMAXConfig(config.modResults, props);
+        config.modResults = setSKAdNetworkIdentifiers(config.modResults, props);
+        return config;
+    });
+};
+
+const setAppLovinMAXConfig = (infoPlist: InfoPlist, props: any) => {
+    if (!props.infoPlist) return infoPlist;
+
+    for (const item of props.infoPlist) {
+        infoPlist[item.key] = item.value;
+    }
+
+    return infoPlist;
+};
+
+const setSKAdNetworkIdentifiers = (infoPlist: InfoPlist, props: any) => {
+    if (!props.skAdNetworkIdFile) return infoPlist;
+
+    let skAdNetworkIdContent;
+
+    // console.log("Loading SKAdNetworkIds from " + props.skAdNetworkIdFile);
+
+    try {
+        skAdNetworkIdContent = readFileSync(props.skAdNetworkIdFile, 'utf-8');
+    } catch (err) {
+        console.error("Can't read " + props.skAdNetworkIdFile + " for SKAdNetworkIds");
+        return infoPlist;
+    }
+
+    // Use regexp to find a list of SKAdNetwork strings instead of using a DOM parser since there is
+    // no standard DOM parser in Node.js.
+    const regexp = new RegExp("<string>(.*?)</string>", "g");
+    const matchedStringList = skAdNetworkIdContent.match(regexp);
+    if (!matchedStringList) {
+        console.error("SKAdNetworkIdentifier not found in " + props.skAdNetworkIdFile);
+        return infoPlist;
+    }
+
+    // extract a string from the tagged string
+    const skAdNetworkIdList = matchedStringList.map(s => s.replace(/<string>|<\/string>/g, ""));
+    if (!skAdNetworkIdList) {
+        console.error("SKAdNetworkIdentifier not found in " + props.skAdNetworkIdFile);
+        return infoPlist;
+    }
+
+    if (!Array.isArray(infoPlist.SKAdNetworkItems)) {
+        infoPlist.SKAdNetworkItems = [];
+    }
+
+    // Get ids
+    let existingIds = infoPlist.SKAdNetworkItems.map(
+        (item: any) => item?.SKAdNetworkIdentifier ?? null,
+    ).filter(Boolean) as string[];
+    // remove duplicates
+    existingIds = [...new Set(existingIds)];
+
+    for (let i = 0; i <  skAdNetworkIdList.length; i++) {
+        const skAdNetworkId = skAdNetworkIdList[i];
+        if (!existingIds.includes(skAdNetworkId)) {
+            infoPlist.SKAdNetworkItems.push({
+                SKAdNetworkIdentifier: skAdNetworkId,
+            });
+        }
+    }
+
+    return infoPlist;
+};
+
+const updatePodfileContentsWithDependencies = (contents: string, props: any) => {
+    if (!props.dependencies) return contents;
+
+    const patchKey = "post_install";
+    const slicedContent = contents.split(patchKey);
+
+    slicedContent[0] += '\n';
+    slicedContent[0] +=  "  pod 'AppLovinSDK'\n";
+
+    slicedContent[0] += '\n';
+    for (const item of props.dependencies) {
+        slicedContent[0] +=  "  " + item + "\n";
+    }
+    slicedContent[0] += '\n';
+
+    return slicedContent.join(patchKey);
+}
+
+export const withAppLovinMAXPodFile: ConfigPlugin = (config, props) => {
+    return withDangerousMod(config, [
+        'ios',
+        async (c) => {
+            const { platformProjectRoot } = c.modRequest;
+            const podfile = resolve(platformProjectRoot, 'Podfile');
+            const contents = readFileSync(podfile, 'utf-8');
+            const updatedContents = updatePodfileContentsWithDependencies(contents, props);
+            writeFileSync(podfile, updatedContents);
+            return c;
+        }
+    ]);
+};

--- a/plugin/tsconfig.json
+++ b/plugin/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "expo-module-scripts/tsconfig.plugin",
+  "compilerOptions": {
+    "outDir": "build",
+    "rootDir": "src"
+  },
+  "include": ["./src"],
+  "exclude": ["**/__mocks__/*", "**/__tests__/*"]
+}


### PR DESCRIPTION
Add support for the Expo plugin.    To enable the plugin, the user has to add the following properties to `app.json` to configure the integration.   Please review the naming of the keys, what values should be configured, and so on.   After running `npx expo prebuild`, the properties are added to `build.gradle`, `AndroidManifest.xml`, `Info.Plist`, and `Podfile`.   Also, review the integration steps.

```
    "plugins": [
      [
        "react-native-applovin-max",
        {
          "android": {
            "adReviewKey": "2IiA8Kee5lMTgUyRqzEqRSzSxyEimWcMG_qtTzv3BbmTAUViTXZpSX-pC7VlwveUbBSHSD2A3rJ_qyewNr6RMJ",
            "dependencies": [
              {
                "dependency": "implementation (\"com.applovin.mediation:facebook-adapter:+\")"
              },
              {
                "repository": "maven { url \"https://artifactory.bidmachine.io/bidmachine\" }",
                "dependency": "implementation (\"com.applovin.mediation:bidmachine-adapter:+\")"
              },
              {
                "repository": "maven { url \"https://android-sdk.is.com\" }",
                "dependency": "implementation (\"com.applovin.mediation:ironsource-adapter:+\")"
              }
            ],
            "metaDataMainApplication": [
              {
                "name": "applovin.sdk.verbose_logging",
                "value": "true"
              },
              {
                "name": "com.google.android.gms.ads.APPLICATION_ID",
                "value": "your_admob_app"
              },
              {
                "name": "com.google.android.gms.ads.AD_MANAGER_APP",
                "value": "true"
              }
            ]
          },
          "ios": {
            "dependencies": [
              "pod 'AppLovinMediationFacebookAdapter'",
              "pod 'AppLovinMediationMintegralAdapter'"
            ],
            "skAdNetworkIdFile": "skadnetwork_ids.xml",
            "infoPlist": [
              {
                "key": "AppLovinVerboseLoggingOn",
                "value": true
              },
              {
                "key": "NSUserTrackingUsageDescription",
                "value": "This uses device info for more personalized ads and content"
              },
              {
                "key": "NSAdvertisingAttributionReportEndpoint",
                "value": "https://postbacks-app.com"
              },
              {
                "key": "GADApplicationIdentifier",
                "value": "your_admob_app_id"
              },
              {
                "key": "GADIsAdManagerApp",
                "value": true
              }
            ]
          }
        }
      ]
    ]

```

Here is a step-by-step instruction for the integration.

0.  create a local package from the current branch for testing

npm pack

1.  create a brand new expo project

npx create-expo-app ALMaxExpoTest

2. install the local package

npm install react-native-applovin-max-5.2.3.tgz

3. create a file for skadnetwork (optional) 

use [info.plist generator](https://dash.applovin.com/documentation/mediation/ios/getting-started/skadnetwork-info#info.plist-generator) to generate a list of skadnetworkids, then cut & paste to a file.

4.  add the above properties to app.json

5.  run prebuild

npx expo prebuild --clean

6. run android

npx expo run:android

7. run ios

npx expo run:ios

8. run ios with AdReview

cd ios
ruby AppLovinQualityServiceSetup-ios.rb
npx expo run:ios
 

