### PR TITLE
fix/inconsistent_naming_for_enum_fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Versions
 
 ## x.x.x
+* Fix inconsistent naming for enum fields.
 * Add support for Terms and Privacy Policy Flow. For more info, check out our [docs](https://dash.applovin.com/documentation/mediation/react-native/getting-started/terms-and-privacy-policy-flow).
 * Add APIs for Selective Init. For more info, check out our [docs](https://dash.applovin.com/documentation/mediation/react-native/getting-started/advanced-settings#selective-init).
 * Fix TypeScript compilation errors. (https://github.com/AppLovin/AppLovin-MAX-React-Native/issues/271)

--- a/src/Privacy.ts
+++ b/src/Privacy.ts
@@ -38,7 +38,7 @@ export enum AppTrackingStatus {
      * The user has not yet received an authorization request to authorize access to app-related
      * data that can be used for tracking the user or the device.
      */
-    NOTDETERMINED = 'N',
+    NOT_DETERMINED = 'N',
 
     /**
      * Authorization to access app-related data that can be used for tracking the user or the device

--- a/src/TargetingData.ts
+++ b/src/TargetingData.ts
@@ -72,10 +72,10 @@ export const TargetingData: TargetingDataType = {
      */
     set gender(value: UserGender | Promise<UserGender>) {
         if (
-            value === UserGender.Unknown ||
-            value === UserGender.Female ||
-            value === UserGender.Male ||
-            value === UserGender.Other
+            value === UserGender.UNKNOWN ||
+            value === UserGender.FEMALE ||
+            value === UserGender.MALE ||
+            value === UserGender.OTHER
         ) {
             nativeMethods.setTargetingDataGender(value);
         } else {
@@ -99,10 +99,10 @@ export const TargetingData: TargetingDataType = {
      */
     set maximumAdContentRating(value: AdContentRating | Promise<AdContentRating>) {
         if (
-            value === AdContentRating.None ||
-            value === AdContentRating.AllAudiences ||
-            value === AdContentRating.EveryoneOverTwelve ||
-            value === AdContentRating.MatureAudiences
+            value === AdContentRating.NONE ||
+            value === AdContentRating.ALL_AUDIENCES ||
+            value === AdContentRating.EVERYONE_OVER_TWELVE ||
+            value === AdContentRating.MATURE_AUDIENCES
         ) {
             nativeMethods.setTargetingDataMaximumAdContentRating(value);
         } else {

--- a/src/TargetingData.ts
+++ b/src/TargetingData.ts
@@ -27,20 +27,20 @@ const nativeMethods: NativeTargetingDataType = AppLovinMAX;
  * This enumeration represents content ratings for the ads shown to users.
  */
 export enum AdContentRating {
-    None = 0,
-    AllAudiences = 1,
-    EveryoneOverTwelve = 2,
-    MatureAudiences = 3,
+    NONE = 0,
+    ALL_AUDIENCES = 1,
+    EVERYONE_OVER_TWELVE = 2,
+    MATURE_AUDIENCES = 3,
 }
 
 /**
  * This enumeration represents gender.
  */
 export enum UserGender {
-    Unknown = 'U',
-    Female = 'F',
-    Male = 'M',
-    Other = 'O',
+    UNKNOWN = 'U',
+    FEMALE = 'F',
+    MALE = 'M',
+    OTHER = 'O',
 }
 
 /**


### PR DESCRIPTION
Fix inconsistent naming for enum fields.

Can we do this now?  I guess (hope) the impact will be minimal.

Here is a list of the current enums:
```
export enum ConsentFlowUserGeography {
    UNKNOWN = 'U',
    GDPR = 'G',
    OTHER = 'O',
}

export enum AppTrackingStatus {
    UNAVAILABLE = 'U',
    NOTDETERMINED = 'N',
    RESTRICTED = 'R',
    DENIED = 'D',
    AUTHORIZED = 'A',
}

export enum AdContentRating {
    None = 0,
    AllAudiences = 1,
    EveryoneOverTwelve = 2,
    MatureAudiences = 3,
}

export enum UserGender {
    Unknown = 'U',
    Female = 'F',
    Male = 'M',
    Other = 'O',
}

export enum AdFormat {
    BANNER = BANNER_AD_FORMAT_LABEL,
    MREC = MREC_AD_FORMAT_LABEL,
}

export enum AdViewPosition {
    TOP_CENTER = TOP_CENTER_POSITION,
    TOP_LEFT = TOP_LEFT_POSITION,
    TOP_RIGHT = TOP_RIGHT_POSITION,
    CENTERED = CENTERED_POSITION,
    CENTER_LEFT = CENTER_LEFT_POSITION,
    CENTER_RIGHT = CENTER_RIGHT_POSITION,
    BOTTOM_LEFT = BOTTOM_LEFT_POSITION,
    BOTTOM_CENTER = BOTTOM_CENTER_POSITION,
    BOTTOM_RIGHT = BOTTOM_RIGHT_POSITION,
}
```
