### PR TITLE
feat/amazon_support

### DIFF
--- a/android/src/main/java/com/applovin/reactnative/AppLovinMAXModule.java
+++ b/android/src/main/java/com/applovin/reactnative/AppLovinMAXModule.java
@@ -2673,6 +2673,76 @@ public class AppLovinMAXModule
         return networkResponseObject;
     }
 
+    // Amazon
+
+    public void setAmazonBannerResult(final Object result, final String adUnitId)
+    {
+        setAmazonResult( result, adUnitId, MaxAdFormat.BANNER );
+    }
+
+    public void setAmazonMRecResult(final Object result, final String adUnitId)
+    {
+        setAmazonResult( result, adUnitId, MaxAdFormat.MREC );
+    }
+
+    public void setAmazonInterstitialResult(final Object result, final String adUnitId)
+    {
+        setAmazonResult( result, adUnitId, MaxAdFormat.INTERSTITIAL );
+    }
+
+    private void setAmazonResult(final Object result, final String adUnitId, final MaxAdFormat adFormat)
+    {
+        if ( !isValidToProceedForAdUnitId( adUnitId, result ) ) return;
+
+        if ( adFormat == MaxAdFormat.INTERSTITIAL )
+        {
+            MaxInterstitialAd interstitial = retrieveInterstitial( adUnitId, "setAmazonResult" );
+            setAmazonResult( result, interstitial );
+        }
+        else
+        {
+            MaxAdView adView = retrieveAdView( adUnitId, adFormat );
+            setAmazonResult( result, adView );
+        }
+    }
+
+    private boolean isValidToProceedForAdUnitId(final String adUnitId, final Object result)
+    {
+        if ( sdk == null )
+        {
+            e( "Failed to set Amazon result - SDK not initialized: " + adUnitId );
+            return false;
+        }
+
+        if ( result == null )
+        {
+            e( "Failed to set Amazon result - null value" );
+            return false;
+        }
+
+        return true;
+    }
+
+    private void setAmazonResult(final Object /* DTBAdResponse or DTBAdErrorInfo */ result, final Object /* MAInterstitialAd or MAAdView */ adObject)
+    {
+        String key = localExtraParameterKeyForAmazonResult( result );
+
+        if ( adObject instanceof MaxInterstitialAd )
+        {
+            ( (MaxInterstitialAd) adObject ).setLocalExtraParameter( key, result );
+        }
+        else if ( adObject instanceof MaxAdView )
+        {
+            ( (MaxAdView) adObject ).setLocalExtraParameter( key, result );
+        }
+    }
+
+    private String localExtraParameterKeyForAmazonResult(final Object /* DTBAdResponse or DTBAdErrorInfo */ result)
+    {
+        String className = result.getClass().getSimpleName();
+        return "DTBAdResponse".equalsIgnoreCase( className ) ? "amazon_ad_response" : "amazon_ad_error";
+    }
+
     // Lifecycle Events
 
     @Override

