### PR TITLE
fix/remove_showconsentdialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Versions
 
+## x.x.x
+* Remove an obsolete function `Privacy.showConsentDialog()`.
 ## 6.0.1
 * Depend on iOS SDK 11.11.4.
 * Fix TypeScript compilation errors. (https://github.com/AppLovin/AppLovin-MAX-React-Native/issues/199#issuecomment-1791339558)

--- a/src/types/Privacy.ts
+++ b/src/types/Privacy.ts
@@ -5,11 +5,6 @@ export type PrivacyType = {
     /**********************************************************************************/
 
     /**
-     * Shows the user consent dialog to the user by using a dialog in the AppLovinMAX SDK.
-     */
-    showConsentDialog(): Promise<void>;
-
-    /**
      * Sets whether or not the user provided consent for information-sharing with AppLovin.
      * 
      * @param hasUserConsent true if the user provided consent for information sharing.


### PR DESCRIPTION
Remove an obsolete function: `Privacy.showConsentDialog()`