### PR TITLE
fix/build_error_with_incompatible_types_on_android

### DIFF
--- a/android/src/main/java/com/applovin/reactnative/AppLovinMAXModule.java
+++ b/android/src/main/java/com/applovin/reactnative/AppLovinMAXModule.java
@@ -2446,7 +2446,7 @@ public class AppLovinMAXModule
         {
             errInfo.putInt( "code", error.getCode() );
             errInfo.putString( "message", error.getMessage() );
-            errInfo.putString( "mediatedNetworkErrorCode", error.getMediatedNetworkErrorCode() );
+            errInfo.putInt( "mediatedNetworkErrorCode", error.getMediatedNetworkErrorCode() );
             errInfo.putString( "mediatedNetworkErrorMessage", error.getMediatedNetworkErrorMessage() );
             errInfo.putString( "adLoadFailureInfo", error.getAdLoadFailureInfo() );
             errInfo.putMap( "waterfall", createAdWaterfallInfo( error.getWaterfall() ) );
@@ -2464,7 +2464,7 @@ public class AppLovinMAXModule
         WritableMap info = getAdInfo( ad );
         info.putInt( "code", error.getCode() );
         info.putString( "message", error.getMessage() );
-        info.putString( "mediatedNetworkErrorCode", error.getMediatedNetworkErrorCode() );
+        info.putInt( "mediatedNetworkErrorCode", error.getMediatedNetworkErrorCode() );
         info.putString( "mediatedNetworkErrorMessage", error.getMediatedNetworkErrorMessage() );
         return info;
     }


### PR DESCRIPTION
Fix a build error from `MaxError.getMediatedNetworkErrorCode()` on Android.

```
/Users/hiroshi.watanabe/Max/rn/ALMRN2/android/src/main/java/com/applovin/reactnative/AppLovinMAXModule.java:2449: error: incompatible types: int cannot be converted to String
            errInfo.putString( "mediatedNetworkErrorCode", error.getMediatedNetworkErrorCode() );
                                                                                            ^
/Users/hiroshi.watanabe/Max/rn/ALMRN2/android/src/main/java/com/applovin/reactnative/AppLovinMAXModule.java:2467: error: incompatible types: int cannot be converted to String
        info.putString( "mediatedNetworkErrorCode", error.getMediatedNetworkErrorCode() );
                                                                                     ^
```

iOS works fine.