### PR TITLE
ref/remove_default_aspectratio_from_mediaview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Versions
 
 ## x.x.x
+* Remove the default aspect ratio of a media view from the native ad properties.
 * Fix IconView not being displayed when setting it up with an empty DOM node.
 ## 5.2.3
 * Fix banner/MREC crashes related to previous release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Versions
 
 ## x.x.x
-* Remove the default aspect ratio of a media view from the native ad properties.
+* Remove the default media view aspect ratio of `1.0` when a mediated network does not provide it.
 * Fix IconView not being displayed when setting it up with an empty DOM node.
 ## 5.2.3
 * Fix banner/MREC crashes related to previous release.

--- a/android/src/main/java/com/applovin/reactnative/AppLovinMAXNativeAdView.java
+++ b/android/src/main/java/com/applovin/reactnative/AppLovinMAXNativeAdView.java
@@ -398,7 +398,7 @@ public class AppLovinMAXNativeAdView
 
         // The aspect ratio can be 0.0f when it is not provided by the network.
         float aspectRatio = ad.getMediaContentAspectRatio();
-        if ( !Float.isNaN( aspectRatio ) && Math.signum( aspectRatio ) > 0 )
+        if ( aspectRatio > 0 )
         {
             nativeAdInfo.putDouble( "mediaContentAspectRatio", aspectRatio );
         }

--- a/android/src/main/java/com/applovin/reactnative/AppLovinMAXNativeAdView.java
+++ b/android/src/main/java/com/applovin/reactnative/AppLovinMAXNativeAdView.java
@@ -396,14 +396,11 @@ public class AppLovinMAXNativeAdView
             nativeAdInfo.putDouble( "starRating", ad.getStarRating().doubleValue() );
         }
 
+        // The aspect ratio can be 0.0f when it is not provided by the network.
         float aspectRatio = ad.getMediaContentAspectRatio();
-        if ( !Float.isNaN( aspectRatio ) )
+        if ( !Float.isNaN( aspectRatio ) && Math.signum( aspectRatio ) > 0 )
         {
-            // The aspect ratio can be 0.0f when it is not provided by the network.
-            if ( Math.signum( aspectRatio ) != 0 )
-            {
-                nativeAdInfo.putDouble( "mediaContentAspectRatio", aspectRatio );
-            }
+            nativeAdInfo.putDouble( "mediaContentAspectRatio", aspectRatio );
         }
 
         nativeAdInfo.putBoolean( "isIconImageAvailable", ( ad.getIcon() != null ) );

--- a/android/src/main/java/com/applovin/reactnative/AppLovinMAXNativeAdView.java
+++ b/android/src/main/java/com/applovin/reactnative/AppLovinMAXNativeAdView.java
@@ -400,18 +400,10 @@ public class AppLovinMAXNativeAdView
         if ( !Float.isNaN( aspectRatio ) )
         {
             // The aspect ratio can be 0.0f when it is not provided by the network.
-            if ( Math.signum( aspectRatio ) == 0 )
-            {
-                nativeAdInfo.putDouble( "mediaContentAspectRatio", 1.0 );
-            }
-            else
+            if ( Math.signum( aspectRatio ) != 0 )
             {
                 nativeAdInfo.putDouble( "mediaContentAspectRatio", aspectRatio );
             }
-        }
-        else
-        {
-            nativeAdInfo.putDouble( "mediaContentAspectRatio", 1.0 );
         }
 
         nativeAdInfo.putBoolean( "isIconImageAvailable", ( ad.getIcon() != null ) );

