### PR TITLE
ref/allow_setmuted_before_sdk_init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Versions
 
 ## x.x.x
-* Allow calling `setMuted()` before SDK is initialized.
+* Allow calls to `AppLovinMAX.setMuted(...)` before SDK is initialized.
 * Improve loading time for native ads. (https://github.com/AppLovin/AppLovin-MAX-React-Native/issues/273)
 * Depend on Android SDK 12.1.0 and iOS SDK 12.1.0.
 ## 6.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Versions
 
 ## x.x.x
+* Allow calling `setMuted()` before SDK is initialized.
 * Improve loading time for native ads. (https://github.com/AppLovin/AppLovin-MAX-React-Native/issues/273)
 * Depend on Android SDK 12.1.0 and iOS SDK 12.1.0.
 ## 6.1.0

--- a/android/src/main/java/com/applovin/reactnative/AppLovinMAXModule.java
+++ b/android/src/main/java/com/applovin/reactnative/AppLovinMAXModule.java
@@ -151,6 +151,7 @@ public class AppLovinMAXModule
     // Store these values if pub attempts to set it before initializing
     private       List<String>        initializationAdUnitIdsToSet;
     private       String              userIdToSet;
+    private       Boolean             mutedToSet;
     private       List<String>        testDeviceAdvertisingIdsToSet;
     private       Boolean             verboseLoggingToSet;
     private       Boolean             creativeDebuggerEnabledToSet;
@@ -329,6 +330,13 @@ public class AppLovinMAXModule
         {
             settings.getTermsAndPrivacyPolicyFlowSettings().setDebugUserGeography( getAppLovinConsentFlowUserGeography( debugUserGeographyToSet ) );
             debugUserGeographyToSet = null;
+        }
+
+        // Set muted if needed
+        if ( mutedToSet != null )
+        {
+            settings.setMuted( mutedToSet );
+            mutedToSet = null;
         }
 
         // Set test device ids if needed
@@ -531,9 +539,15 @@ public class AppLovinMAXModule
     @ReactMethod
     public void setMuted(final boolean muted)
     {
-        if ( !isPluginInitialized ) return;
-
-        sdk.getSettings().setMuted( muted );
+        if ( isPluginInitialized )
+        {
+            sdk.getSettings().setMuted( muted );
+            mutedToSet = null;
+        }
+        else
+        {
+            mutedToSet = muted;
+        }
     }
 
     @ReactMethod

--- a/ios/AppLovinMAX.m
+++ b/ios/AppLovinMAX.m
@@ -39,6 +39,7 @@
 // Store these values if pub attempts to set it before initializing
 @property (nonatomic, strong, nullable) NSArray<NSString *> *initializationAdUnitIdentifiersToSet;
 @property (nonatomic,   copy, nullable) NSString *userIdentifierToSet;
+@property (nonatomic, strong, nullable) NSNumber *mutedToSet;
 @property (nonatomic, strong, nullable) NSArray<NSString *> *testDeviceIdentifiersToSet;
 @property (nonatomic, strong, nullable) NSNumber *verboseLoggingToSet;
 @property (nonatomic, strong, nullable) NSNumber *creativeDebuggerEnabledToSet;
@@ -277,6 +278,13 @@ RCT_EXPORT_METHOD(initialize:(NSString *)pluginVersion :(NSString *)sdkKey :(RCT
         }
     }
 
+    // Set muted if needed
+    if ( self.mutedToSet )
+    {
+        settings.muted = self.mutedToSet;
+        self.mutedToSet = nil;
+    }
+
     // Set test device ids if needed
     if ( self.testDeviceIdentifiersToSet )
     {
@@ -438,9 +446,15 @@ RCT_EXPORT_METHOD(setUserId:(NSString *)userId)
 
 RCT_EXPORT_METHOD(setMuted:(BOOL)muted)
 {
-    if ( ![self isPluginInitialized] ) return;
-    
-    self.sdk.settings.muted = muted;
+    if ( [self isPluginInitialized] )
+    {
+        self.sdk.settings.muted = muted;
+        self.mutedToSet = nil;
+    }
+    else
+    {
+        self.mutedToSet = @(muted);
+    }
 }
 
 RCT_EXPORT_METHOD(isMuted:(RCTPromiseResolveBlock)resolve :(RCTPromiseRejectBlock)reject)


### PR DESCRIPTION
Allow calling setMuted() before SDK is initialized ([ticket](https://app.asana.com/0/573104092700345/1206102448675921/f)).