### PR TITLE
fix/cta_not_clickable_after_google_ads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Versions
 
+## x.x.x
+* Fix a Call to action (CTA) button not clickable after Google ads.
 ## 6.3.1
 * Depend on Android SDK 12.3.1 and iOS SDK 12.3.1.
 ## 6.3.0

--- a/ios/AppLovinMAXNativeAdView.m
+++ b/ios/AppLovinMAXNativeAdView.m
@@ -196,6 +196,9 @@
         return;
     }
     
+    // Workaround for the Google adapter to turn this off on its integration
+    view.userInteractionEnabled = YES;
+
     view.tag = CALL_TO_ACTION_VIEW_TAG;
     
     [self.clickableViews addObject: view];


### PR DESCRIPTION
Google adapters turn off user interaction when integrating so that the other network ads become unclickable.