### PR TITLE
fix/wrong_return_type_from_setlocationcollectionenabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Versions
 
+## x.x.x
+* Fix wrong return type with `AppLovinMAX.setLocationCollectionEnabled()`.
 ## 6.0.1
 * Depend on iOS SDK 11.11.4.
 * Fix TypeScript compilation errors. (https://github.com/AppLovin/AppLovin-MAX-React-Native/issues/199#issuecomment-1791339558)

--- a/src/types/AppLovinMAX.ts
+++ b/src/types/AppLovinMAX.ts
@@ -83,5 +83,5 @@ export type AppLovinMAXType = {
      *
      * @param enabled Defaults to true.
      */
-    setLocationCollectionEnabled(enabled: boolean): Promise<void>;
+    setLocationCollectionEnabled(enabled: boolean): void;
 };


### PR DESCRIPTION
`AppLovinMAX.setLocationCollectionEnabled()` is defined to return `Promise<void>`

```
    setLocationCollectionEnabled(enabled: boolean): Promise<void.;
```

But it should return `void`:

```
    setLocationCollectionEnabled(enabled: boolean): void;
```