### PR TITLE
ref/improve_loading_time_for_native_ads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Versions
 
+## x.x.x
+* Improve loading time for native ads. (https://github.com/AppLovin/AppLovin-MAX-React-Native/issues/273)
 ## 6.1.0
 * Fix inconsistent naming for enum fields.
 * Add support for Terms and Privacy Policy Flow. For more info, check out our [docs](https://dash.applovin.com/documentation/mediation/react-native/getting-started/terms-and-privacy-policy-flow).

--- a/android/src/main/java/com/applovin/reactnative/AppLovinMAXNativeAdViewManager.java
+++ b/android/src/main/java/com/applovin/reactnative/AppLovinMAXNativeAdViewManager.java
@@ -149,6 +149,14 @@ public class AppLovinMAXNativeAdViewManager
     }
 
     @Override
+    public void onAfterUpdateTransaction(final AppLovinMAXNativeAdView view)
+    {
+        super.onAfterUpdateTransaction( view );
+
+        view.onSetProps();
+    }
+
+    @Override
     public void onDropViewInstance(@NonNull final AppLovinMAXNativeAdView view)
     {
         view.destroy();


### PR DESCRIPTION
Improve loading time for native ads (Issue #273).

Currently, `NativeAdView` utilizes timers for 
- loading an ad
- rendering the loaded ad 

Because we don't know the exact timing of

- when all the JavaScript properties are set to the native `NativeAdView` component
- when all the asset views are set to the native `NativeAdView` component

React Native provides a function to be invoked when the props are all set.

- [onAfterUpdateTransaction()](https://github.com/facebook/react-native/blob/616a9077985e18ed077d7db4d47740be0d2e6cd4/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewManager.java#L250)
- [didSetProps()](https://github.com/facebook/react-native/blob/616a9077985e18ed077d7db4d47740be0d2e6cd4/packages/react-native/React/Views/RCTComponent.h#L44)

But, Android behaves differently in the 2nd case, so it has to know when the last asset view is set.

Tested with:

Android: Admob, Line, InMobi, Pangle
iOS: Admob, Line, InMobi, Mintegral