--- a/example/src/NativeAdViewExample.js
+++ b/example/src/NativeAdViewExample.js
@@ -26,7 +26,9 @@ export const NativeAdViewExample = forwardRef((props, ref) => {
             ref={ref}
             style={styles.nativead}
             onAdLoaded={(adInfo) => {
-                setAspectRatio(adInfo.nativeAd.mediaContentAspectRatio);
+                if (adInfo.nativeAd.mediaContentAspectRatio) {
+                    setAspectRatio(adInfo.nativeAd.mediaContentAspectRatio);
+                }
                 props.onStatusText('Native ad loaded from ' + adInfo.networkName);
             }}
             onAdLoadFailed={(errorInfo) => {
@@ -101,7 +103,7 @@ const styles = StyleSheet.create({
     },
     mediaView: {
         alignSelf: 'center',
-        aspectRatio: 1,
+        aspectRatio: 1.77,
     },
     callToAction: {
         padding: 5,

--- a/example/src/NativeAdViewExample.js
+++ b/example/src/NativeAdViewExample.js
@@ -3,6 +3,7 @@ import {StyleSheet, Text, View} from 'react-native';
 import AppLovinMAX from '../../src/index';
 
 export const NativeAdViewExample = forwardRef((props, ref) => {
+    const DEFAULT_ASPECT_RATIO = (16/9);
     const {adUnitId} = props;
     const [aspectRatio, setAspectRatio] = useState(1.0);
     const [mediaViewSize, setMediaViewSize] = useState({});
@@ -28,6 +29,8 @@ export const NativeAdViewExample = forwardRef((props, ref) => {
             onAdLoaded={(adInfo) => {
                 if (adInfo.nativeAd.mediaContentAspectRatio) {
                     setAspectRatio(adInfo.nativeAd.mediaContentAspectRatio);
+                } else {
+                    setAspectRatio(DEFAULT_ASPECT_RATIO);
                 }
                 props.onStatusText('Native ad loaded from ' + adInfo.networkName);
             }}
@@ -103,7 +106,6 @@ const styles = StyleSheet.create({
     },
     mediaView: {
         alignSelf: 'center',
-        aspectRatio: 1.77,
     },
     callToAction: {
         padding: 5,

--- a/ios/AppLovinMAXNativeAdView.m
+++ b/ios/AppLovinMAXNativeAdView.m
@@ -305,21 +305,10 @@
     nativeAdInfo[@"callToAction"] = ad.callToAction;
     nativeAdInfo[@"starRating"] = ad.starRating;
     
-    if ( !isnan(ad.mediaContentAspectRatio) )
+    // The aspect ratio can be 0.0f when it is not provided by the network.
+    if ( !isnan(ad.mediaContentAspectRatio) && ad.mediaContentAspectRatio > FLT_EPSILON )
     {
-        // The aspect ratio can be 0.0f when it is not provided by the network.
-        if ( fabs(ad.mediaContentAspectRatio) < FLT_EPSILON )
-        {
-            nativeAdInfo[@"mediaContentAspectRatio"] = @(1.0);
-        }
-        else
-        {
-            nativeAdInfo[@"mediaContentAspectRatio"] = @(ad.mediaContentAspectRatio);
-        }
-    }
-    else
-    {
-        nativeAdInfo[@"mediaContentAspectRatio"] = @(1.0);
+        nativeAdInfo[@"mediaContentAspectRatio"] = @(ad.mediaContentAspectRatio);
     }
     
     nativeAdInfo[@"isIconImageAvailable"] = @(ad.icon != nil);

--- a/ios/AppLovinMAXNativeAdView.m
+++ b/ios/AppLovinMAXNativeAdView.m
@@ -306,7 +306,7 @@
     nativeAdInfo[@"starRating"] = ad.starRating;
     
     // The aspect ratio can be 0.0f when it is not provided by the network.
-    if ( !isnan(ad.mediaContentAspectRatio) && ad.mediaContentAspectRatio > FLT_EPSILON )
+    if ( ad.mediaContentAspectRatio > 0 )
     {
         nativeAdInfo[@"mediaContentAspectRatio"] = @(ad.mediaContentAspectRatio);
     }


### PR DESCRIPTION
Remove the default aspect ratio of a media view from the native ad properties.   Currently, the default value is provided when the network does not give it.   However, the default value differs from network to network.   The pub should decide the best value for the target network when unavailable.