### PR TITLE
fix/npe_in_nativeadview_when_closed_before_shown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Versions
 
+## x.x.x
+* Fix NPE in NativeAdView when it's closed before shown.
 ## 5.5.0
 * Depend on Android SDK 11.10.0 and iOS SDK 11.10.0.
 ## 5.4.0

--- a/android/src/main/java/com/applovin/reactnative/AppLovinMAXNativeAdView.java
+++ b/android/src/main/java/com/applovin/reactnative/AppLovinMAXNativeAdView.java
@@ -401,7 +401,7 @@ public class AppLovinMAXNativeAdView
 
                 // Reassure the size of `mediaView` and its children for the networks, such as
                 // LINE, where the actual ad contents are loaded after `mediaView` is sized.
-                if ( mediaView != null )
+                if ( mediaView != null && mediaView.getParent() != null )
                 {
                     sizeToFit( mediaView, (View) mediaView.getParent() );
                 }


### PR DESCRIPTION
Fix NPE in NativeAdView when it's closed before shown.    
```
FATAL EXCEPTION: main
Process: jp.co.incrementp.milemobile, PID: 24799
java.lang.NullPointerException: Attempt to invoke virtual method 'int android.view.View.getWidth()' on a null object reference
    at com.applovin.reactnative.AppLovinMAXNativeAdView.sizeToFit(AppLovinMAXNativeAdView.java:348)
    at com.applovin.reactnative.AppLovinMAXNativeAdView.access$900(AppLovinMAXNativeAdView.java:34)
    at com.applovin.reactnative.AppLovinMAXNativeAdView$NativeAdListener.lambda$onNativeAdLoaded$0$AppLovinMAXNativeAdView$NativeAdListener(AppLovinMAXNativeAdView.java:406)
    at com.applovin.reactnative.-$$Lambda$AppLovinMAXNativeAdView$NativeAdListener$pD_i8boeJIrgRbDujDNDZK_LxIo.run(Unknown Source:4)
    at android.os.Handler.handleCallback(Handler.java:938)
    at android.os.Handler.dispatchMessage(Handler.java:99)
    at android.os.Looper.loopOnce(Looper.java:201)
    at android.os.Looper.loop(Looper.java:288)
    at android.app.ActivityThread.main(ActivityThread.java:7980)
    at java.lang.reflect.Method.invoke(Native Method)
    at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:548)
    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1009)
```

The issue is also logged in #224.