### PR TITLE
fix/tsc_type_errors

### DIFF
--- a/example/src/NativeAdViewExample.tsx
+++ b/example/src/NativeAdViewExample.tsx
@@ -81,11 +81,11 @@ export const NativeAdViewExample = ({
                     log('Native ad revenue paid: ' + adInfo.revenue);
                 }}
             >
-                <View style={{flex: 1, flexDirection: 'column', justifyContent: 'space-between'}}>
-                    <View style={{flexDirection: 'row', justifyContent: 'space-between'}}>
+                <View style={{ flex: 1, flexDirection: 'column', justifyContent: 'space-between' }}>
+                    <View style={{ flexDirection: 'row', justifyContent: 'space-between' }}>
                         <IconView style={styles.icon} />
-                        <View style={{width: 4}} />
-                        <View style={{flexDirection: 'column', flexGrow: 1}}>
+                        <View style={{ width: 4 }} />
+                        <View style={{ flexDirection: 'column', flexGrow: 1 }}>
                             <TitleView numberOfLines={1} style={styles.title} />
                             <AdvertiserView numberOfLines={1} style={styles.advertiser} />
                             <StarRatingView style={styles.starRatingView} />
@@ -93,8 +93,8 @@ export const NativeAdViewExample = ({
                         <OptionsView style={styles.optionsView} />
                     </View>
                     <BodyView numberOfLines={2} style={styles.body} />
-                    <MediaView style={{...styles.mediaView, ...mediaViewSize}} />
-                    <View style={{height: 10}} />
+                    <MediaView style={{ ...styles.mediaView, ...mediaViewSize }} />
+                    <View style={{ height: 10 }} />
                     <CallToActionView style={styles.callToAction} />
                 </View>
             </NativeAdView>
@@ -179,7 +179,7 @@ const styles = StyleSheet.create({
         padding: 8,
         fontSize: 14,
         textAlign: 'center',
-        textAlignVertical: 'center'
+        textAlignVertical: 'center',
     },
     mediaView: {
         alignSelf: 'center',

--- a/src/AdView.tsx
+++ b/src/AdView.tsx
@@ -8,7 +8,7 @@ import {
     findNodeHandle,
     useWindowDimensions,
 } from 'react-native';
-import type { ViewProps, ViewStyle, StyleProp, NativeMethods } from 'react-native';
+import type { ViewProps, ViewStyle, StyleProp, NativeMethods, DimensionValue } from 'react-native';
 import type { AdDisplayFailedInfo, AdInfo, AdLoadFailedInfo, AdRevenueInfo } from './types/AdInfo';
 import type { AdNativeEvent } from './types/AdEvent';
 import type { AdViewProps, AdViewHandler } from './types/AdViewProps';
@@ -75,7 +75,7 @@ const AdViewComponent = requireNativeComponent<AdViewProps & ViewProps & AdViewN
 type AdViewType = React.Component<AdViewProps> & NativeMethods;
 
 type SizeKey = 'width' | 'height';
-type SizeRecord = Partial<Record<SizeKey, number | string>>;
+type SizeRecord = Partial<Record<SizeKey, DimensionValue>>;
 
 const ADVIEW_SIZE = {
     banner: { width: 320, height: 50 },
@@ -173,6 +173,7 @@ export const AdView = forwardRef<AdViewHandler, AdViewProps & ViewProps>(functio
         if (adViewRef.current) {
             UIManager.dispatchViewManagerCommand(
                 findNodeHandle(adViewRef.current),
+                // @ts-ignore: Issue in RN ts defs
                 UIManager.getViewManagerConfig('AppLovinMAXAdView').Commands.loadAd,
                 undefined
             );

--- a/src/nativeAd/NativeAdView.tsx
+++ b/src/nativeAd/NativeAdView.tsx
@@ -116,6 +116,7 @@ const NativeAdViewImpl = forwardRef<NativeAdViewHandler, NativeAdViewProps & Vie
         if (nativeAdViewRef) {
             UIManager.dispatchViewManagerCommand(
                 findNodeHandle(nativeAdViewRef.current),
+                // @ts-ignore: Issue in RN ts defs
                 UIManager.getViewManagerConfig('AppLovinMAXNativeAdView').Commands.loadAd,
                 undefined
             );


### PR DESCRIPTION
Fix tsc errors.   Found errors while upgrading the workspace to the latest.

```
npm ERR! src/AdView.tsx:220:31 - error TS2322: Type 'number | AnimatedNode | "auto" | `${number}%` | undefined' is not assignable to type 'string | number | undefined'.
npm ERR!   Type 'AnimatedNode' is not assignable to type 'string | number | undefined'.
npm ERR!
npm ERR! 220         sizeProps.current = { width: width, height: height };
npm ERR!                                   ~~~~~
npm ERR!
npm ERR! src/AdView.tsx:220:45 - error TS2322: Type 'number | AnimatedNode | "auto" | `${number}%` | undefined' is not assignable to type 'string | number | undefined'.
npm ERR!
npm ERR! 220         sizeProps.current = { width: width, height: height };
npm ERR!                                                 ~~~~~~
npm ERR!
npm ERR! src/AdView.tsx:236:17 - error TS2322: Type 'string | number | AnimatedNode | undefined' is not assignable to type 'string | number | undefined'.
npm ERR!   Type 'AnimatedNode' is not assignable to type 'string | number | undefined'.
npm ERR!
npm ERR! 236                 width: width === 'auto' ? adFormatSize.current.width : width,
npm ERR!                     ~~~~~
npm ERR!
npm ERR! src/AdView.tsx:237:17 - error TS2322: Type 'string | number | AnimatedNode | undefined' is not assignable to type 'string | number | undefined'.
npm ERR!
npm ERR! 237                 height: height === 'auto' ? adFormatSize.current.height : height,
npm ERR!                     ~~~~~~
npm ERR!
npm ERR! src/nativeAd/NativeAdView.tsx:119:17 - error TS2345: Argument of type 'number | undefined' is not assignable to parameter of type 'string | number'.
npm ERR!   Type 'undefined' is not assignable to type 'string | number'.
npm ERR!
npm ERR! 119                 UIManager.getViewManagerConfig('AppLovinMAXNativeAdView').Commands.loadAd,
npm ERR!                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```