### PR TITLE
fix/missing_line_mediaview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Versions
 
 ## x.x.x
+* Fix LINE media view not showing.
 * Fix IconView not being displayed when setting it up with an empty DOM node.
 ## 5.2.3
 * Fix banner/MREC crashes related to previous release.

--- a/android/src/main/java/com/applovin/reactnative/AppLovinMAXNativeAdView.java
+++ b/android/src/main/java/com/applovin/reactnative/AppLovinMAXNativeAdView.java
@@ -357,6 +357,13 @@ public class AppLovinMAXNativeAdView
                     adLoader.b( ad );
                 }
 
+                // Reassure the size of `mediaView` and its children for the networks, such as
+                // LINE, where the actual ad contents are loaded after `mediaView` is sized.
+                if ( mediaView != null )
+                {
+                    sizeToFit( mediaView, (ReactViewGroup) mediaView.getParent() );
+                }
+
                 isLoading.set( false );
             }, 500L );
         }


### PR DESCRIPTION
Fix LINE media view not showing.

The actual content of the LINE media view comes after the RN media view is added and sized.    The entire media view, including the LINE's components, has to be resized to be correctly positioned.