--- a/ios/AppLovinMAX.m
+++ b/ios/AppLovinMAX.m
@@ -2247,7 +2247,19 @@ RCT_EXPORT_METHOD(setAppOpenAdLocalExtraParameter:(NSString *)adUnitIdentifier :
 
 - (void)setAmazonResult:(id /* DTBAdResponse or DTBAdErrorInfo */)result forAdUnitIdentifier:(NSString *)adUnitIdentifier adFormat:(MAAdFormat *)adFormat
 {
-    if ( ![self isValidToProceedForAdUnitIdentifier: adUnitIdentifier result: result] ) return;
+    if ( !self.sdk )
+    {
+        NSString *errorMessage = [NSString stringWithFormat: @"Failed to set Amazon result - SDK not initialized: %@", adUnitIdentifier];
+        [self logUninitializedAccessError: errorMessage];
+        
+        return;
+    }
+    
+    if ( !result )
+    {
+        [self log: @"Failed to set Amazon result - nil value"];
+        return;
+    }
     
     if ( adFormat == MAAdFormat.interstitial )
     {
@@ -2261,31 +2273,13 @@ RCT_EXPORT_METHOD(setAppOpenAdLocalExtraParameter:(NSString *)adUnitIdentifier :
     }
 }
 
-- (BOOL)isValidToProceedForAdUnitIdentifier:(NSString *)adUnitIdentifier result:(id)result
-{
-    if ( !self.sdk )
-    {
-        NSString *errorMessage = [NSString stringWithFormat: @"Failed to set Amazon result - SDK not initialized: %@", adUnitIdentifier];
-        [self logUninitializedAccessError: errorMessage];
-        return NO;
-    }
-    
-    if ( !result )
-    {
-        [self log: @"Failed to set Amazon result - nil value"];
-        return NO;
-    }
-    
-    return YES;
-}
-
 - (void)setAmazonResult:(id /* DTBAdResponse or DTBAdErrorInfo */)result forAdObject:(id /* MAInterstitialAd or MAAdView */)adObject
 {
     NSString *key = [self localExtraParameterKeyForAmazonResult: result];
     [adObject setLocalExtraParameterForKey: key value: result];
 }
 
-- (NSString *)localExtraParameterKeyForAmazonResult:(id /* DTBAdResponse or DTBAdErrorInfo */)result
+- (NSString *)localExtraParameterKeyForAmazonResult:(id /* DTBAdResponse or AdError */)result
 {
     NSString *className = NSStringFromClass([result class]);
     return [@"DTBAdResponse" isEqualToString: className] ? @"amazon_ad_response" : @"amazon_ad_error";

--- a/ios/AppLovinMAX.m
+++ b/ios/AppLovinMAX.m
@@ -2279,7 +2279,7 @@ RCT_EXPORT_METHOD(setAppOpenAdLocalExtraParameter:(NSString *)adUnitIdentifier :
     [adObject setLocalExtraParameterForKey: key value: result];
 }
 
-- (NSString *)localExtraParameterKeyForAmazonResult:(id /* DTBAdResponse or AdError */)result
+- (NSString *)localExtraParameterKeyForAmazonResult:(id /* DTBAdResponse or DTBAdErrorInfo */)result
 {
     NSString *className = NSStringFromClass([result class]);
     return [@"DTBAdResponse" isEqualToString: className] ? @"amazon_ad_response" : @"amazon_ad_error";

--- a/ios/AppLovinMAX.m
+++ b/ios/AppLovinMAX.m
@@ -2261,22 +2261,18 @@ RCT_EXPORT_METHOD(setAppOpenAdLocalExtraParameter:(NSString *)adUnitIdentifier :
         return;
     }
     
+    NSString *key = [self localExtraParameterKeyForAmazonResult: result];
+    
     if ( adFormat == MAAdFormat.interstitial )
     {
         MAInterstitialAd *interstitial = [self retrieveInterstitialForAdUnitIdentifier: adUnitIdentifier];
-        [self setAmazonResult: result forAdObject: interstitial];
+        [interstitial setLocalExtraParameterForKey: key value: result];
     }
     else
     {
         MAAdView *adView = [self retrieveAdViewForAdUnitIdentifier: adUnitIdentifier adFormat: adFormat];
-        [self setAmazonResult: result forAdObject: adView];
+        [adView setLocalExtraParameterForKey: key value: result];
     }
-}
-
-- (void)setAmazonResult:(id /* DTBAdResponse or DTBAdErrorInfo */)result forAdObject:(id /* MAInterstitialAd or MAAdView */)adObject
-{
-    NSString *key = [self localExtraParameterKeyForAmazonResult: result];
-    [adObject setLocalExtraParameterForKey: key value: result];
 }
 
 - (NSString *)localExtraParameterKeyForAmazonResult:(id /* DTBAdResponse or DTBAdErrorInfo */)result


### PR DESCRIPTION
Allows publishers to easily pass in the Amazon success/error objects to the MAX SDK natively.

On iOS, publishers can do so via:

**Banners**
```
        Class AppLovinMAXClass = NSClassFromString(@"AppLovinMAX");
        NSObject *AppLovinMAX = [AppLovinMAXClass performSelector: @selector(shared)];
        [AppLovinMAX performSelector: @selector(setAmazonResult:forBannerAdUnitIdentifier:)
                                            withObject: result
                                            withObject: @"YOUR_AD_UNIT_ID"];
```

**MRECs**
```
        Class AppLovinMAXClass = NSClassFromString(@"AppLovinMAX");
        NSObject *AppLovinMAX = [AppLovinMAXClass performSelector: @selector(shared)];
        [AppLovinMAX performSelector: @selector(setAmazonResult:forMRecAdUnitIdentifier:)
                                            withObject: result
                                            withObject: @"YOUR_AD_UNIT_ID"];
```

**Interstitials**
```
        Class AppLovinMAXClass = NSClassFromString(@"AppLovinMAX");
        NSObject *AppLovinMAX = [AppLovinMAXClass performSelector: @selector(shared)];
        [AppLovinMAX performSelector: @selector(setAmazonResult:forInterstitialAdUnitIdentifier:)
                                            withObject: result
                                            withObject: @"YOUR_AD_UNIT_ID"];
```