### PR TITLE
ref/add_support_for_local_extra_parameters_with_non_string_values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Versions
 
+## x.x.x
+* Add support for local extra parameters API with non-String values.
 ## 5.5.2
 * Fix NPE in NativeAdView when it's closed before shown. (https://github.com/AppLovin/AppLovin-MAX-React-Native/issues/224)
 ## 5.5.1

--- a/android/src/main/java/com/applovin/reactnative/AppLovinMAXAdView.java
+++ b/android/src/main/java/com/applovin/reactnative/AppLovinMAXAdView.java
@@ -252,7 +252,7 @@ class AppLovinMAXAdView
             {
                 for ( Map.Entry<String, Object> entry : localExtraParameters.entrySet() )
                 {
-                    adView.setLocalExtraParameter( entry.getKey(), (String) entry.getValue() );
+                    adView.setLocalExtraParameter( entry.getKey(), entry.getValue() );
                 }
             }
 

--- a/src/AppLovinMAXAdView.js
+++ b/src/AppLovinMAXAdView.js
@@ -129,7 +129,7 @@ const AdView = (props) => {
     <AppLovinMAXAdView
       style={{...style, ...dimensions}}
       extraParameters={sanitizeExtraParameters('extraParameters', extraParameters)}
-      localExtraParameters={sanitizeExtraParameters('localExtraParameters', localExtraParameters)}
+      localExtraParameters={localExtraParameters}
       onAdLoadedEvent={onAdLoadedEvent}
       onAdLoadFailedEvent={onAdLoadFailedEvent}
       onAdDisplayFailedEvent={onAdDisplayFailedEvent}

--- a/src/NativeAdView.js
+++ b/src/NativeAdView.js
@@ -92,7 +92,7 @@ const NativeAdView = forwardRef((props, ref) => {
     <AppLovinMAXNativeAdView
       ref={saveElement}
       extraParameters={sanitizeExtraParameters('extraParameters', extraParameters)}
-      localExtraParameters={sanitizeExtraParameters('localExtraParameters', localExtraParameters)}
+      localExtraParameters={localExtraParameters}
       onAdLoadedEvent={onAdLoadedEvent}
       onAdLoadFailedEvent={onAdLoadFailedEvent}
       onAdClickedEvent={onAdClickedEvent}


### PR DESCRIPTION
Allow not string values for local extra parameters:

- #230 
- https://app.asana.com/0/337926977135969/1204919837056309/f

Verified Object/id to be passed as Map/NSDictionary or List/NSArray.