### PR TITLE
ref/update_key_in_local_extra_parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Versions
 
+## x.x.x
+* Fix a warning of `key` in the local extra parameter not enclosing in brackets.
 ## 5.7.1
 * Fix Anrdoid build issue.
 ## 5.7.0

--- a/src/index.js
+++ b/src/index.js
@@ -22,7 +22,7 @@ const setBannerExtraParameter = (adUnitId, key, value) => {
 }
 
 const setBannerLocalExtraParameter = (adUnitId, key, value) => {
-  AppLovinMAX.setBannerLocalExtraParameter(adUnitId, {key:value});
+  AppLovinMAX.setBannerLocalExtraParameter(adUnitId, {[key]:value});
 }
 
 /*-------*/
@@ -39,7 +39,7 @@ const setMRecExtraParameter = (adUnitId, key, value) => {
 }
 
 const setMRecLocalExtraParameter = (adUnitId, key, value) => {
-  AppLovinMAX.setMRecLocalExtraParameter(adUnitId, {key:value});
+  AppLovinMAX.setMRecLocalExtraParameter(adUnitId, {[key]:value});
 }
 
 /*---------------*/
@@ -73,7 +73,7 @@ const setInterstitialExtraParameter = (adUnitId, key, value) => {
 }
 
 const setInterstitialLocalExtraParameter = (adUnitId, key, value) => {
-  AppLovinMAX.setInterstitialLocalExtraParameter(adUnitId, {key:value});
+  AppLovinMAX.setInterstitialLocalExtraParameter(adUnitId, {[key]:value});
 }
 
 /*----------*/
@@ -107,7 +107,7 @@ const setRewardedAdExtraParameter = (adUnitId, key, value) => {
 }
 
 const setRewardedAdLocalExtraParameter = (adUnitId, key, value) => {
-  AppLovinMAX.setRewardedAdLocalExtraParameter(adUnitId, {key:value});
+  AppLovinMAX.setRewardedAdLocalExtraParameter(adUnitId, {[key]:value});
 }
 
 /*----------*/
@@ -141,7 +141,7 @@ const setAppOpenAdExtraParameter = (adUnitId, key, value) => {
 }
 
 const setAppOpenAdLocalExtraParameter = (adUnitId, key, value) => {
-  AppLovinMAX.setAppOpenAdLocalExtraParameter(adUnitId, {key:value});
+  AppLovinMAX.setAppOpenAdLocalExtraParameter(adUnitId, {[key]:value});
 }
 
 export default {


### PR DESCRIPTION
Fix the following warning for 'key' in the local extra parameter:

'key' is declared but its value is never read.ts(6133)

I guess format checking is more strict in the TS-based editor.

