### PR TITLE
fix/missing_inmobi_mediaview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Versions
 
 ## x.x.x
+* Fix InMobi media view not showing due to lack of sizing.
 * Fix IconView not being displayed when setting it up with an empty DOM node.
 ## 5.2.3
 * Fix banner/MREC crashes related to previous release.

--- a/android/src/main/java/com/applovin/reactnative/AppLovinMAXNativeAdView.java
+++ b/android/src/main/java/com/applovin/reactnative/AppLovinMAXNativeAdView.java
@@ -60,10 +60,13 @@ public class AppLovinMAXNativeAdView
     // TODO: Allow publisher to select which views are clickable and which isn't via prop
     private final List<View> clickableViews = new ArrayList<>();
 
+    private OnHierarchyChangeListener onHierarchyChangeListener;
+
     public AppLovinMAXNativeAdView(final Context context)
     {
         super( context );
         reactContext = (ReactContext) context;
+        onHierarchyChangeListener = new HierarchyChangeListener();
     }
 
     public void destroy()
@@ -290,26 +293,29 @@ public class AppLovinMAXNativeAdView
         // to be resized when the network's media view is added.
         if ( mediaView instanceof ViewGroup )
         {
-            ( (ViewGroup) mediaView ).setOnHierarchyChangeListener( new OnHierarchyChangeListener()
+            ( (ViewGroup) mediaView ).setOnHierarchyChangeListener( onHierarchyChangeListener );
+        }
+    }
+
+    private static class HierarchyChangeListener
+            implements OnHierarchyChangeListener
+    {
+        @Override
+        public void onChildViewAdded(final View parent, final View child)
+        {
+            parent.post( new Runnable()
             {
                 @Override
-                public void onChildViewAdded(final View parent, final View child)
+                public void run()
                 {
-                    mediaView.post( new Runnable()
-                    {
-                        @Override
-                        public void run()
-                        {
-                            sizeToFit( child, parent );
-                        }
-                    } );
-                }
-
-                @Override
-                public void onChildViewRemoved(final View parent, final View child)
-                {
+                    sizeToFit( child, parent );
                 }
             } );
+        }
+
+        @Override
+        public void onChildViewRemoved(final View parent, final View child)
+        {
         }
     }
 
@@ -326,7 +332,7 @@ public class AppLovinMAXNativeAdView
         }
     }
 
-    private void sizeToFit(final @Nullable View view, final View parentView)
+    private static void sizeToFit(final @Nullable View view, final View parentView)
     {
         if ( view != null )
         {

--- a/android/src/main/java/com/applovin/reactnative/AppLovinMAXNativeAdView.java
+++ b/android/src/main/java/com/applovin/reactnative/AppLovinMAXNativeAdView.java
@@ -284,6 +284,33 @@ public class AppLovinMAXNativeAdView
         view.addView( mediaView );
 
         sizeToFit( mediaView, view );
+
+        // Resize the child of `mediaView` for the networks, especially for InMobi, where the actual
+        // media view is added in `MaxNativeAdLoader.b()` after `mediaView` is sized so that it has
+        // to be resized when the network's media view is added.
+        if ( mediaView instanceof ViewGroup )
+        {
+            ( (ViewGroup) mediaView ).setOnHierarchyChangeListener( new OnHierarchyChangeListener()
+            {
+                @Override
+                public void onChildViewAdded(final View parent, final View child)
+                {
+                    mediaView.post( new Runnable()
+                    {
+                        @Override
+                        public void run()
+                        {
+                            sizeToFit( child, parent );
+                        }
+                    } );
+                }
+
+                @Override
+                public void onChildViewRemoved(final View parent, final View child)
+                {
+                }
+            } );
+        }
     }
 
     @Override


### PR DESCRIPTION
Fix InMobi media view not showing due to lack of sizing.   

In InMobi, the adapter provides the empty `FrameLayout` when RN adds it to the native ad view.  Then, the actual InMobi media view is added to the `FrameLayout` later in `MaxNativeAdLoader.b()`.  The entire media view has to be sized again to reposition. Otherwise, some of the views are located nowhere.