### PR TITLE
ref/amazon_support_for_adview

### DIFF
--- a/android/src/main/java/com/applovin/reactnative/AppLovinMAXAdView.java
+++ b/android/src/main/java/com/applovin/reactnative/AppLovinMAXAdView.java
@@ -43,6 +43,7 @@ class AppLovinMAXAdView
     private String              customData;
     private boolean             adaptiveBannerEnabled;
     private boolean             autoRefresh;
+    private boolean             loadOnMount;
     @Nullable
     private Map<String, Object> extraParameters;
     @Nullable
@@ -144,6 +145,11 @@ class AppLovinMAXAdView
                 adView.stopAutoRefresh();
             }
         }
+    }
+
+    public void setLoadOnMount(final boolean enabled)
+    {
+        loadOnMount = enabled;
     }
 
     public void setExtraParameters(@Nullable final ReadableMap readableMap)
@@ -273,12 +279,26 @@ class AppLovinMAXAdView
                 adView.stopAutoRefresh();
             }
 
-            adView.loadAd();
+            if ( loadOnMount )
+            {
+                adView.loadAd();
+            }
 
             addView( adView );
 
             adViewInstances.put( adUnitId, adView );
         }, 250 );
+    }
+
+    public void loadAd()
+    {
+        if ( adView == null )
+        {
+            AppLovinMAXModule.e( "Attempting to load uninitialized MaxAdView for " + adUnitId );
+            return;
+        }
+
+        adView.loadAd();
     }
 
     public void destroy()

--- a/android/src/main/java/com/applovin/reactnative/AppLovinMAXAdViewManager.java
+++ b/android/src/main/java/com/applovin/reactnative/AppLovinMAXAdViewManager.java
@@ -1,6 +1,7 @@
 package com.applovin.reactnative;
 
 import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.common.MapBuilder;
 import com.facebook.react.uimanager.SimpleViewManager;
