### PR TITLE
fix/typescript_comiplation_error

### DIFF
--- a/src/AdView.tsx
+++ b/src/AdView.tsx
@@ -195,7 +195,8 @@ export const AdView = ({
     useEffect(() => {
         if (!isInitialized) return;
         const [width, height] = getOutlineViewSize(style);
-        // @ts-expect-error: width and height should be of type DimensionValue in react-native 0.72.0 and above
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore: width and height should be of type DimensionValue in react-native 0.72.0 and above
         sizeAdViewDimensions(adFormat, adaptiveBannerEnabled, width, height).then((value: Record<string, number>) => {
             setDimensions(value);
         });


### PR DESCRIPTION
Fix TypeScript compilation error with `@ts-expect-error`.

Use `@ts-ignore` instead.  It is almost the same but has been available since TypeScript 2.9 (released in 2017).

Then, `eslint` complains using `@ts-ignore` since `@ts-expect-error` is preferred to use.  `eslint-disable-next-line @typescript-eslint/ban-ts-comment` suppresses the eslin error.
