### PR TITLE
feat/add_support_for_adview_preloading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Versions
 
+## x.x.x
+* Add support for AdView preloading.
 ## 6.1.1
 * Allow calls to `AppLovinMAX.setMuted(...)` before SDK is initialized.
 * Improve loading time for native ads. (https://github.com/AppLovin/AppLovin-MAX-React-Native/issues/273)

--- a/android/src/main/java/com/applovin/reactnative/AppLovinMAXAdView.java
+++ b/android/src/main/java/com/applovin/reactnative/AppLovinMAXAdView.java
@@ -1,156 +1,45 @@
 package com.applovin.reactnative;
 
 import android.content.Context;
-import android.text.TextUtils;
 
-import com.applovin.mediation.MaxAd;
-import com.applovin.mediation.MaxAdFormat;
-import com.applovin.mediation.MaxAdListener;
-import com.applovin.mediation.MaxAdRevenueListener;
-import com.applovin.mediation.MaxAdViewAdListener;
-import com.applovin.mediation.MaxError;
-import com.applovin.mediation.ads.MaxAdView;
-import com.facebook.react.bridge.ReadableMap;
-import com.facebook.react.bridge.WritableMap;
-import com.facebook.react.uimanager.ThemedReactContext;
-import com.facebook.react.uimanager.events.RCTEventEmitter;
 import com.facebook.react.views.view.ReactViewGroup;
 
-import java.util.Map;
+import java.lang.ref.WeakReference;
 
-import androidx.annotation.Nullable;
-
-/**
- * Created by Thomas So on September 27 2020
- */
 class AppLovinMAXAdView
         extends ReactViewGroup
-        implements MaxAdListener, MaxAdViewAdListener, MaxAdRevenueListener
 {
-    private final ThemedReactContext reactContext;
+    private final WeakReference<AppLovinMAXAdViewAdManager> managerRef;
 
-    @Nullable
-    private MaxAdView adView;
+    private Integer adViewAdId;
 
-    private String              adUnitId;
-    private MaxAdFormat         adFormat;
-    @Nullable
-    private String              placement;
-    @Nullable
-    private String              customData;
-    private boolean             adaptiveBannerEnabled;
-    private boolean             autoRefresh;
-    @Nullable
-    private Map<String, Object> extraParameters;
-    @Nullable
-    private Map<String, Object> localExtraParameters;
-
-    public AppLovinMAXAdView(final Context context)
+    public AppLovinMAXAdView(final Context context, final AppLovinMAXAdViewAdManager manager)
     {
         super( context );
-        reactContext = (ThemedReactContext) context;
+        managerRef = new WeakReference<>( manager );
     }
 
-    public void setAdUnitId(final String value)
+    public void attachAdView(final int adViewAdId)
     {
-        // Ad Unit ID must be set prior to creating MaxAdView
-        if ( adView != null )
-        {
-            AppLovinMAXModule.e( "Attempting to set Ad Unit ID " + value + " after MaxAdView is created" );
-            return;
-        }
+        this.adViewAdId = adViewAdId;
 
-        adUnitId = value;
-
-        maybeAttachAdView();
-    }
-
-    public void setAdFormat(final String value)
-    {
-        // Ad format must be set prior to creating MaxAdView
-        if ( adView != null )
+        AppLovinMAXAdViewAd adViewAd = managerRef.get().getAdViewAd( adViewAdId );
+        if ( adViewAd != null )
         {
-            AppLovinMAXModule.e( "Attempting to set ad format " + value + " after MaxAdView is created" );
-            return;
-        }
-
-        if ( MaxAdFormat.BANNER.getLabel().equals( value ) )
-        {
-            adFormat = AppLovinMAXModule.getDeviceSpecificBannerAdViewAdFormat( reactContext );
-        }
-        else if ( MaxAdFormat.MREC.getLabel().equals( value ) )
-        {
-            adFormat = MaxAdFormat.MREC;
+            adViewAd.attachView( this );
         }
         else
         {
-            AppLovinMAXModule.e( "Attempting to set an invalid ad format of \"" + value + "\" for " + adUnitId );
-            return;
-        }
-
-        maybeAttachAdView();
-    }
-
-    public void setPlacement(@Nullable final String value)
-    {
-        placement = value;
-
-        if ( adView != null )
-        {
-            adView.setPlacement( placement );
+            AppLovinMAXModule.e( "Cannot find AdViewAd with id " + adViewAdId + " for adding to AdView." );
         }
     }
 
-    public void setCustomData(@Nullable final String value)
+    public void detachAdView()
     {
-        customData = value;
-
-        if ( adView != null )
+        AppLovinMAXAdViewAd adViewAd = managerRef.get().getAdViewAd( adViewAdId );
+        if ( adViewAd != null )
         {
-            adView.setCustomData( customData );
-        }
-    }
-
-    public void setAdaptiveBannerEnabled(final boolean enabled)
-    {
-        adaptiveBannerEnabled = enabled;
-
-        if ( adView != null )
-        {
-            adView.setExtraParameter( "adaptive_banner", Boolean.toString( enabled ) );
-        }
-    }
-
-    public void setAutoRefresh(final boolean enabled)
-    {
-        autoRefresh = enabled;
-
-        if ( adView != null )
-        {
-            if ( autoRefresh )
-            {
-                adView.startAutoRefresh();
-            }
-            else
-            {
-                adView.stopAutoRefresh();
-            }
-        }
-    }
-
-    public void setExtraParameters(@Nullable final ReadableMap readableMap)
-    {
-        if ( readableMap != null )
-        {
-            extraParameters = readableMap.toHashMap();
-        }
-    }
-
-    public void setLocalExtraParameters(@Nullable final ReadableMap readableMap)
-    {
-        if ( readableMap != null )
-        {
-            localExtraParameters = readableMap.toHashMap();
+            adViewAd.detachView();
         }
     }
 
@@ -159,188 +48,12 @@ class AppLovinMAXAdView
     {
         super.requestLayout();
 
-        // https://stackoverflow.com/a/39838774/5477988
-        // This is required to ensure ad refreshes render correctly in RN Android due to known issue where `getWidth()` and `getHeight()` return 0 on attach
-        if ( adView != null )
-        {
-            int currentWidthPx = getWidth();
-            int currentHeightPx = getHeight();
+        if ( adViewAdId == null ) return;
 
-            adView.measure(
-                    MeasureSpec.makeMeasureSpec( currentWidthPx, MeasureSpec.EXACTLY ),
-                    MeasureSpec.makeMeasureSpec( currentHeightPx, MeasureSpec.EXACTLY )
-            );
-            adView.layout( 0, 0, currentWidthPx, currentHeightPx );
+        AppLovinMAXAdViewAd adViewAd = managerRef.get().getAdViewAd( adViewAdId );
+        if ( adViewAd != null )
+        {
+            adViewAd.measureAndLayout( 0, 0, getWidth(), getHeight() );
         }
     }
-
-    @Override
-    protected void onDetachedFromWindow()
-    {
-        super.onDetachedFromWindow();
-
-        if ( adView != null )
-        {
-            adView.stopAutoRefresh();
-        }
-    }
-
-    @Override
-    protected void onAttachedToWindow()
-    {
-        super.onAttachedToWindow();
-
-        if ( adView != null )
-        {
-            adView.startAutoRefresh();
-        }
-    }
-
-    private void maybeAttachAdView()
-    {
-        // Re-assign in case of race condition
-        final String adUnitId = this.adUnitId;
-        final MaxAdFormat adFormat = this.adFormat;
-
-        // Run after 0.25 sec delay to allow all properties to set
-        postDelayed( () -> {
-
-            if ( AppLovinMAXModule.getInstance().getSdk() == null )
-            {
-                AppLovinMAXModule.logUninitializedAccessError( "AppLovinMAXAdView.maybeAttachAdView" );
-                return;
-            }
-
-            if ( TextUtils.isEmpty( adUnitId ) )
-            {
-                AppLovinMAXModule.e( "Attempting to attach MaxAdView without Ad Unit ID" );
-                return;
-            }
-
-            if ( adFormat == null )
-            {
-                AppLovinMAXModule.e( "Attempting to attach MaxAdView without ad format" );
-                return;
-            }
-
-            if ( adView != null )
-            {
-                AppLovinMAXModule.e( "Attempting to re-attach with existing MaxAdView: " + adView );
-                return;
-            }
-
-            AppLovinMAXModule.d( "Attaching MaxAdView for " + adUnitId );
-
-            adView = new MaxAdView( adUnitId, adFormat, AppLovinMAXModule.getInstance().getSdk(), reactContext );
-            adView.setListener( this );
-            adView.setRevenueListener( this );
-            adView.setPlacement( placement );
-            adView.setCustomData( customData );
-            adView.setExtraParameter( "adaptive_banner", Boolean.toString( adaptiveBannerEnabled ) );
-            // Set this extra parameter to work around a SDK bug that ignores calls to stopAutoRefresh()
-            adView.setExtraParameter( "allow_pause_auto_refresh_immediately", "true" );
-
-            if ( extraParameters != null )
-            {
-                for ( Map.Entry<String, Object> entry : extraParameters.entrySet() )
-                {
-                    adView.setExtraParameter( entry.getKey(), (String) entry.getValue() );
-                }
-            }
-
-            if ( localExtraParameters != null )
-            {
-                for ( Map.Entry<String, Object> entry : localExtraParameters.entrySet() )
-                {
-                    adView.setLocalExtraParameter( entry.getKey(), entry.getValue() );
-                }
-            }
-
-            if ( autoRefresh )
-            {
-                adView.startAutoRefresh();
-            }
-            else
-            {
-                adView.stopAutoRefresh();
-            }
-
-            adView.loadAd();
-
-            addView( adView );
-        }, 250 );
-    }
-
-    public void destroy()
-    {
-        if ( adView != null )
-        {
-            AppLovinMAXModule.d( "Unmounting MaxAdView: " + adView );
-
-            removeView( adView );
-
-            adView.setListener( null );
-            adView.setRevenueListener( null );
-            adView.destroy();
-
-            adView = null;
-        }
-    }
-
-    @Override
-    public void onAdLoaded(final MaxAd ad)
-    {
-        WritableMap adInfo = AppLovinMAXModule.getInstance().getAdInfo( ad );
-        reactContext.getJSModule( RCTEventEmitter.class ).receiveEvent( getId(), "onAdLoadedEvent", adInfo );
-    }
-
-    @Override
-    public void onAdLoadFailed(final String adUnitId, final MaxError error)
-    {
-        WritableMap adLoadFailedInfo = AppLovinMAXModule.getInstance().getAdLoadFailedInfo( adUnitId, error );
-        reactContext.getJSModule( RCTEventEmitter.class ).receiveEvent( getId(), "onAdLoadFailedEvent", adLoadFailedInfo );
-    }
-
-    @Override
-    public void onAdDisplayFailed(final MaxAd ad, final MaxError error)
-    {
-        WritableMap adDisplayFailedInfo = AppLovinMAXModule.getInstance().getAdDisplayFailedInfo( ad, error );
-        reactContext.getJSModule( RCTEventEmitter.class ).receiveEvent( getId(), "onAdDisplayFailedEvent", adDisplayFailedInfo );
-    }
-
-    @Override
-    public void onAdClicked(final MaxAd ad)
-    {
-        WritableMap adInfo = AppLovinMAXModule.getInstance().getAdInfo( ad );
-        reactContext.getJSModule( RCTEventEmitter.class ).receiveEvent( getId(), "onAdClickedEvent", adInfo );
-    }
-
-    @Override
-    public void onAdExpanded(final MaxAd ad)
-    {
-        WritableMap adInfo = AppLovinMAXModule.getInstance().getAdInfo( ad );
-        reactContext.getJSModule( RCTEventEmitter.class ).receiveEvent( getId(), "onAdExpandedEvent", adInfo );
-    }
-
-    @Override
-    public void onAdCollapsed(final MaxAd ad)
-    {
-        WritableMap adInfo = AppLovinMAXModule.getInstance().getAdInfo( ad );
-        reactContext.getJSModule( RCTEventEmitter.class ).receiveEvent( getId(), "onAdCollapsedEvent", adInfo );
-    }
-
-    @Override
-    public void onAdRevenuePaid(final MaxAd ad)
-    {
-        WritableMap adRevenueInfo = AppLovinMAXModule.getInstance().getAdRevenueInfo( ad );
-        reactContext.getJSModule( RCTEventEmitter.class ).receiveEvent( getId(), "onAdRevenuePaidEvent", adRevenueInfo );
-    }
-
-    /// Deprecated Callbacks
-
-    @Override
-    public void onAdDisplayed(final MaxAd ad) { }
-
-    @Override
-    public void onAdHidden(final MaxAd ad) { }
 }

--- a/android/src/main/java/com/applovin/reactnative/AppLovinMAXAdViewAd.java
+++ b/android/src/main/java/com/applovin/reactnative/AppLovinMAXAdViewAd.java
@@ -1,0 +1,278 @@
+package com.applovin.reactnative;
+
+import android.view.View;
+import android.view.ViewGroup;
+
+import com.applovin.mediation.MaxAd;
+import com.applovin.mediation.MaxAdFormat;
+import com.applovin.mediation.MaxAdListener;
+import com.applovin.mediation.MaxAdRevenueListener;
+import com.applovin.mediation.MaxAdViewAdListener;
+import com.applovin.mediation.MaxError;
+import com.applovin.mediation.ads.MaxAdView;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReadableMap;
+import com.facebook.react.bridge.WritableMap;
+
+import java.lang.ref.WeakReference;
+import java.util.Iterator;
+import java.util.Map;
+
+import androidx.annotation.Nullable;
+
+class AppLovinMAXAdViewAd
+        implements MaxAdListener, MaxAdViewAdListener, MaxAdRevenueListener
+{
+    private final ReactApplicationContext context;
+
+    private final WeakReference<AppLovinMAXAdViewAdManager> managerRef;
+
+    private boolean autoRefresh;
+
+    @Nullable
+    private MaxAdView adView;
+
+    public AppLovinMAXAdViewAd(final ReactApplicationContext context, final AppLovinMAXAdViewAdManager manager)
+    {
+        this.context = context;
+        this.managerRef = new WeakReference<>( manager );
+    }
+
+    public int createAdView(final String adUnitId, final MaxAdFormat adFormat)
+    {
+        context.runOnUiQueueThread( () -> {
+
+            adView = new MaxAdView( adUnitId, adFormat, AppLovinMAXModule.getInstance().getSdk(), context );
+            adView.setListener( this );
+            adView.setRevenueListener( this );
+
+            adView.setExtraParameter( "adaptive_banner", "true" );
+
+            // Set this extra parameter to work around a SDK bug that ignores calls to stopAutoRefresh()
+            adView.setExtraParameter( "allow_pause_auto_refresh_immediately", "true" );
+
+            // Hide AdView until it is attached to the parent view
+            adView.setVisibility( View.GONE );
+
+            adView.stopAutoRefresh();
+
+            adView.loadAd();
+
+            AppLovinMAXModule.d( "Ad Unit ID " + adUnitId + " MaxAdView is created with id " + AppLovinMAXAdViewAd.this.hashCode() );
+        } );
+
+        return hashCode();
+    }
+
+    public void destroyAdView()
+    {
+        context.runOnUiQueueThread( () -> {
+
+            ViewGroup parentView = (ViewGroup) adView.getParent();
+            if ( parentView != null )
+            {
+                parentView.removeView( adView );
+            }
+
+            AppLovinMAXModule.d( "Ad Unit ID " + adView.getAdUnitId() + " MaxAdView is destroyed with id " + AppLovinMAXAdViewAd.this.hashCode() );
+
+            adView.setListener( null );
+            adView.setRevenueListener( null );
+            adView.destroy();
+
+            adView = null;
+        } );
+    }
+
+    public void loadAd()
+    {
+        context.runOnUiQueueThread( () -> {
+
+            adView.loadAd();
+        } );
+    }
+
+    public void setPlacement(String placement)
+    {
+        context.runOnUiQueueThread( () -> {
+
+            adView.setPlacement( placement );
+        } );
+    }
+
+    public void setCustomData(String customData)
+    {
+        context.runOnUiQueueThread( () -> {
+
+            adView.setCustomData( customData );
+        } );
+    }
+
+    public void setAdaptiveBannerEnabled(boolean enabled)
+    {
+        context.runOnUiQueueThread( () -> {
+
+            adView.setExtraParameter( "adaptive_banner", Boolean.toString( enabled ) );
+        } );
+    }
+
+    public void setAutoRefresh(boolean autoRefresh)
+    {
+        this.autoRefresh = autoRefresh;
+
+        context.runOnUiQueueThread( () -> {
+
+            if ( adView.getVisibility() != View.VISIBLE ) return;
+
+            if ( autoRefresh )
+            {
+                adView.startAutoRefresh();
+            }
+            else
+            {
+                adView.stopAutoRefresh();
+            }
+        } );
+    }
+
+    public void setExtraParameters(final ReadableMap extraParameters)
+    {
+        context.runOnUiQueueThread( () -> {
+
+            if ( extraParameters != null )
+            {
+                Iterator<Map.Entry<String, Object>> iterator = extraParameters.getEntryIterator();
+                while ( iterator.hasNext() )
+                {
+                    Map.Entry<String, Object> entry = iterator.next();
+                    adView.setExtraParameter( entry.getKey(), (String) entry.getValue() );
+                }
+            }
+        } );
+    }
+
+    public void setLocalExtraParameters(final ReadableMap localExtraParameters)
+    {
+        context.runOnUiQueueThread( () -> {
+
+            if ( localExtraParameters != null )
+            {
+                Iterator<Map.Entry<String, Object>> iterator = localExtraParameters.getEntryIterator();
+                while ( iterator.hasNext() )
+                {
+                    Map.Entry<String, Object> entry = iterator.next();
+                    adView.setLocalExtraParameter( entry.getKey(), entry.getValue() );
+                }
+            }
+        } );
+    }
+
+    public void attachView(ViewGroup view)
+    {
+        context.runOnUiQueueThread( () -> {
+
+            adView.setVisibility( View.VISIBLE );
+
+            if ( autoRefresh )
+            {
+                adView.startAutoRefresh();
+            }
+
+            view.addView( adView );
+        } );
+    }
+
+    public void detachView()
+    {
+        context.runOnUiQueueThread( () -> {
+
+            ViewGroup parentView = (ViewGroup) adView.getParent();
+            if ( parentView != null )
+            {
+                parentView.removeView( adView );
+            }
+
+            adView.setVisibility( View.GONE );
+            adView.stopAutoRefresh();
+        } );
+    }
+
+    public void measureAndLayout(int x, int y, int width, int height)
+    {
+        context.runOnUiQueueThread( () -> {
+
+            if ( adView == null ) return;
+
+            adView.measure(
+                    View.MeasureSpec.makeMeasureSpec( width, View.MeasureSpec.EXACTLY ),
+                    View.MeasureSpec.makeMeasureSpec( height, View.MeasureSpec.EXACTLY )
+            );
+
+            adView.layout( x, y, width, height );
+        } );
+    }
+
+    @Override
+    public void onAdLoaded(final MaxAd ad)
+    {
+        WritableMap adInfo = AppLovinMAXModule.getInstance().getAdInfo( ad );
+        adInfo.putInt( "adViewAdId", hashCode() );
+        managerRef.get().sendLoadAdEvent( adInfo );
+    }
+
+    @Override
+    public void onAdLoadFailed(final String adUnitId, final MaxError error)
+    {
+        WritableMap adLoadFailedInfo = AppLovinMAXModule.getInstance().getAdLoadFailedInfo( adUnitId, error );
+        adLoadFailedInfo.putInt( "adViewAdId", hashCode() );
+        managerRef.get().sendFailToLoadAdEvent( adLoadFailedInfo );
+    }
+
+    @Override
+    public void onAdDisplayFailed(final MaxAd ad, final MaxError error)
+    {
+        WritableMap adDisplayFailedInfo = AppLovinMAXModule.getInstance().getAdDisplayFailedInfo( ad, error );
+        adDisplayFailedInfo.putInt( "adViewAdId", hashCode() );
+        managerRef.get().sendFailToDisplayAEvent( adDisplayFailedInfo );
+    }
+
+    @Override
+    public void onAdClicked(final MaxAd ad)
+    {
+        WritableMap adInfo = AppLovinMAXModule.getInstance().getAdInfo( ad );
+        adInfo.putInt( "adViewAdId", hashCode() );
+        managerRef.get().sendClickAdEvent( adInfo );
+    }
+
+    @Override
+    public void onAdExpanded(final MaxAd ad)
+    {
+        WritableMap adInfo = AppLovinMAXModule.getInstance().getAdInfo( ad );
+        adInfo.putInt( "adViewAdId", hashCode() );
+        managerRef.get().sendExpandAdEvent( adInfo );
+    }
+
+    @Override
+    public void onAdCollapsed(final MaxAd ad)
+    {
+        WritableMap adInfo = AppLovinMAXModule.getInstance().getAdInfo( ad );
+        adInfo.putInt( "adViewAdId", hashCode() );
+        managerRef.get().sendCollapseAdEvent( adInfo );
+    }
+
+    @Override
+    public void onAdRevenuePaid(final MaxAd ad)
+    {
+        WritableMap adRevenueInfo = AppLovinMAXModule.getInstance().getAdRevenueInfo( ad );
+        adRevenueInfo.putInt( "adViewAdId", hashCode() );
+        managerRef.get().sendPayRevenueEvent( adRevenueInfo );
+    }
+
+    /// Deprecated Callbacks
+
+    @Override
+    public void onAdDisplayed(final MaxAd ad) { }
+
+    @Override
+    public void onAdHidden(final MaxAd ad) { }
+}

--- a/android/src/main/java/com/applovin/reactnative/AppLovinMAXAdViewAdManager.java
+++ b/android/src/main/java/com/applovin/reactnative/AppLovinMAXAdViewAdManager.java
@@ -1,0 +1,206 @@
+package com.applovin.reactnative;
+
+import android.text.TextUtils;
+
+import com.applovin.mediation.MaxAdFormat;
+import com.facebook.react.bridge.Promise;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReactContextBaseJavaModule;
+import com.facebook.react.bridge.ReactMethod;
+import com.facebook.react.bridge.ReadableMap;
+import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.module.annotations.ReactModule;
+import com.facebook.react.modules.core.DeviceEventManagerModule;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+@ReactModule(name = "AppLovinMAXAdViewAdManager")
+class AppLovinMAXAdViewAdManager
+        extends ReactContextBaseJavaModule
+{
+    private static final String ON_ADVIEW_AD_LOADED_EVENT         = "OnAdViewAdLoadedEvent";
+    private static final String ON_ADVIEW_AD_LOAD_FAILED_EVENT    = "OnAdViewAdLoadFailedEvent";
+    private static final String ON_ADVIEW_AD_CLICKED_EVENT        = "OnAdViewAdClickedEvent";
+    private static final String ON_ADVIEW_AD_COLLAPSED_EVENT      = "OnAdViewAdCollapsedEvent";
+    private static final String ON_ADVIEW_AD_EXPANDED_EVENT       = "OnAdViewAdExpandedEvent";
+    private static final String ON_ADVIEW_AD_DISPLAY_FAILED_EVENT = "OnAdViewAdDisplayFailedEvent";
+    private static final String ON_ADVIEW_AD_REVENUE_PAID         = "OnAdViewAdRevenuePaid";
+
+    private final Map<Integer, AppLovinMAXAdViewAd> adViewAds = new HashMap<>( 2 );
+
+    AppLovinMAXAdViewAdManager(final ReactApplicationContext context)
+    {
+        super( context );
+    }
+
+    @NonNull
+    @Override
+    public String getName()
+    {
+        return "AppLovinMAXAdViewAdManager";
+    }
+
+    public AppLovinMAXAdViewAd getAdViewAd(final int adViewAdId)
+    {
+        return adViewAds.get( adViewAdId );
+    }
+
+    @ReactMethod
+    public void createAdView(final String adUnitId, final String adFormatStr, final Promise promise)
+    {
+        if ( TextUtils.isEmpty( adUnitId ) )
+        {
+            promise.reject( new IllegalStateException( "Attempting to create MaxAdView without Ad Unit ID" ) );
+            return;
+        }
+
+        MaxAdFormat adFormat;
+
+        if ( MaxAdFormat.BANNER.getLabel().equals( adFormatStr ) )
+        {
+            adFormat = AppLovinMAXModule.getDeviceSpecificBannerAdViewAdFormat( getReactApplicationContext() );
+        }
+        else if ( MaxAdFormat.MREC.getLabel().equals( adFormatStr ) )
+        {
+            adFormat = MaxAdFormat.MREC;
+        }
+        else
+        {
+            promise.reject( new IllegalStateException( "Attempting to set an invalid ad format of \"" + adFormatStr + "\" for " + adUnitId ) );
+            return;
+        }
+
+        AppLovinMAXAdViewAd adViewAd = new AppLovinMAXAdViewAd( getReactApplicationContext(), this );
+        int adViewAdId = adViewAd.createAdView( adUnitId, adFormat );
+        adViewAds.put( adViewAdId, adViewAd );
+        promise.resolve( adViewAdId );
+    }
+
+    @ReactMethod
+    public void destroyAdView(final int adViewAdId, final Promise promise)
+    {
+        AppLovinMAXAdViewAd adViewAd = adViewAds.get( adViewAdId );
+        adViewAd.destroyAdView();
+        adViewAds.remove( adViewAdId );
+        promise.resolve( null );
+    }
+
+    @ReactMethod
+    public void loadAd(final int adViewAdId, final Promise promise)
+    {
+        AppLovinMAXAdViewAd adViewAd = adViewAds.get( adViewAdId );
+        adViewAd.loadAd();
+        promise.resolve( null );
+    }
+
+    @ReactMethod
+    public void setPlacement(final int adViewAdId, final String placement, final Promise promise)
+    {
+        AppLovinMAXAdViewAd adViewAd = adViewAds.get( adViewAdId );
+        adViewAd.setPlacement( placement );
+        promise.resolve( null );
+    }
+
+    @ReactMethod
+    public void setCustomData(final int adViewAdId, final String customData, final Promise promise)
+    {
+        AppLovinMAXAdViewAd adViewAd = adViewAds.get( adViewAdId );
+        adViewAd.setCustomData( customData );
+        promise.resolve( null );
+    }
+
+    @ReactMethod
+    public void setAdaptiveBannerEnabled(final int adViewAdId, final boolean adaptiveBannerEnabled, final Promise promise)
+    {
+        AppLovinMAXAdViewAd adViewAd = adViewAds.get( adViewAdId );
+        adViewAd.setAdaptiveBannerEnabled( adaptiveBannerEnabled );
+        promise.resolve( null );
+    }
+
+    @ReactMethod
+    public void setAutoRefresh(final int adViewAdId, final boolean autoRefresh, final Promise promise)
+    {
+        AppLovinMAXAdViewAd adViewAd = adViewAds.get( adViewAdId );
+        adViewAd.setAutoRefresh( autoRefresh );
+        promise.resolve( null );
+    }
+
+    @ReactMethod
+    public void setExtraParameters(final int adViewAdId, final ReadableMap parameterMap, final Promise promise)
+    {
+        AppLovinMAXAdViewAd adViewAd = adViewAds.get( adViewAdId );
+        adViewAd.setExtraParameters( parameterMap );
+        promise.resolve( null );
+    }
+
+    @ReactMethod
+    public void setLocalExtraParameters(final int adViewAdId, final ReadableMap parameterMap, final Promise promise)
+    {
+        AppLovinMAXAdViewAd adViewAd = adViewAds.get( adViewAdId );
+        adViewAd.setLocalExtraParameters( parameterMap );
+        promise.resolve( null );
+    }
+
+    public void sendLoadAdEvent(@Nullable final WritableMap params)
+    {
+        sendReactNativeEvent( ON_ADVIEW_AD_LOADED_EVENT, params );
+    }
+
+    public void sendFailToDisplayAEvent(@Nullable final WritableMap params)
+    {
+        sendReactNativeEvent( ON_ADVIEW_AD_DISPLAY_FAILED_EVENT, params );
+    }
+
+    public void sendFailToLoadAdEvent(@Nullable final WritableMap params)
+    {
+        sendReactNativeEvent( ON_ADVIEW_AD_LOAD_FAILED_EVENT, params );
+    }
+
+    public void sendClickAdEvent(@Nullable final WritableMap params)
+    {
+        sendReactNativeEvent( ON_ADVIEW_AD_CLICKED_EVENT, params );
+    }
+
+    public void sendCollapseAdEvent(@Nullable final WritableMap params)
+    {
+        sendReactNativeEvent( ON_ADVIEW_AD_COLLAPSED_EVENT, params );
+    }
+
+    public void sendExpandAdEvent(@Nullable final WritableMap params)
+    {
+        sendReactNativeEvent( ON_ADVIEW_AD_EXPANDED_EVENT, params );
+    }
+
+    public void sendPayRevenueEvent(@Nullable final WritableMap params)
+    {
+        sendReactNativeEvent( ON_ADVIEW_AD_REVENUE_PAID, params );
+    }
+
+    private void sendReactNativeEvent(final String name, @Nullable final WritableMap params)
+    {
+        getReactApplicationContext()
+                .getJSModule( DeviceEventManagerModule.RCTDeviceEventEmitter.class )
+                .emit( name, params );
+    }
+
+    @Override
+    @Nullable
+    public Map<String, Object> getConstants()
+    {
+        final Map<String, Object> constants = new HashMap<>();
+
+        constants.put( "ON_ADVIEW_AD_LOADED_EVENT", ON_ADVIEW_AD_LOADED_EVENT );
+        constants.put( "ON_ADVIEW_AD_LOAD_FAILED_EVENT", ON_ADVIEW_AD_LOAD_FAILED_EVENT );
+        constants.put( "ON_ADVIEW_AD_CLICKED_EVENT", ON_ADVIEW_AD_CLICKED_EVENT );
+        constants.put( "ON_ADVIEW_AD_COLLAPSED_EVENT", ON_ADVIEW_AD_COLLAPSED_EVENT );
+        constants.put( "ON_ADVIEW_AD_EXPANDED_EVENT", ON_ADVIEW_AD_EXPANDED_EVENT );
+        constants.put( "ON_ADVIEW_AD_DISPLAY_FAILED_EVENT", ON_ADVIEW_AD_DISPLAY_FAILED_EVENT );
+        constants.put( "ON_ADVIEW_AD_REVENUE_PAID", ON_ADVIEW_AD_REVENUE_PAID );
+
+        return constants;
+    }
+}

--- a/android/src/main/java/com/applovin/reactnative/AppLovinMAXAdViewManager.java
+++ b/android/src/main/java/com/applovin/reactnative/AppLovinMAXAdViewManager.java
@@ -1,105 +1,42 @@
 package com.applovin.reactnative;
 
 import com.facebook.react.bridge.ReactApplicationContext;
-import com.facebook.react.bridge.ReadableMap;
-import com.facebook.react.common.MapBuilder;
 import com.facebook.react.uimanager.SimpleViewManager;
 import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.annotations.ReactProp;
 
-import java.util.Map;
+import androidx.annotation.NonNull;
 
-import androidx.annotation.Nullable;
-
-/**
- * Created by Thomas So on September 26 2020
- */
 class AppLovinMAXAdViewManager
         extends SimpleViewManager<AppLovinMAXAdView>
 {
     public AppLovinMAXAdViewManager(final ReactApplicationContext reactApplicationContext) { }
 
+    @NonNull
     @Override
     public String getName()
     {
         return "AppLovinMAXAdView";
     }
 
-    @Nullable
-    @Override
-    public Map<String, Object> getExportedCustomDirectEventTypeConstants()
-    {
-        // mapping Android events to JavaScript events
-        return MapBuilder.<String, Object>builder()
-                .put( "onAdLoadedEvent", MapBuilder.of( "registrationName", "onAdLoadedEvent" ) )
-                .put( "onAdLoadFailedEvent", MapBuilder.of( "registrationName", "onAdLoadFailedEvent" ) )
-                .put( "onAdDisplayFailedEvent", MapBuilder.of( "registrationName", "onAdDisplayFailedEvent" ) )
-                .put( "onAdClickedEvent", MapBuilder.of( "registrationName", "onAdClickedEvent" ) )
-                .put( "onAdExpandedEvent", MapBuilder.of( "registrationName", "onAdExpandedEvent" ) )
-                .put( "onAdCollapsedEvent", MapBuilder.of( "registrationName", "onAdCollapsedEvent" ) )
-                .put( "onAdRevenuePaidEvent", MapBuilder.of( "registrationName", "onAdRevenuePaidEvent" ) )
-                .build();
-    }
-
+    @NonNull
     @Override
     protected AppLovinMAXAdView createViewInstance(final ThemedReactContext reactContext)
     {
-        // NOTE: Do not set frame or backgroundColor as RN will overwrite the values set by your custom class in order to match your JavaScript component's layout props - hence wrapper
-        return new AppLovinMAXAdView( reactContext );
+        AppLovinMAXAdViewAdManager manager = reactContext.getNativeModule( AppLovinMAXAdViewAdManager.class );
+        return new AppLovinMAXAdView( reactContext, manager );
     }
 
-    @ReactProp(name = "adUnitId")
-    public void setAdUnitId(final AppLovinMAXAdView view, final String adUnitId)
+    @ReactProp(name = "adViewAdId")
+    public void setAdViewAdId(final AppLovinMAXAdView view, final int adViewAdId)
     {
-        view.setAdUnitId( adUnitId );
-    }
-
-    @ReactProp(name = "adFormat")
-    public void setAdFormat(final AppLovinMAXAdView view, final String adFormatStr)
-    {
-        view.setAdFormat( adFormatStr );
-    }
-
-    @ReactProp(name = "placement")
-    public void setPlacement(final AppLovinMAXAdView view, @Nullable final String placement)
-    {
-        view.setPlacement( placement );
-    }
-
-    @ReactProp(name = "customData")
-    public void setCustomData(final AppLovinMAXAdView view, @Nullable final String customData)
-    {
-        view.setCustomData( customData );
-    }
-
-    @ReactProp(name = "adaptiveBannerEnabled")
-    public void setAdaptiveBannerEnabled(final AppLovinMAXAdView view, final boolean enabled)
-    {
-        view.setAdaptiveBannerEnabled( enabled );
-    }
-
-    @ReactProp(name = "autoRefresh")
-    public void setAutoRefresh(final AppLovinMAXAdView view, final boolean enabled)
-    {
-        view.setAutoRefresh( enabled );
-    }
-
-    @ReactProp(name = "extraParameters")
-    public void setExtraParameters(final AppLovinMAXAdView view, @Nullable final ReadableMap value)
-    {
-        view.setExtraParameters( value );
-    }
-
-    @ReactProp(name = "localExtraParameters")
-    public void setLocalExtraParameters(final AppLovinMAXAdView view, @Nullable final ReadableMap value)
-    {
-        view.setLocalExtraParameters( value );
+        view.attachAdView( adViewAdId );
     }
 
     @Override
     public void onDropViewInstance(AppLovinMAXAdView view)
     {
-        view.destroy();
+        view.detachAdView();
 
         super.onDropViewInstance( view );
     }

--- a/android/src/main/java/com/applovin/reactnative/AppLovinMAXPackage.java
+++ b/android/src/main/java/com/applovin/reactnative/AppLovinMAXPackage.java
@@ -21,6 +21,7 @@ public class AppLovinMAXPackage
     {
         List<NativeModule> module = new ArrayList<>( 1 );
         module.add( new AppLovinMAXModule( reactContext ) );
+        module.add( new AppLovinMAXAdViewAdManager( reactContext ) );
         return module;
     }
 

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -161,6 +161,7 @@ const App = () => {
                     bannerAdUnitId={BANNER_AD_UNIT_ID}
                     mrecAdUnitId={MREC_AD_UNIT_ID}
                     isInitialized={isInitialized}
+                    log={setStatusText}
                     isNativeAdShowing={isNativeAdShowing}
                 />
             </View>

--- a/ios/AppLovinMAXAdView.h
+++ b/ios/AppLovinMAXAdView.h
@@ -9,7 +9,11 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+@class AppLovinMAXAdViewAdManager;
+
 @interface AppLovinMAXAdView : UIView
+
+- (instancetype)initWithAdViewAdManager:(AppLovinMAXAdViewAdManager *)manager;
 
 @end
 

--- a/ios/AppLovinMAXAdView.m
+++ b/ios/AppLovinMAXAdView.m
@@ -5,265 +5,58 @@
 //  Copyright © 2022 AppLovin. All rights reserved.
 //
 
-#import <AppLovinSDK/AppLovinSDK.h>
 #import "AppLovinMAX.h"
 #import "AppLovinMAXAdView.h"
+#import "AppLovinMAXAdViewAd.h"
+#import "AppLovinMAXAdViewAdManager.h"
 
-@interface AppLovinMAXAdView()<MAAdViewAdDelegate, MAAdRevenueDelegate>
-
-@property (nonatomic, strong, nullable) MAAdView *adView; // nil when unmounted
-
-// The following properties are updated from RN layer via the view manager
-@property (nonatomic, copy) NSString *adUnitId;
-@property (nonatomic, weak) MAAdFormat *adFormat;
-@property (nonatomic, copy, nullable) NSString *placement;
-@property (nonatomic, copy, nullable) NSString *customData;
-@property (nonatomic, assign, readonly, getter=isAdaptiveBannerEnabled) BOOL adaptiveBannerEnabled;
-@property (nonatomic, assign, readonly, getter=isAutoRefresh) BOOL autoRefresh;
-@property (nonatomic, copy, nullable) NSDictionary *extraParameters;
-@property (nonatomic, copy, nullable) NSDictionary *localExtraParameters;
-
-@property (nonatomic, copy) RCTDirectEventBlock onAdLoadedEvent;
-@property (nonatomic, copy) RCTDirectEventBlock onAdLoadFailedEvent;
-@property (nonatomic, copy) RCTDirectEventBlock onAdDisplayFailedEvent;
-@property (nonatomic, copy) RCTDirectEventBlock onAdClickedEvent;
-@property (nonatomic, copy) RCTDirectEventBlock onAdExpandedEvent;
-@property (nonatomic, copy) RCTDirectEventBlock onAdCollapsedEvent;
-@property (nonatomic, copy) RCTDirectEventBlock onAdRevenuePaidEvent;
-
+@interface AppLovinMAXAdView()
+@property (nonatomic, weak) AppLovinMAXAdViewAdManager *manager;
+@property (nonatomic, copy) NSNumber *adViewAdId;
 @end
 
 @implementation AppLovinMAXAdView
 
-- (void)setAdUnitId:(NSString *)adUnitId
+- (instancetype)initWithAdViewAdManager:(AppLovinMAXAdViewAdManager *)manager
 {
-    // Ad Unit ID must be set prior to creating MAAdView
-    if ( self.adView )
+    self = [super init];
+    if ( self )
     {
-        [[AppLovinMAX shared] log: @"Attempting to set Ad Unit ID %@ after MAAdView is created", adUnitId];
-        return;
+        self.manager = manager;
     }
-    
-    _adUnitId = adUnitId;
-    
-    [self attachAdViewIfNeeded];
-}  
+    return self;
+}
 
-- (void)setAdFormat:(NSString *)adFormat
+// Called when AdView is mounted with AdViewAd in JavaScript
+- (void)setAdViewAdId:(NSNumber *)adViewAdId
 {
-    // Ad format must be set prior to creating MAAdView
-    if ( self.adView )
-    {
-        [[AppLovinMAX shared] log: @"Attempting to set ad format %@ after MAAdView is created", adFormat];
-        return;
-    }
+    _adViewAdId = adViewAdId;
     
-    if ( [MAAdFormat.banner.label isEqualToString: adFormat] )
+    AppLovinMAXAdViewAd *adViewAd = [self.manager adViewAd: adViewAdId];
+    if ( adViewAd )
     {
-        _adFormat = DEVICE_SPECIFIC_ADVIEW_AD_FORMAT;
-    }
-    else if ( [MAAdFormat.mrec.label isEqualToString: adFormat] )
-    {
-        _adFormat = MAAdFormat.mrec;
+        [adViewAd attachView: self];
     }
     else
     {
-        [[AppLovinMAX shared] log: @"Attempting to set an invalid ad format of \"%@\" for %@", adFormat, self.adUnitId];
-        return;
-    }
-    
-    [self attachAdViewIfNeeded];
-}  
-
-- (void)setPlacement:(NSString *)placement
-{
-    _placement = placement;
-    
-    if ( self.adView )
-    {
-        self.adView.placement = placement;
+        [[AppLovinMAX shared] log: @"Cannot find AdViewAd with id %@ for adding to AdView", adViewAdId];
     }
 }
 
-- (void)setCustomData:(NSString *)customData
-{
-    _customData = customData;
-    
-    if ( self.adView )
-    {
-        self.adView.customData = customData;
-    }
-}
-
-- (void)setAdaptiveBannerEnabled:(BOOL)adaptiveBannerEnabled
-{
-    _adaptiveBannerEnabled = adaptiveBannerEnabled;
-    
-    if ( self.adView )
-    {
-        [self.adView setExtraParameterForKey: @"adaptive_banner" value: adaptiveBannerEnabled ? @"true" : @"false"];
-    }
-}
-
-- (void)setAutoRefresh:(BOOL)autoRefresh
-{
-    _autoRefresh = autoRefresh;
-    
-    if ( self.adView )
-    {
-        if ( autoRefresh )
-        {
-            [self.adView startAutoRefresh];
-        }
-        else
-        {
-            [self.adView stopAutoRefresh];
-        }
-    }
-}
-
-- (void)attachAdViewIfNeeded
-{
-    // Re-assign in case of race condition
-    NSString *adUnitId = self.adUnitId;
-    MAAdFormat *adFormat = self.adFormat;
-    
-    // Run after 0.25 sec delay to allow all properties to set
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t) (0.25 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-        
-        if ( ![AppLovinMAX shared].sdk )
-        {
-            [[AppLovinMAX shared] logUninitializedAccessError: @"AppLovinMAXAdview.attachAdViewIfNeeded"];
-            return;
-        }
-
-        if ( ![adUnitId al_isValidString] )
-        {
-            [[AppLovinMAX shared] log: @"Attempting to attach MAAdView without Ad Unit ID"];
-            return;
-        }
-        
-        if ( !adFormat )
-        {
-            [[AppLovinMAX shared] log: @"Attempting to attach MAAdView without ad format"];
-            return;
-        }
-        
-        if ( self.adView )
-        {
-            [[AppLovinMAX shared] log: @"Attempting to re-attach with existing MAAdView: %@", self.adView];
-            return;
-        }
-        
-        [[AppLovinMAX shared] log: @"Attaching MAAdView for %@", adUnitId];
-        
-        self.adView = [[MAAdView alloc] initWithAdUnitIdentifier: adUnitId
-                                                        adFormat: adFormat
-                                                             sdk: [AppLovinMAX shared].sdk];
-        self.adView.frame = (CGRect) { CGPointZero, self.frame.size };
-        self.adView.delegate = self;
-        self.adView.revenueDelegate = self;
-        self.adView.placement = self.placement;
-        self.adView.customData = self.customData;
-        [self.adView setExtraParameterForKey: @"adaptive_banner" value: [self isAdaptiveBannerEnabled] ? @"true" : @"false"];
-        // Set this extra parameter to work around a SDK bug that ignores calls to stopAutoRefresh()
-        [self.adView setExtraParameterForKey: @"allow_pause_auto_refresh_immediately" value: @"true"];
-        
-        for ( NSString *key in self.extraParameters )
-        {
-            [self.adView setExtraParameterForKey: key value: self.extraParameters[key]];
-        }
-        
-        for ( NSString *key in self.localExtraParameters )
-        {
-            [self.adView setLocalExtraParameterForKey: key value: self.localExtraParameters[key]];
-        }
-        
-        if ( [self isAutoRefresh] )
-        {
-            [self.adView startAutoRefresh];
-        }
-        else
-        {
-            [self.adView stopAutoRefresh];
-        }
-        
-        [self.adView loadAd];
-        
-        [self addSubview: self.adView];
-        
-        [NSLayoutConstraint activateConstraints: @[[self.adView.widthAnchor constraintEqualToAnchor: self.widthAnchor],
-                                                   [self.adView.heightAnchor constraintEqualToAnchor: self.heightAnchor],
-                                                   [self.adView.centerXAnchor constraintEqualToAnchor: self.centerXAnchor],
-                                                   [self.adView.centerYAnchor constraintEqualToAnchor: self.centerYAnchor]]];
-    });
-}
-
+// Called when AdView is unmounted in JavaScript
 - (void)didMoveToWindow
 {
     [super didMoveToWindow];
     
     // This view is unmounted
-    if ( !self.window && !self.superview )
+    if ( !self.window )
     {
-        if ( self.adView )
+        AppLovinMAXAdViewAd *adViewAd = [self.manager adViewAd: self.adViewAdId];
+        if ( adViewAd )
         {
-            [[AppLovinMAX shared] log: @"Unmounting MAAdView: %@", self.adView];
-            
-            self.adView.delegate = nil;
-            self.adView.revenueDelegate = nil;
-            
-            [self.adView removeFromSuperview];
-            
-            self.adView = nil;
+            [adViewAd detachView];
         }
     }
 }
-
-#pragma mark - MAAdDelegate Protocol
-
-- (void)didLoadAd:(MAAd *)ad
-{
-    self.onAdLoadedEvent([[AppLovinMAX shared] adInfoForAd: ad]);
-}
-
-- (void)didFailToLoadAdForAdUnitIdentifier:(NSString *)adUnitIdentifier withError:(MAError *)error
-{
-    self.onAdLoadFailedEvent([[AppLovinMAX shared] adLoadFailedInfoForAd: adUnitIdentifier withError: error]);
-}
-
-- (void)didFailToDisplayAd:(MAAd *)ad withError:(MAError *)error
-{
-    self.onAdDisplayFailedEvent([[AppLovinMAX shared] adDisplayFailedInfoForAd: ad withError: error]);
-}
-
-- (void)didClickAd:(MAAd *)ad
-{
-    self.onAdClickedEvent([[AppLovinMAX shared] adInfoForAd: ad]);
-}
-
-#pragma mark - MAAdViewAdDelegate Protocol
-
-- (void)didExpandAd:(MAAd *)ad
-{
-    self.onAdExpandedEvent([[AppLovinMAX shared] adInfoForAd: ad]);
-}
-
-- (void)didCollapseAd:(MAAd *)ad
-{
-    self.onAdCollapsedEvent([[AppLovinMAX shared] adInfoForAd: ad]);
-}
-
-#pragma mark - MAAdRevenueDelegate Protocol
-
-- (void)didPayRevenueForAd:(MAAd *)ad
-{
-    self.onAdRevenuePaidEvent([[AppLovinMAX shared] adRevenueInfoForAd: ad]);
-}
-
-#pragma mark - Deprecated Callbacks
-
-- (void)didDisplayAd:(MAAd *)ad {}
-- (void)didHideAd:(MAAd *)ad {}
 
 @end

--- a/ios/AppLovinMAXAdViewAd.h
+++ b/ios/AppLovinMAXAdViewAd.h
@@ -1,0 +1,25 @@
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@class AppLovinMAXAdViewAdManager;
+
+@interface AppLovinMAXAdViewAd : NSObject
+
+@property (nonatomic, copy, nullable) NSString *placement;
+@property (nonatomic, copy, nullable) NSString *customData;
+@property (nonatomic, assign) BOOL adaptiveBannerEnabled;
+@property (nonatomic, assign, getter=isAutoRefresh) BOOL autoRefresh;
+@property (nonatomic, copy, nullable) NSDictionary *extraParameters;
+@property (nonatomic, copy, nullable) NSDictionary *localExtraParameters;
+
+- (instancetype)initWithManager:(AppLovinMAXAdViewAdManager *)manager;
+- (NSNumber *)createAdView:(NSString *)adUnitIdentifier adFormat:(MAAdFormat *)adFormat;
+- (void)destroyAdView;
+- (void)loadAd;
+- (void)attachView:(UIView *)view;
+- (void)detachView;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/AppLovinMAXAdViewAd.m
+++ b/ios/AppLovinMAXAdViewAd.m
@@ -1,0 +1,208 @@
+#import "AppLovinMAX.h"
+#import "AppLovinMAXAdViewAdManager.h"
+#import "AppLovinMAXAdViewAd.h"
+
+@interface AppLovinMAXAdViewAd()<MAAdViewAdDelegate, MAAdRevenueDelegate>
+@property (nonatomic, weak) AppLovinMAXAdViewAdManager *manager;
+@property (nonatomic, strong) MAAdView *adView;
+@end
+
+@implementation AppLovinMAXAdViewAd
+
+- (instancetype)initWithManager:(AppLovinMAXAdViewAdManager *)manager
+{
+    self = [super init];
+    if ( self )
+    {
+        self.manager = manager;
+    }
+    
+    return self;
+}
+
+- (NSNumber *)createAdView:(NSString *)adUnitIdentifier adFormat:(MAAdFormat *)adFormat
+{
+    self.adView = [[MAAdView alloc] initWithAdUnitIdentifier: adUnitIdentifier adFormat: adFormat sdk: [AppLovinMAX shared].sdk];
+    
+    self.adView.delegate = self;
+    self.adView.revenueDelegate = self;
+    self.adView.userInteractionEnabled = NO;
+    self.adView.translatesAutoresizingMaskIntoConstraints = NO;
+
+    [self.adView setExtraParameterForKey: @"adaptive_banner" value: @"true"];
+    
+    // Set this extra parameter to work around a SDK bug that ignores calls to stopAutoRefresh()
+    [self.adView setExtraParameterForKey: @"allow_pause_auto_refresh_immediately" value: @"true"];
+    
+    // Hide AdView until it is attached to the parent view
+    self.adView.hidden = YES;
+    
+    // Set frame to supprss an error of zero Adview area
+    self.adView.frame = (CGRect) { CGPointZero, adFormat.size };
+
+    [self.adView stopAutoRefresh];
+
+    [self.adView loadAd];
+
+    [[AppLovinMAX shared] log: @"Ad Unit ID %@ MAAdView is created with id %@", adUnitIdentifier, self.hash];
+    
+    return @(self.hash);
+}
+
+-(void)destroyAdView
+{
+    [self.adView removeFromSuperview];
+    
+    [[AppLovinMAX shared] log: @"Ad Unit ID %@ MAAdView is destroyed with id %@", self.adView.adUnitIdentifier, self.hash];
+
+    self.adView.delegate = nil;
+    self.adView.revenueDelegate = nil;
+
+    self.adView = nil;
+}
+
+-(void)loadAd
+{
+    [self.adView loadAd];
+}
+
+-(void)setPlacement:(nullable NSString *)placement
+{
+    self.adView.placement = placement;
+}
+
+-(void)setCustomData:(nullable NSString *)customData
+{
+    self.adView.customData = customData;
+}
+
+-(void)setAdaptiveBannerEnabled:(BOOL)adaptiveBannerEnabled
+{
+    [self.adView setExtraParameterForKey: @"adaptive_banner" value: adaptiveBannerEnabled ? @"true" : @"false"];
+}
+
+-(void)setAutoRefresh:(BOOL)autoRefresh
+{
+    _autoRefresh = autoRefresh;
+
+    if ( self.adView.isHidden ) return;
+    
+    if ( autoRefresh )
+    {
+        [self.adView startAutoRefresh];
+    }
+    else
+    {
+        [self.adView stopAutoRefresh];
+    }
+}
+
+-(void)setExtraParameters:(NSDictionary<NSString *, id> *)parameterDict
+{
+    for (NSString *key in parameterDict)
+    {
+        NSString *value = (NSString *) parameterDict[key];
+        [self.adView setExtraParameterForKey:key value:value];
+    }
+}
+
+-(void)setLocalExtraParameters:(NSDictionary<NSString *, id> *)parameterDict
+{
+    for (NSString *key in parameterDict)
+    {
+        id value = parameterDict[key];
+        [self.adView setLocalExtraParameterForKey:key value:value];
+    }
+}
+
+-(void)attachView:(UIView *)view
+{
+    self.adView.hidden = NO;
+    self.adView.userInteractionEnabled = YES;
+
+    if ( self.isAutoRefresh )
+    {
+        [self.adView startAutoRefresh];
+    }
+
+    self.adView.frame = (CGRect) { CGPointZero, view.frame.size };
+
+    [view addSubview: self.adView];
+    
+    [NSLayoutConstraint activateConstraints: @[[self.adView.widthAnchor constraintEqualToAnchor: view.widthAnchor],
+                                               [self.adView.heightAnchor constraintEqualToAnchor: view.heightAnchor],
+                                               [self.adView.centerXAnchor constraintEqualToAnchor: view.centerXAnchor],
+                                               [self.adView.centerYAnchor constraintEqualToAnchor: view.centerYAnchor]]];
+}
+
+-(void)detachView
+{
+    [self.adView removeFromSuperview];
+
+    self.adView.hidden = YES;
+    self.adView.userInteractionEnabled = NO;
+
+    [self.adView stopAutoRefresh];
+}
+
+#pragma mark - MAAdDelegate Protocol
+
+- (void)didLoadAd:(nonnull MAAd *)ad
+{
+    NSMutableDictionary *adInfo = [[AppLovinMAX shared] adInfoForAd: ad].mutableCopy;
+    adInfo[@"adViewAdId"] = @(self.hash);
+    [self.manager sendLoadAdEvent: adInfo];
+}
+
+- (void)didFailToLoadAdForAdUnitIdentifier:(nonnull NSString *)adUnitIdentifier withError:(nonnull MAError *)error
+{
+    NSMutableDictionary *adInfo = [[AppLovinMAX shared] adLoadFailedInfoForAd: adUnitIdentifier withError: error].mutableCopy;
+    adInfo[@"adViewAdId"] = @(self.hash);
+    [self.manager sendFailToLoadAdEvent: adInfo];
+}
+
+- (void)didFailToDisplayAd:(nonnull MAAd *)ad withError:(nonnull MAError *)error
+{
+    NSMutableDictionary *adInfo = [[AppLovinMAX shared] adDisplayFailedInfoForAd: ad withError: error].mutableCopy;
+    adInfo[@"adViewAdId"] = @(self.hash);
+    [self.manager sendFailToDisplayAEvent: adInfo];
+}
+
+- (void)didClickAd:(nonnull MAAd *)ad
+{
+    NSMutableDictionary *adInfo = [[AppLovinMAX shared] adInfoForAd: ad].mutableCopy;
+    adInfo[@"adViewAdId"] = @(self.hash);
+    [self.manager sendClickAdEvent: adInfo];
+}
+
+#pragma mark - MAAdViewAdDelegate Protocol
+
+- (void)didExpandAd:(nonnull MAAd *)ad
+{
+    NSMutableDictionary *adInfo = [[AppLovinMAX shared] adInfoForAd: ad].mutableCopy;
+    adInfo[@"adViewAdId"] = @(self.hash);
+    [self.manager sendExpandAdEvent: adInfo];
+}
+
+- (void)didCollapseAd:(nonnull MAAd *)ad
+{
+    NSMutableDictionary *adInfo = [[AppLovinMAX shared] adInfoForAd: ad].mutableCopy;
+    adInfo[@"adViewAdId"] = @(self.hash);
+    [self.manager sendCollapseAdEvent: adInfo];
+}
+
+#pragma mark - MAAdRevenueDelegate Protocol
+
+- (void)didPayRevenueForAd:(nonnull MAAd *)ad
+{
+    NSMutableDictionary *adInfo = [[AppLovinMAX shared] adRevenueInfoForAd: ad].mutableCopy;
+    adInfo[@"adViewAdId"] = @(self.hash);
+    [self.manager sendPayRevenueEvent: adInfo];
+}
+
+#pragma mark - Deprecated Callbacks
+
+- (void)didDisplayAd:(nonnull MAAd *)ad {}
+- (void)didHideAd:(nonnull MAAd *)ad {}
+
+@end

--- a/ios/AppLovinMAXAdViewAdManager.h
+++ b/ios/AppLovinMAXAdViewAdManager.h
@@ -1,0 +1,23 @@
+#import <React/RCTBridgeModule.h>
+#import <React/RCTEventEmitter.h>
+#import <React/RCTUIManager.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@class AppLovinMAXAdViewAd;
+
+@interface AppLovinMAXAdViewAdManager : RCTEventEmitter<RCTBridgeModule>
+
+- (AppLovinMAXAdViewAd *)adViewAd:(nonnull NSNumber *)adViewAdId;
+
+- (void)sendLoadAdEvent:(NSDictionary<NSString *, id> *)body;
+- (void)sendFailToDisplayAEvent:(NSDictionary<NSString *, id> *)body;
+- (void)sendFailToLoadAdEvent:(NSDictionary<NSString *, id> *)body;
+- (void)sendClickAdEvent:(NSDictionary<NSString *, id> *)body;
+- (void)sendCollapseAdEvent:(NSDictionary<NSString *, id> *)body;
+- (void)sendExpandAdEvent:(NSDictionary<NSString *, id> *)body;
+- (void)sendPayRevenueEvent:(NSDictionary<NSString *, id> *)body;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/AppLovinMAXAdViewAdManager.m
+++ b/ios/AppLovinMAXAdViewAdManager.m
@@ -1,0 +1,191 @@
+#import "AppLovinMAX.h"
+#import "AppLovinMAXAdViewAdManager.h"
+#import "AppLovinMAXAdViewAd.h"
+
+static NSString *const ON_ADVIEW_AD_LOADED_EVENT = @"OnAdViewAdLoadedEvent";
+static NSString *const ON_ADVIEW_AD_LOAD_FAILED_EVENT = @"OnAdViewAdLoadFailedEvent";
+static NSString *const ON_ADVIEW_AD_CLICKED_EVENT = @"OnAdViewAdClickedEvent";
+static NSString *const ON_ADVIEW_AD_COLLAPSED_EVENT = @"OnAdViewAdCollapsedEvent";
+static NSString *const ON_ADVIEW_AD_EXPANDED_EVENT = @"OnAdViewAdExpandedEvent";
+static NSString *const ON_ADVIEW_AD_DISPLAY_FAILED_EVENT = @"OnAdViewAdDisplayFailedEvent";
+static NSString *const ON_ADVIEW_AD_REVENUE_PAID = @"OnAdViewAdRevenuePaid";
+
+@interface AppLovinMAXAdViewAdManager()
+@property (nonatomic, strong) NSMutableDictionary<NSNumber *, AppLovinMAXAdViewAd *> *adViewAds;
+@end
+
+@implementation AppLovinMAXAdViewAdManager
+
+RCT_EXPORT_MODULE()
+
++ (BOOL)requiresMainQueueSetup
+{
+    return YES;
+}
+
+- (dispatch_queue_t)methodQueue
+{
+    return dispatch_get_main_queue();
+}
+
+- (instancetype)init
+{
+    self = [super init];
+    if ( self )
+    {
+        self.adViewAds = [NSMutableDictionary dictionaryWithCapacity: 2];
+    }
+    return self;
+}
+
+- (AppLovinMAXAdViewAd *)adViewAd:(nonnull NSNumber *)adViewAdId
+{
+    return self.adViewAds[adViewAdId];
+}
+
+RCT_EXPORT_METHOD(createAdView:(NSString *)adUnitIdentifier :(NSString *)adFormatStr :(RCTPromiseResolveBlock)resolve :(RCTPromiseRejectBlock)reject)
+{
+    if ( ![adUnitIdentifier al_isValidString] )
+    {
+        reject(RCTErrorUnspecified, @"Attempting to attach MAAdView without Ad Unit ID", nil);
+        return;
+    }
+
+    MAAdFormat *adFormat;
+    
+    if ( [MAAdFormat.banner.label isEqualToString: adFormatStr] )
+    {
+        adFormat = DEVICE_SPECIFIC_ADVIEW_AD_FORMAT;
+    }
+    else if ( [MAAdFormat.mrec.label isEqualToString: adFormatStr] )
+    {
+        adFormat = MAAdFormat.mrec;
+    }
+    else
+    {
+        NSString *error = [NSString stringWithFormat: @"Attempting to set an invalid ad format of %@ for %@!", adFormatStr, adUnitIdentifier];
+        reject(RCTErrorUnspecified, error, nil);
+        return;
+    }
+    
+    AppLovinMAXAdViewAd *adViewAd = [[AppLovinMAXAdViewAd alloc] initWithManager: self];
+    NSNumber *adViewAdId = [adViewAd createAdView: adUnitIdentifier adFormat: adFormat];
+    self.adViewAds[adViewAdId] = adViewAd;
+    resolve(adViewAdId);
+}
+
+RCT_EXPORT_METHOD(destroyAdView:(nonnull NSNumber *)adViewAdId :(RCTPromiseResolveBlock)resolve :(RCTPromiseRejectBlock)reject)
+{
+    AppLovinMAXAdViewAd *adViewAd = self.adViewAds[adViewAdId];
+    [adViewAd destroyAdView];
+    [self.adViewAds removeObjectForKey: adViewAdId];
+    resolve(nil);
+}
+
+RCT_EXPORT_METHOD(loadAd:(nonnull NSNumber *)adViewAdId :(RCTPromiseResolveBlock)resolve :(RCTPromiseRejectBlock)reject)
+{
+    AppLovinMAXAdViewAd *adViewAd = self.adViewAds[adViewAdId];
+    [adViewAd loadAd];
+    resolve(nil);
+}
+
+RCT_EXPORT_METHOD(setPlacement:(nonnull NSNumber *)adViewAdId :(nullable NSString *)placement :(RCTPromiseResolveBlock)resolve :(RCTPromiseRejectBlock)reject)
+{
+    AppLovinMAXAdViewAd *adViewAd = self.adViewAds[adViewAdId];
+    adViewAd.placement = placement;
+    resolve(nil);
+}
+
+RCT_EXPORT_METHOD(setCustomData:(nonnull NSNumber *)adViewAdId :(nullable NSString *)customData :(RCTPromiseResolveBlock)resolve :(RCTPromiseRejectBlock)reject)
+{
+    AppLovinMAXAdViewAd *adViewAd = self.adViewAds[adViewAdId];
+    adViewAd.customData = customData;
+    resolve(nil);
+}
+
+RCT_EXPORT_METHOD(setAdaptiveBannerEnabled:(nonnull NSNumber *)adViewAdId :(BOOL)adaptiveBannerEnabled :(RCTPromiseResolveBlock)resolve :(RCTPromiseRejectBlock)reject)
+{
+    AppLovinMAXAdViewAd *adViewAd = self.adViewAds[adViewAdId];
+    adViewAd.adaptiveBannerEnabled = adaptiveBannerEnabled;
+    resolve(nil);
+}
+
+RCT_EXPORT_METHOD(setAutoRefresh:(nonnull NSNumber *)adViewAdId :(BOOL)autoRefresh :(RCTPromiseResolveBlock)resolve :(RCTPromiseRejectBlock)reject)
+{
+    AppLovinMAXAdViewAd *adViewAd = self.adViewAds[adViewAdId];
+    adViewAd.autoRefresh = autoRefresh;
+    resolve(nil);
+}
+
+RCT_EXPORT_METHOD(setExtraParameters:(nonnull NSNumber *)adViewAdId :(NSDictionary<NSString *, id> *)parameterDict :(RCTPromiseResolveBlock)resolve :(RCTPromiseRejectBlock)reject)
+{
+    AppLovinMAXAdViewAd *adViewAd = self.adViewAds[adViewAdId];
+    adViewAd.extraParameters = parameterDict;
+    resolve(nil);
+}
+
+RCT_EXPORT_METHOD(setLocalExtraParameters:(nonnull NSNumber *)adViewAdId :(NSDictionary<NSString *, id> *)parameterDict :(RCTPromiseResolveBlock)resolve :(RCTPromiseRejectBlock)reject)
+{
+    AppLovinMAXAdViewAd *adViewAd = self.adViewAds[adViewAdId];
+    adViewAd.localExtraParameters = parameterDict;
+    resolve(nil);
+}
+
+- (void)sendLoadAdEvent:(NSDictionary<NSString *, id> *)body
+{
+    [self sendEventWithName: ON_ADVIEW_AD_LOADED_EVENT body: body];
+}
+
+- (void)sendFailToDisplayAEvent:(NSDictionary<NSString *, id> *)body
+{
+    [self sendEventWithName: ON_ADVIEW_AD_DISPLAY_FAILED_EVENT body: body];
+}
+
+- (void)sendFailToLoadAdEvent:(NSDictionary<NSString *, id> *)body
+{
+    [self sendEventWithName: ON_ADVIEW_AD_LOAD_FAILED_EVENT body: body];
+}
+
+- (void)sendClickAdEvent:(NSDictionary<NSString *, id> *)body
+{
+    [self sendEventWithName: ON_ADVIEW_AD_CLICKED_EVENT body: body];
+}
+
+- (void)sendCollapseAdEvent:(NSDictionary<NSString *, id> *)body
+{
+    [self sendEventWithName: ON_ADVIEW_AD_COLLAPSED_EVENT body: body];
+}
+
+- (void)sendExpandAdEvent:(NSDictionary<NSString *, id> *)body
+{
+    [self sendEventWithName: ON_ADVIEW_AD_EXPANDED_EVENT body: body];
+}
+
+- (void)sendPayRevenueEvent:(NSDictionary<NSString *, id> *)body
+{
+    [self sendEventWithName: ON_ADVIEW_AD_REVENUE_PAID body: body];
+}
+
+- (NSArray<NSString *> *)supportedEvents
+{
+    return @[ON_ADVIEW_AD_LOADED_EVENT,
+             ON_ADVIEW_AD_LOAD_FAILED_EVENT,
+             ON_ADVIEW_AD_CLICKED_EVENT,
+             ON_ADVIEW_AD_COLLAPSED_EVENT,
+             ON_ADVIEW_AD_EXPANDED_EVENT,
+             ON_ADVIEW_AD_DISPLAY_FAILED_EVENT,
+             ON_ADVIEW_AD_REVENUE_PAID];
+}
+
+- (NSDictionary *)constantsToExport
+{
+    return @{@"ON_ADVIEW_AD_LOADED_EVENT" : ON_ADVIEW_AD_LOADED_EVENT,
+             @"ON_ADVIEW_AD_LOAD_FAILED_EVENT" : ON_ADVIEW_AD_LOAD_FAILED_EVENT,
+             @"ON_ADVIEW_AD_CLICKED_EVENT" : ON_ADVIEW_AD_CLICKED_EVENT,
+             @"ON_ADVIEW_AD_COLLAPSED_EVENT" : ON_ADVIEW_AD_COLLAPSED_EVENT,
+             @"ON_ADVIEW_AD_EXPANDED_EVENT" : ON_ADVIEW_AD_EXPANDED_EVENT,
+             @"ON_ADVIEW_AD_DISPLAY_FAILED_EVENT" : ON_ADVIEW_AD_DISPLAY_FAILED_EVENT,
+             @"ON_ADVIEW_AD_REVENUE_PAID" : ON_ADVIEW_AD_REVENUE_PAID};
+}
+
+@end

--- a/ios/AppLovinMAXAdViewManager.m
+++ b/ios/AppLovinMAXAdViewManager.m
@@ -1,34 +1,12 @@
-//
-//  AppLovinMAXAdViewManager.m
-//  AppLovinMAX
-//
-//  Created by Thomas So on 9/24/20.
-//  Copyright © 2020 AppLovin. All rights reserved.
-//
-
 #import "AppLovinMAXAdViewManager.h"
-#import "AppLovinMAXAdview.h"
+#import "AppLovinMAXAdViewAdManager.h"
+#import "AppLovinMAXAdView.h"
 
 @implementation AppLovinMAXAdViewManager
 
 RCT_EXPORT_MODULE(AppLovinMAXAdView)
 
-RCT_EXPORT_VIEW_PROPERTY(adUnitId, NSString)
-RCT_EXPORT_VIEW_PROPERTY(adFormat, NSString)
-RCT_EXPORT_VIEW_PROPERTY(placement, NSString)
-RCT_EXPORT_VIEW_PROPERTY(customData, NSString)
-RCT_EXPORT_VIEW_PROPERTY(adaptiveBannerEnabled, BOOL)
-RCT_EXPORT_VIEW_PROPERTY(autoRefresh, BOOL)
-RCT_EXPORT_VIEW_PROPERTY(extraParameters, NSDictionary)
-RCT_EXPORT_VIEW_PROPERTY(localExtraParameters, NSDictionary)
-
-RCT_EXPORT_VIEW_PROPERTY(onAdLoadedEvent, RCTDirectEventBlock)
-RCT_EXPORT_VIEW_PROPERTY(onAdLoadFailedEvent, RCTDirectEventBlock)
-RCT_EXPORT_VIEW_PROPERTY(onAdDisplayFailedEvent, RCTDirectEventBlock)
-RCT_EXPORT_VIEW_PROPERTY(onAdClickedEvent, RCTDirectEventBlock)
-RCT_EXPORT_VIEW_PROPERTY(onAdExpandedEvent, RCTDirectEventBlock)
-RCT_EXPORT_VIEW_PROPERTY(onAdCollapsedEvent, RCTDirectEventBlock)
-RCT_EXPORT_VIEW_PROPERTY(onAdRevenuePaidEvent, RCTDirectEventBlock)
+RCT_EXPORT_VIEW_PROPERTY(adViewAdId, NSNumber)
 
 + (BOOL)requiresMainQueueSetup
 {
@@ -37,7 +15,8 @@ RCT_EXPORT_VIEW_PROPERTY(onAdRevenuePaidEvent, RCTDirectEventBlock)
 
 - (UIView *)view
 {
-    return [[AppLovinMAXAdView alloc] init];
+    AppLovinMAXAdViewAdManager *manager = (AppLovinMAXAdViewAdManager *) [self.bridge moduleForName: @"AppLovinMAXAdViewAdManager"];
+    return [[AppLovinMAXAdView alloc] initWithAdViewAdManager: manager];
 }
 
 @end

--- a/src/AdViewAd.ts
+++ b/src/AdViewAd.ts
@@ -1,0 +1,264 @@
+import { NativeModules, NativeEventEmitter } from 'react-native';
+import type { EventSubscription } from 'react-native';
+import AppLovinMAX from './AppLovinMAX';
+import { AdFormat } from './AdView';
+import type { AdEventObject, AdEventListener } from './types/AdEvent';
+import type { AdInfo, AdLoadFailedInfo, AdDisplayFailedInfo, AdRevenueInfo } from './types/AdInfo';
+import type { AdViewAd } from './types/AdViewAd';
+import type { LocalExtraParameterValue } from './types/AdProps';
+
+const { AppLovinMAXAdViewAdManager } = NativeModules;
+
+const {
+    ON_ADVIEW_AD_LOADED_EVENT,
+    ON_ADVIEW_AD_LOAD_FAILED_EVENT,
+    ON_ADVIEW_AD_CLICKED_EVENT,
+    ON_ADVIEW_AD_COLLAPSED_EVENT,
+    ON_ADVIEW_AD_EXPANDED_EVENT,
+    ON_ADVIEW_AD_DISPLAY_FAILED_EVENT,
+    ON_ADVIEW_AD_REVENUE_PAID,
+} = AppLovinMAXAdViewAdManager.getConstants();
+
+type AdViewAdNativeModules = {
+    createAdView(adUnitId: string, adFormat: AdFormat): Promise<number>;
+
+    destroyAdView(adViewAdId: number): Promise<void>;
+
+    loadAd(adViewAdId: number): Promise<void>;
+
+    setPlacement(adViewAdId: number, placement: string | null): Promise<void>;
+
+    setCustomData(adViewAdId: number, placement: string | null): Promise<void>;
+
+    setAdaptiveBannerEnabled(adViewAdId: number, adaptiveBannerEnabled: boolean): Promise<void>;
+
+    setAutoRefresh(adViewAdId: number, autoRefresh: boolean): Promise<void>;
+
+    setExtraParameters(adViewAdId: number, extraParameters: Record<string, string | null>): Promise<void>;
+
+    setLocalExtraParameters(
+        adViewAdId: number,
+        localExtraParameters: Record<string, LocalExtraParameterValue>
+    ): Promise<void>;
+};
+
+const nativeMethods: AdViewAdNativeModules = AppLovinMAXAdViewAdManager;
+
+const nativeEmitter = new NativeEventEmitter(AppLovinMAXAdViewAdManager);
+
+const addEventListener = <T extends AdEventObject>(event: string, handler: AdEventListener<T>): EventSubscription => {
+    return nativeEmitter.addListener(event, handler);
+};
+
+export type AdViewAdId = {
+    // hidden from the user
+    adViewAdId: number;
+};
+
+export type AdViewAdWithId = AdViewAd & AdViewAdId;
+
+class AdViewAdImpl implements AdViewAdWithId {
+    private _adViewAdId: number;
+    private _adUnitId: string;
+    private _adFormat: AdFormat;
+    private _loadedEventListener: EventSubscription | null;
+    private _loadFailedEventListener: EventSubscription | null;
+    private _displayFailedEventListener: EventSubscription | null;
+    private _clickedventListener: EventSubscription | null;
+    private _collapsedEventListener: EventSubscription | null;
+    private _expandedEventListener: EventSubscription | null;
+    private _revenuePaidEventListener: EventSubscription | null;
+
+    constructor(adUnitId: string, adFormat: AdFormat) {
+        this._adViewAdId = 0;
+        this._adUnitId = adUnitId;
+        this._adFormat = adFormat;
+        this._loadedEventListener = null;
+        this._loadFailedEventListener = null;
+        this._displayFailedEventListener = null;
+        this._clickedventListener = null;
+        this._collapsedEventListener = null;
+        this._expandedEventListener = null;
+        this._revenuePaidEventListener = null;
+    }
+
+    static async build(adUnitId: string, adFormat: AdFormat): Promise<AdViewAd> {
+        const isInitialized = await AppLovinMAX.isInitialized();
+        if (isInitialized) {
+            const adView: AdViewAdWithId = new AdViewAdImpl(adUnitId, adFormat);
+            adView.adViewAdId = await nativeMethods.createAdView(adView.adUnitId, adView.adFormat);
+            adView.autoRefresh = true;
+            adView.adaptiveBannerEnabled = true;
+            return adView as AdViewAd;
+        }
+        return Promise.reject(new Error('Not initialized the AppLovinMAX React Native Module'));
+    }
+
+    set adViewAdId(adViewAdId: number) {
+        this._adViewAdId = adViewAdId;
+    }
+
+    get adViewAdId(): number {
+        return this._adViewAdId;
+    }
+
+    get adUnitId(): string {
+        return this._adUnitId;
+    }
+
+    get adFormat(): AdFormat {
+        return this._adFormat;
+    }
+
+    set placement(placement: string | null) {
+        (async () => {
+            return await nativeMethods.setPlacement(this._adViewAdId, placement);
+        })();
+    }
+
+    set customData(customData: string | null) {
+        (async () => {
+            return await nativeMethods.setCustomData(this._adViewAdId, customData);
+        })();
+    }
+
+    set adaptiveBannerEnabled(adaptiveBannerEnabled: boolean) {
+        (async () => {
+            return await nativeMethods.setAdaptiveBannerEnabled(this._adViewAdId, adaptiveBannerEnabled);
+        })();
+    }
+
+    set autoRefresh(autoRefresh: boolean) {
+        (async () => {
+            return await nativeMethods.setAutoRefresh(this._adViewAdId, autoRefresh);
+        })();
+    }
+
+    set extraParameters(extraParameters: { [key: string]: string | null }) {
+        (async () => {
+            return await nativeMethods.setExtraParameters(this._adViewAdId, extraParameters);
+        })();
+    }
+
+    set localExtraParameters(localExtraParameters: { [key: string]: LocalExtraParameterValue }) {
+        (async () => {
+            return await nativeMethods.setLocalExtraParameters(this._adViewAdId, localExtraParameters);
+        })();
+    }
+
+    loadAd(): void {
+        nativeMethods.loadAd(this._adViewAdId);
+    }
+
+    destroy(): void {
+        nativeMethods.destroyAdView(this._adViewAdId);
+    }
+
+    addAdLoadedEventListener = (listener: (adInfo: AdInfo) => void) => {
+        this._loadedEventListener = addEventListener(ON_ADVIEW_AD_LOADED_EVENT, (adInfo: AdInfo & AdViewAdId) => {
+            // Need to filter the event since the event name is global
+            if (adInfo.adViewAdId == this._adViewAdId) {
+                listener(adInfo);
+            }
+        });
+    };
+
+    addAdLoadFailedEventListener = (listener: (adInfo: AdLoadFailedInfo) => void) => {
+        this._loadFailedEventListener = addEventListener(
+            ON_ADVIEW_AD_LOAD_FAILED_EVENT,
+            (adInfo: AdLoadFailedInfo & AdViewAdId) => {
+                if (adInfo.adViewAdId == this._adViewAdId) {
+                    listener(adInfo);
+                }
+            }
+        );
+    };
+
+    addAdDisplayFailedEventListener(listener: AdEventListener<AdDisplayFailedInfo>): void {
+        this._displayFailedEventListener = addEventListener(
+            ON_ADVIEW_AD_DISPLAY_FAILED_EVENT,
+            (adInfo: AdDisplayFailedInfo & AdViewAdId) => {
+                if (adInfo.adViewAdId == this._adViewAdId) {
+                    listener(adInfo);
+                }
+            }
+        );
+    }
+
+    addAdClickedEventListener = (listener: (adInfo: AdInfo) => void) => {
+        this._clickedventListener = addEventListener(ON_ADVIEW_AD_CLICKED_EVENT, (adInfo: AdInfo & AdViewAdId) => {
+            if (adInfo.adViewAdId == this._adViewAdId) {
+                listener(adInfo);
+            }
+        });
+    };
+
+    addAdCollapsedEventListener = (listener: (adInfo: AdInfo) => void) => {
+        this._collapsedEventListener = addEventListener(ON_ADVIEW_AD_COLLAPSED_EVENT, (adInfo: AdInfo & AdViewAdId) => {
+            if (adInfo.adViewAdId == this._adViewAdId) {
+                listener(adInfo);
+            }
+        });
+    };
+
+    addAdExpandedEventListener = (listener: (adInfo: AdInfo) => void) => {
+        this._expandedEventListener = addEventListener(ON_ADVIEW_AD_EXPANDED_EVENT, (adInfo: AdInfo & AdViewAdId) => {
+            if (adInfo.adViewAdId == this._adViewAdId) {
+                listener(adInfo);
+            }
+        });
+    };
+
+    addAdRevenuePaidListener = (listener: (adInfo: AdRevenueInfo) => void) => {
+        this._revenuePaidEventListener = addEventListener(
+            ON_ADVIEW_AD_REVENUE_PAID,
+            (adInfo: AdRevenueInfo & AdViewAdId) => {
+                if (adInfo.adViewAdId == this._adViewAdId) {
+                    listener(adInfo);
+                }
+            }
+        );
+    };
+
+    removeAdLoadedEventListener() {
+        this._loadedEventListener?.remove();
+    }
+
+    removeAdLoadFailedEventListener() {
+        this._loadFailedEventListener?.remove();
+    }
+
+    removeAdDisplayFailedEventListener() {
+        this._displayFailedEventListener?.remove();
+    }
+
+    removeAdClickedEventListener() {
+        this._clickedventListener?.remove();
+    }
+
+    removeAdCollapsedEventListener() {
+        this._collapsedEventListener?.remove();
+    }
+
+    removeAdExpandedEventListener() {
+        this._expandedEventListener?.remove();
+    }
+
+    removeAdRevenuePaidListener() {
+        this._revenuePaidEventListener?.remove();
+    }
+}
+
+/**
+ * Creates {@link AdViewAd} that loads a view-based ad (i.e. Banner or MREC) for {@link AdView}.
+ *
+ * You can create {@link AdViewAd} earlier and pass it to {@link AdView} when you mount
+ * {@link AdView} for quick ad display.
+ *
+ * @param adUnitId The ad unit ID to load an ad for.
+ * @param adFormat An enum value representing the ad format to load ads for. Should be either {@link AdFormat.BANNER} or {@link AdFormat.MREC}.
+ * @returns AdViewAd An ad object for you to pass to {@link AdView}.
+ */
+export const createAdViewAd = (adUnitId: string, adFormat: AdFormat): Promise<AdViewAd> => {
+    return AdViewAdImpl.build(adUnitId, adFormat);
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ export { AppOpenAd } from './AppOpenAd';
 export { BannerAd } from './BannerAd';
 export { MRecAd } from './MRecAd';
 export { AdView, AdFormat, AdViewPosition } from './AdView';
+export { createAdViewAd } from './AdViewAd';
 export { NativeAdView } from './nativeAd/NativeAdView';
 export {
     TitleView,

--- a/src/types/AdViewAd.ts
+++ b/src/types/AdViewAd.ts
@@ -1,0 +1,159 @@
+import type { AdFormat } from '../AdView';
+import type { AdEventListener } from './AdEvent';
+import type { AdInfo, AdLoadFailedInfo, AdDisplayFailedInfo, AdRevenueInfo } from './AdInfo';
+import type { LocalExtraParameterValue } from './AdProps';
+
+/**
+ * Encapsulates an ad object for you to pass to {@link AdView}. {@link AdViewAd} loads view-based
+ * ads (i.e. banner or MREC) and can be passed to {@link AdView} when you mount {@link AdView}.
+ */
+export type AdViewAd = {
+    /**
+     * A string value representing the ad unit id to load ads for.
+     */
+    adUnitId: string;
+
+    /**
+     * A string value representing the ad format to load ads for. Should be either
+     * {@link AdFormat.BANNER} or {@link AdFormat.MREC}.
+     */
+    adFormat: AdFormat;
+
+    /**
+     * A string value representing the placement name that you assign when you integrate each ad
+     * format, for granular reporting in ad events.
+     */
+    placement?: string | null;
+
+    /**
+     * The custom data to tie the showing ad to.
+     */
+    customData?: string | null;
+
+    /**
+     * A boolean value representing whether or not to enable adaptive banners.
+     */
+    adaptiveBannerEnabled?: boolean;
+
+    /**
+     * A boolean value representing whether or not to enable auto-refresh. Note that auto-refresh is
+     * enabled by default.
+     */
+    autoRefresh?: boolean;
+
+    /**
+     * A dictionary value representing the extra parameters to set a list of key-value string pairs
+     * for the ad.
+     */
+    extraParameters?: { [key: string]: string | null };
+
+    /**
+     * A dictionary value representing the local extra parameters to set a list of key-value pairs
+     * to pass to the adapter instances.
+     */
+    localExtraParameters?: { [key: string]: LocalExtraParameterValue };
+
+    /**
+     * Loads an ad.
+     */
+    loadAd(): void;
+
+    /**
+     * Destroys the {@link AdViewAd} object.
+     */
+    destroy(): void;
+
+    /**
+     * Adds the specified event listener to receive {@link AdInfo} when {@link AdViewAd} loads a new ad.
+     *
+     * @param listener Listener to be notified.
+     */
+    addAdLoadedEventListener(listener: AdEventListener<AdInfo>): void;
+
+    /**
+     * Removes the event listener to receive {@link AdInfo} when {@link AdViewAd} loads a new ad.
+     */
+    removeAdLoadedEventListener(): void;
+
+    /**
+     * Adds the specified event listener to receive {@link AdLoadFailedInfo} when {@link AdViewAd}
+     * could not load a new ad.
+     *
+     * @param listener Listener to be notified.
+     */
+    addAdLoadFailedEventListener(listener: AdEventListener<AdLoadFailedInfo>): void;
+
+    /**
+     * Removes the event listener to receive {@link AdLoadFailedInfo} when {@link AdViewAd} could
+     * not load a new ad.
+     */
+    removeAdLoadFailedEventListener(): void;
+
+    /**
+     * Adds the specified event listener to receive {@link AdDisplayFailedInfo} when {@link AdViewAd}
+     * fails to display the ad.
+     *
+     * @param listener Listener to be notified.
+     */
+    addAdDisplayFailedEventListener(listener: AdEventListener<AdDisplayFailedInfo>): void;
+
+    /**
+     * Removes the event listener to receive {@link AdDisplayFailedInfo} when {@link AdViewAd}
+     * fails to display the ad.
+     */
+    removeAdDisplayFailedEventListener(): void;
+
+    /**
+     * Adds the specified event listener to receive {@link AdInfo} when the user clicks the ad.
+     *
+     * @param listener Listener to be notified.
+     */
+    addAdClickedEventListener(listener: AdEventListener<AdInfo>): void;
+
+    /**
+     * Removes the event listener to receive {@link AdInfo} when the user clicks the ad.
+     */
+    removeAdClickedEventListener(): void;
+
+    /**
+     * Adds the specified event listener to receive {@link AdInfo} when {@link AdViewAd} collapses
+     * the ad.
+     *
+     * @param listener Listener to be notified.
+     */
+    addAdCollapsedEventListener(listener: AdEventListener<AdInfo>): void;
+
+    /**
+     * Removes the event listener to receive {@link AdInfo} when {@link AdViewAd} collapses
+     * the ad.
+     */
+    removeAdCollapsedEventListener(): void;
+
+    /**
+     * Adds the specified event listener to receive {@link AdInfo} when {@link AdViewAd} expands
+     * the ad.
+     *
+     * @param listener Listener to be notified.
+     */
+    addAdExpandedEventListener(listener: AdEventListener<AdInfo>): void;
+
+    /**
+     * Removes the event listener to receive {@link AdInfo} when {@link AdViewAd} expands
+     * the ad.
+     */
+    removeAdExpandedEventListener(): void;
+
+    /**
+     * Adds the specified event listener to receive {@link AdRevenueInfo} when {@link AdViewAd} pays
+     * ad revenue to the publisher.
+     *
+     * @param listener Listener to be notified.
+     */
+    addAdRevenuePaidListener(listener: AdEventListener<AdRevenueInfo>): void;
+
+    /**
+     * Removes the event listener to receive {@link AdRevenueInfo} when {@link AdViewAd} pays ad
+     * revenue to the publisher.
+     */
+    removeAdRevenuePaidListener(): void;
+};

--- a/src/types/AdViewProps.ts
+++ b/src/types/AdViewProps.ts
@@ -1,6 +1,7 @@
 import type { AdProps } from './AdProps';
 import type { AdInfo } from './AdInfo';
 import type { AdFormat } from '../AdView';
+import type { AdViewAd } from './AdViewAd';
 
 /**
  * Represents an {@link AdView} - Banner / MREC.
@@ -32,4 +33,14 @@ export type AdViewProps = AdProps & {
      * A callback fuction that {@link AdView} fires when it collapses the ad.
      */
     onAdCollapsed?: (adInfo: AdInfo) => void;
+};
+
+/**
+ * Defines props for {@link AdView} with {@link AdViewAd}.
+ */
+export type LoadedAdViewProps = {
+    /**
+     * A loaded ad.
+     */
+    ad: AdViewAd;
 };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,3 +2,4 @@ export * from './Configuration';
 export * from './AdInfo';
 export * from './AdViewProps';
 export * from './NativeAdViewProps';
+export * from './AdViewAd';


### PR DESCRIPTION
Add support for `AdView` preloading.   (#57)

 This introduces the following new object and function to support preloading while keeping the current AdView interface.  

- `AdViewAd`
- `createAdViewAd()`

`createAdAviewAd()` returns `AdViewAd` for you to load ads in advance.

```
const adViewAd = createAdAviewAd(adUnitId, adFormat);
adViewAd.addAdLoadedEventListener((info: AdInfo) => { });
```

Then, pass it to `AdView` for mounting.

```
<AdView
    ad={adViewAd}
    style={banner.style}
/>
```

`AdViewAd` won't be destroyed when `AdView` is unmounted.  It must be explicitly destroyed with its `destroy()` function.


Again, this current interface still works. 

```
<AdView
    adUnitId={...}
    adFormat={...}
    style={banner.style}
/>
```

The example is added to [ScrolledAdViewExample](https://github.com/AppLovin/AppLovin-MAX-React-Native/commit/c752b8dae60a7aea735d5f38bdab5dcfd55b1269#diff-c95f359c2af628ec64378bf4e25e9c4e5e20c6ad64521424d127b2a12c684378).
