### PR TITLE
fix/add_initializationMessage_to_guard_multiple_initialization

### DIFF
--- a/android/src/main/java/com/applovin/reactnative/AppLovinMAXModule.java
+++ b/android/src/main/java/com/applovin/reactnative/AppLovinMAXModule.java
@@ -270,7 +270,11 @@ public class AppLovinMAXModule
     private void performInitialization(final String pluginVersion, final String sdkKey, final Context context, final Promise promise)
     {
         // Guard against running init logic multiple times
-        if ( isPluginInitialized ) return;
+        if ( isPluginInitialized )
+        {
+            promise.resolve( getInitializationMessage() );
+            return;
+        }
 
         isPluginInitialized = true;
 
@@ -457,13 +461,23 @@ public class AppLovinMAXModule
                     }
                 }.enable();
 
-                WritableMap sdkConfiguration = Arguments.createMap();
-                sdkConfiguration.putString( "countryCode", configuration.getCountryCode() );
-                sdkConfiguration.putString( "consentFlowUserGeography", getRawAppLovinConsentFlowUserGeography( configuration.getConsentFlowUserGeography() ) );
-                sdkConfiguration.putBoolean( "isTestModeEnabled", configuration.isTestModeEnabled() );
-                promise.resolve( sdkConfiguration );
+                promise.resolve( getInitializationMessage() );
             }
         } );
+    }
+
+    private WritableMap getInitializationMessage()
+    {
+        WritableMap message = Arguments.createMap();
+
+        if ( sdkConfiguration != null )
+        {
+            message.putString( "countryCode", sdkConfiguration.getCountryCode() );
+            message.putString( "consentFlowUserGeography", getRawAppLovinConsentFlowUserGeography( sdkConfiguration.getConsentFlowUserGeography() ) );
+            message.putBoolean( "isTestModeEnabled", sdkConfiguration.isTestModeEnabled() );
+        }
+
+        return message;
     }
 
     // General Public API

--- a/ios/AppLovinMAX.m
+++ b/ios/AppLovinMAX.m
@@ -206,7 +206,11 @@ RCT_EXPORT_METHOD(isInitialized:(RCTPromiseResolveBlock)resolve :(RCTPromiseReje
 RCT_EXPORT_METHOD(initialize:(NSString *)pluginVersion :(NSString *)sdkKey :(RCTPromiseResolveBlock)resolve :(RCTPromiseRejectBlock)reject)
 {
     // Guard against running init logic multiple times
-    if ( [self isPluginInitialized] ) return;
+    if ( [self isPluginInitialized] )
+    {
+        resolve([self initializationMessage]);
+        return;
+    }
     
     self.pluginInitialized = YES;
     
@@ -377,11 +381,23 @@ RCT_EXPORT_METHOD(initialize:(NSString *)pluginVersion :(NSString *)sdkKey :(RCT
         self.sdkConfiguration = configuration;
         self.sdkInitialized = YES;
         
-        resolve(@{@"countryCode" : self.sdk.configuration.countryCode,
-                  @"appTrackingStatus" : [self fromAppLovinAppTrackingStatus: self.sdk.configuration.appTrackingTransparencyStatus],
-                  @"consentFlowUserGeography" : [self fromAppLovinConsentFlowUserGeography: self.sdk.configuration.consentFlowUserGeography],
-                  @"isTestModeEnabled" : @(self.sdk.configuration.isTestModeEnabled)});
+        resolve([self initializationMessage]);
     }];
+}
+
+- (NSDictionary<NSString *, id> *)initializationMessage
+{
+    NSMutableDictionary<NSString *, id> *message = [NSMutableDictionary dictionaryWithCapacity: 4];
+    
+    if ( self.sdkConfiguration )
+    {
+        message[@"countryCode"] = self.sdkConfiguration.countryCode;
+        message[@"appTrackingStatus"] = [self fromAppLovinAppTrackingStatus: self.sdk.configuration.appTrackingTransparencyStatus];
+        message[@"consentFlowUserGeography"] = [self fromAppLovinConsentFlowUserGeography: self.sdk.configuration.consentFlowUserGeography];
+        message[@"isTestModeEnabled"] = @(self.sdkConfiguration.isTestModeEnabled);
+    }
+    
+    return message;
 }
 
 #pragma mark - General Public API


### PR DESCRIPTION
Add `initializationMessage()` to the SDK initialization handler.

This is one of the Various consistency fixes [here](https://app.asana.com/0/573104092700345/1206458373744983/f).