@@ -9,6 +10,7 @@ import com.facebook.react.uimanager.annotations.ReactProp;
 
 import java.util.Map;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 /**
@@ -17,6 +19,8 @@ import androidx.annotation.Nullable;
 class AppLovinMAXAdViewManager
         extends SimpleViewManager<AppLovinMAXAdView>
 {
+    public final int COMMAND_LOAD_AD = 1;
+
     public AppLovinMAXAdViewManager(final ReactApplicationContext reactApplicationContext) { }
 
     @Override
@@ -39,6 +43,26 @@ class AppLovinMAXAdViewManager
                 .put( "onAdCollapsedEvent", MapBuilder.of( "registrationName", "onAdCollapsedEvent" ) )
                 .put( "onAdRevenuePaidEvent", MapBuilder.of( "registrationName", "onAdRevenuePaidEvent" ) )
                 .build();
+    }
+
+    @Nullable
+    @Override
+    public Map<String, Integer> getCommandsMap()
+    {
+        return MapBuilder.of(
+                "loadAd", COMMAND_LOAD_AD
+        );
+    }
+
+    @Override
+    public void receiveCommand(@NonNull final AppLovinMAXAdView root, final int commandId, @Nullable final ReadableArray args)
+    {
+        switch ( commandId )
+        {
+            case COMMAND_LOAD_AD:
+                root.loadAd();
+                break;
+        }
     }
 
     @Override
@@ -82,6 +106,12 @@ class AppLovinMAXAdViewManager
     public void setAutoRefresh(final AppLovinMAXAdView view, final boolean enabled)
     {
         view.setAutoRefresh( enabled );
+    }
+
+    @ReactProp(name = "loadOnMount")
+    public void setLoadOnMount(final AppLovinMAXAdView view, final boolean enabled)
+    {
+        view.setLoadOnMount( enabled );
     }
 
     @ReactProp(name = "extraParameters")

--- a/android/src/main/java/com/applovin/reactnative/AppLovinMAXAdViewManager.java
+++ b/android/src/main/java/com/applovin/reactnative/AppLovinMAXAdViewManager.java
@@ -55,12 +55,12 @@ class AppLovinMAXAdViewManager
     }
 
     @Override
-    public void receiveCommand(@NonNull final AppLovinMAXAdView root, final int commandId, @Nullable final ReadableArray args)
+    public void receiveCommand(@NonNull final AppLovinMAXAdView adView, final int commandId, @Nullable final ReadableArray args)
     {
         switch ( commandId )
         {
             case COMMAND_LOAD_AD:
-                root.loadAd();
+                adView.loadAd();
                 break;
         }
     }

--- a/android/src/main/java/com/applovin/reactnative/AppLovinMAXAdViewManager.java
+++ b/android/src/main/java/com/applovin/reactnative/AppLovinMAXAdViewManager.java
@@ -19,7 +19,7 @@ import androidx.annotation.Nullable;
 class AppLovinMAXAdViewManager
         extends SimpleViewManager<AppLovinMAXAdView>
 {
-    public final int COMMAND_LOAD_AD = 1;
+    private static final int COMMAND_LOAD_AD = 1;
 
     public AppLovinMAXAdViewManager(final ReactApplicationContext reactApplicationContext) { }
 
@@ -55,12 +55,12 @@ class AppLovinMAXAdViewManager
     }
 
     @Override
-    public void receiveCommand(@NonNull final AppLovinMAXAdView adView, final int commandId, @Nullable final ReadableArray args)
+    public void receiveCommand(@NonNull final AppLovinMAXAdView view, final int commandId, @Nullable final ReadableArray args)
     {
         switch ( commandId )
         {
             case COMMAND_LOAD_AD:
-                adView.loadAd();
+                view.loadAd();
                 break;
         }
     }

--- a/ios/AppLovinMAXAdView.h
+++ b/ios/AppLovinMAXAdView.h
@@ -15,6 +15,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (MAAdView *)sharedWithAdUnitIdentifier:(NSString *)adUnitIdentifier;
 
+- (void)loadAd;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ios/AppLovinMAXAdView.m
+++ b/ios/AppLovinMAXAdView.m
@@ -20,6 +20,7 @@
 @property (nonatomic, copy, nullable) NSString *customData;
 @property (nonatomic, assign, readonly, getter=isAdaptiveBannerEnabled) BOOL adaptiveBannerEnabled;
 @property (nonatomic, assign, readonly, getter=isAutoRefresh) BOOL autoRefresh;
+@property (nonatomic, assign, readonly, getter=isLoadOnMount) BOOL loadOnMount;
 @property (nonatomic, copy, nullable) NSDictionary *extraParameters;
 @property (nonatomic, copy, nullable) NSDictionary *localExtraParameters;
 
@@ -135,6 +136,11 @@ static NSMutableDictionary<NSString *, MAAdView *> *adViewInstances;
     }
 }
 
+- (void)setLoadOnMount:(BOOL)loadOnMount
+{
+    _loadOnMount = loadOnMount;
+}
+
 - (void)attachAdViewIfNeeded
 {
     // Re-assign in case of race condition
@@ -202,7 +208,10 @@ static NSMutableDictionary<NSString *, MAAdView *> *adViewInstances;
             [self.adView stopAutoRefresh];
         }
         
-        [self.adView loadAd];
+        if ( [self isLoadOnMount] )
+        {
+            [self.adView loadAd];
+        }
         
         [self addSubview: self.adView];
         
@@ -213,6 +222,17 @@ static NSMutableDictionary<NSString *, MAAdView *> *adViewInstances;
 
         adViewInstances[adUnitId] = self.adView;
     });
+}
+
+- (void)loadAd
+{
+    if ( !self.adView )
+    {
+        [[AppLovinMAX shared] log: @"Attempting to load uninitialized MAAdView for %@", self.adUnitId];
+        return;
+    }
+
+    [self.adView loadAd];
 }
 
 - (void)didMoveToWindow

--- a/ios/AppLovinMAXAdViewManager.m
+++ b/ios/AppLovinMAXAdViewManager.m
@@ -6,6 +6,7 @@
 //  Copyright © 2020 AppLovin. All rights reserved.
 //
 
+#import "AppLovinMAX.h"
 #import "AppLovinMAXAdViewManager.h"
 #import "AppLovinMAXAdview.h"
 
@@ -19,6 +20,7 @@ RCT_EXPORT_VIEW_PROPERTY(placement, NSString)
 RCT_EXPORT_VIEW_PROPERTY(customData, NSString)
 RCT_EXPORT_VIEW_PROPERTY(adaptiveBannerEnabled, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(autoRefresh, BOOL)
+RCT_EXPORT_VIEW_PROPERTY(loadOnMount, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(extraParameters, NSDictionary)
 RCT_EXPORT_VIEW_PROPERTY(localExtraParameters, NSDictionary)
 
@@ -38,6 +40,22 @@ RCT_EXPORT_VIEW_PROPERTY(onAdRevenuePaidEvent, RCTDirectEventBlock)
 - (UIView *)view
 {
     return [[AppLovinMAXAdView alloc] init];
+}
+
+RCT_EXPORT_METHOD(loadAd:(nonnull NSNumber *)viewTag)
+{
+    [self.bridge.uiManager addUIBlock:^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, UIView *> *viewRegistry) {
+        
+        UIView *view = viewRegistry[viewTag];
+        if ( ![view isKindOfClass: [AppLovinMAXAdView class]] )
+        {
+            [[AppLovinMAX shared] log: @"Cannot find AppLovinMAXAdView with tag %@", viewTag];
+            return;
+        }
+        
+        AppLovinMAXAdView *adView = (AppLovinMAXAdView *) view;
+        [adView loadAd];
+    }];
 }
 
 @end

--- a/src/types/AdViewProps.ts
+++ b/src/types/AdViewProps.ts
@@ -7,7 +7,7 @@ import type { AdFormat } from '../AdView';
  */
 export type AdViewHandler = {
     /**
-     * Starts loading ads.
+     * If the {@link loadOnMount} attribute is set to false, you can call this API to start loading ads in this AdView.
      */
     loadAd(): void;
 };

