### PR TITLE
fix/IllegalStateException_on_adding_mediaView

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Versions
 
+## x.x.x
+* Fix NativeAdView crash when adding mediaView. (https://github.com/AppLovin/AppLovin-MAX-React-Native/issues/238)
 ## 5.6.1
 * Add support for local extra parameters API with non-String values for the programmatical methods.
 ## 5.6.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Versions
 
 ## x.x.x
-* Fix NativeAdView crash when adding mediaView. (https://github.com/AppLovin/AppLovin-MAX-React-Native/issues/238)
+* Fix `java.lang.IllegalStateException` when rendering native ads. (https://github.com/AppLovin/AppLovin-MAX-React-Native/issues/238)
 ## 5.6.1
 * Add support for local extra parameters API with non-String values for the programmatical methods.
 ## 5.6.0

--- a/android/src/main/java/com/applovin/reactnative/AppLovinMAXNativeAdView.java
+++ b/android/src/main/java/com/applovin/reactnative/AppLovinMAXNativeAdView.java
@@ -312,13 +312,16 @@ public class AppLovinMAXNativeAdView
         // Some adapters, like Google, expect a Button widget for CTA to be clickable
         if ( view instanceof ViewGroup )
         {
-            Button button = new Button( reactContext );
-            button.setAlpha( 0 );
-            ( (ViewGroup) view ).addView( button );
-            sizeToFit( button, view );
+            if ( view.findViewById( CALL_TO_ACTION_VIEW_TAG ) == null )
+            {
+                Button button = new Button( reactContext );
+                button.setAlpha( 0 );
+                ( (ViewGroup) view ).addView( button );
+                sizeToFit( button, view );
 
-            button.setTag( CALL_TO_ACTION_VIEW_TAG );
-            clickableViews.add( button );
+                button.setTag( CALL_TO_ACTION_VIEW_TAG );
+                clickableViews.add( button );
+            }
         }
         else
         {
@@ -364,7 +367,17 @@ public class AppLovinMAXNativeAdView
         }
 
         view.addOnLayoutChangeListener( this );
-        view.addView( optionsView );
+
+        ViewGroup optionsViewParent = (ViewGroup) optionsView.getParent();
+        if ( optionsViewParent == null )
+        {
+            view.addView( optionsView );
+        }
+        else if ( optionsViewParent != view )
+        {
+            optionsViewParent.removeView( optionsView );
+            view.addView( optionsView );
+        }
 
         sizeToFit( optionsView, view );
     }
@@ -385,7 +398,17 @@ public class AppLovinMAXNativeAdView
         clickableViews.add( view );
 
         view.addOnLayoutChangeListener( this );
-        view.addView( mediaView );
+
+        ViewGroup mediaViewParent = (ViewGroup) mediaView.getParent();
+        if ( mediaViewParent == null )
+        {
+            view.addView( mediaView );
+        }
+        else if ( mediaViewParent != view )
+        {
+            mediaViewParent.removeView( mediaView );
+            view.addView( mediaView );
+        }
 
         sizeToFit( mediaView, view );
 


### PR DESCRIPTION
Fix [Issue 238](https://github.com/AppLovin/AppLovin-MAX-React-Native/issues/238).   Here is the stack trace.

```
 Caused by java.lang.IllegalStateException
The specified child already has a parent. You must call removeView() on the child's parent first.
android.view.ViewGroup.addViewInner (ViewGroup.java:5226)
android.view.ViewGroup.addView (ViewGroup.java:5055)
com.facebook.react.views.view.ReactViewGroup.addView (ReactViewGroup.java:516)
android.view.ViewGroup.addView (ViewGroup.java:4995)
android.view.ViewGroup.addView (ViewGroup.java:4968)
com.applovin.reactnative.AppLovinMAXNativeAdView.setMediaView (AppLovinMAXNativeAdView.java:388)
com.applovin.reactnative.AppLovinMAXNativeAdViewManager.setMediaView (AppLovinMAXNativeAdViewManager.java:148)
```

It seems that the native setter methods are called twice because the same ad is reloaded, or JS somehow tries to update the props twice.  With this fix, the native setter methods can be called multiple times.