### PR TITLE
fix/tsc_compilation_errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Versions
 
+## x.x.x
+* Fix TypeScript compilation errors. (https://github.com/AppLovin/AppLovin-MAX-React-Native/issues/271)
 ## 6.0.2
 * Depend on Android SDK 12.0.0 and iOS SDK 12.0.0.
 * Fix type of argument in `TargetingData.keywords`.

--- a/src/AdView.tsx
+++ b/src/AdView.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useState } from 'react';
+import * as React from 'react';
+import { useEffect, useState } from 'react';
 import { NativeModules, requireNativeComponent, StyleSheet } from 'react-native';
 import type { ViewProps, ViewStyle, StyleProp } from 'react-native';
 import type { AdDisplayFailedInfo, AdInfo, AdLoadFailedInfo, AdRevenueInfo } from './types/AdInfo';
@@ -78,8 +79,8 @@ const getOutlineViewSize = (style: StyleProp<ViewStyle>) => {
 const sizeAdViewDimensions = (
     adFormat: AdFormat,
     adaptiveBannerEnabled?: boolean,
-    width?: number | string,
-    height?: number | string
+    width?: number | string | null,
+    height?: number | string | null
 ): Promise<Record<string, number>> => {
     const sizeForBannerFormat = async () => {
         const isTablet = await AppLovinMAX.isTablet();
@@ -194,6 +195,7 @@ export const AdView = ({
     useEffect(() => {
         if (!isInitialized) return;
         const [width, height] = getOutlineViewSize(style);
+        // @ts-expect-error: width and height should be of type DimensionValue in react-native 0.72.0 and above
         sizeAdViewDimensions(adFormat, adaptiveBannerEnabled, width, height).then((value: Record<string, number>) => {
             setDimensions(value);
         });

--- a/src/nativeAd/NativeAdView.tsx
+++ b/src/nativeAd/NativeAdView.tsx
@@ -1,4 +1,5 @@
-import React, { forwardRef, useContext, useImperativeHandle, useRef, useState, useEffect, useCallback } from 'react';
+import * as React from 'react';
+import { forwardRef, useContext, useImperativeHandle, useRef, useState, useEffect, useCallback } from 'react';
 import { NativeModules, requireNativeComponent, UIManager, findNodeHandle } from 'react-native';
 import type { ViewProps } from 'react-native';
 import { NativeAdViewContext, NativeAdViewProvider } from './NativeAdViewProvider';

--- a/src/nativeAd/NativeAdViewComponents.tsx
+++ b/src/nativeAd/NativeAdViewComponents.tsx
@@ -1,4 +1,5 @@
-import React, { useContext, useRef, useEffect } from 'react';
+import * as React from 'react';
+import { useContext, useRef, useEffect } from 'react';
 import type { ReactNode } from 'react';
 import { findNodeHandle, Text, Image, View, TouchableOpacity, StyleSheet } from 'react-native';
 import type { ViewProps, ImageProps, TextStyle, StyleProp, TextProps } from 'react-native';

--- a/src/nativeAd/NativeAdViewProvider.tsx
+++ b/src/nativeAd/NativeAdViewProvider.tsx
@@ -1,4 +1,5 @@
-import React, { useState, createContext } from 'react';
+import * as React from 'react';
+import { useState, createContext } from 'react';
 import type { NativeMethods } from 'react-native';
 import type { NativeAd } from '../types/NativeAd';
 import type { NativeAdViewProps } from '../types/NativeAdViewProps';


### PR DESCRIPTION
Fix TypeScript compilation errors for  Issue #271.  Here is a list of the errors per the RN versions.

| RN version     |                                                                                        Error                                                                                       |
|----------------|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------:|
|     0.72.0     |      node_modules/react-native-applovin-max/src/AdView.tsx(197,63): error TS2345: Argument of type 'DimensionValue' is not assignable to parameter of type 'string \| number'.     |
|     0.71.0     | node_modules/react-native-applovin-max/src/AdView.tsx(1,8): error TS1259: Module '"node_modules/@types/react/index"' can only be default-imported using the 'esModuleInterop' flag |
| 0.70.0 & below |                                                                                        none                                                                                        |

The fixes are:

0.72.0: suppress the error by `@ts-expect-error` instead of fixing it with `DimensionValue` that is not exported in the lower version,  since this version is still new to many users.

0.71.0: use `import * as React from 'react';`.  ([ref](https://stackoverflow.com/questions/60551025/how-can-i-get-rid-of-my-types-react-index-can-only-be-default-imported-using))