--- a/src/types/AdViewProps.ts
+++ b/src/types/AdViewProps.ts
@@ -3,6 +3,16 @@ import type { AdInfo } from './AdInfo';
 import type { AdFormat } from '../AdView';
 
 /**
+ * A handler of {@link AdView}.
+ */
+export type AdViewHandler = {
+    /**
+     * Starts loading ads.
+     */
+    loadAd(): void;
+};
+
+/**
  * Represents an {@link AdView} - Banner / MREC.
  */
 export type AdViewProps = AdProps & {
@@ -22,6 +32,12 @@ export type AdViewProps = AdProps & {
      * enabled by default.
      */
     autoRefresh?: boolean;
+
+    /**
+     * A boolean value representing whether or not to load an ad as soon as {@link AdView} is
+     * mounted. Note that the default value is true.
+     */
+    loadOnMount?: boolean;
 
     /**
      * A callback fuction that {@link AdView} fires when it expands the ad.


### PR DESCRIPTION
https://app.asana.com/0/573104092700345/1206315471986273/f

Add `loadOnMount` to disable automatic ad loading when mounting `<AdView/>`.    Also, add `AdViewHandler` to start loading ads after mounted.

```
const adViewRef = useRef<AdViewHandler>(null);

<AdView
       ref={ref}
       adUnitId={adUnitId}
       adFormat={AdFormat.MREC}
       style={styles.mrec}
       loadOnMount={false}
       onAdLoaded={(adInfo: AdInfo) => {
       log('MREC ad loaded from ' + adInfo.networkName);
       }}
      ...
/>
``` 

Later, you can call `loadAd()` via the handler.

```
adViewRef.current?.loadAd();
```