### PR TITLE
fix/url_icon_not_clickable_on_native_ad

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Versions
 
 ## x.x.x
-* Fix url icon not clickable in the native ads.
+* Fix native ad app icons not clickable if set using a url.
 ## 6.3.1
 * Depend on Android SDK 12.3.1 and iOS SDK 12.3.1.
 ## 6.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Versions
 
+## x.x.x
+* Fix url icon not clickable in the native ads.
 ## 6.3.1
 * Depend on Android SDK 12.3.1 and iOS SDK 12.3.1.
 ## 6.3.0

--- a/src/nativeAd/NativeAdViewComponents.tsx
+++ b/src/nativeAd/NativeAdViewComponents.tsx
@@ -88,7 +88,7 @@ export const IconView = (props: Omit<ImageProps, 'source'>) => {
     const { nativeAd, nativeAdView } = useContext(NativeAdViewContext);
 
     useEffect(() => {
-        if (!nativeAd.image || !imageRef.current) return;
+        if (!(nativeAd.image || nativeAd.url) || !imageRef.current) return;
 
         nativeAdView?.setNativeProps({
             iconView: findNodeHandle(imageRef.current),
@@ -96,7 +96,7 @@ export const IconView = (props: Omit<ImageProps, 'source'>) => {
     }, [nativeAd]);
 
     return nativeAd.url ? (
-        <Image {...props} source={{ uri: nativeAd.url }} />
+        <Image {...props} ref={imageRef} source={{ uri: nativeAd.url }} />
     ) : nativeAd.image ? (
         <Image {...props} ref={imageRef} source={0} />
     ) : (


### PR DESCRIPTION
Fix url icon not clickable in the native ads.