### PR TITLE
fix/npe_for_accessing_null_current_activity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Versions
 
+## x.x.x
+* Fix NPE for accessing a null activity retruned from `getCurrentActivity()` on Android.
 ## 6.4.1
 * Depend on Android SDK 12.4.2 and iOS SDK 12.4.1.
 ## 6.4.0


### PR DESCRIPTION
The crash is caused by NPE that getCurrentActivity() returns null.  I guess it happened when the app was in the background or during the termination, but we can't expect exactly when.   This NPE is reported elsewhere on the Internet.

https://github.com/facebook/react-native/blob/5a0ae6e2d9d7f2357f9ea6c5dc1d573233075326/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactContextBaseJavaModule.java#L43

Currently, we check for null in some situations, but as the function comment recommends, this PR updates to check for null whenever we need the Activity.   
