### PR TITLE
fix/endering_native_ad_multiple_times_after_updating_all_asset_views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Versions
 
 ## x.x.x
+* Fix native ads rendering multiple times after updating all the asset views.
 * Improve loading time for `<AdView/>`.
 * Upgrade the build platform to support React Native 0.7x.
 ## 6.5.0

--- a/android/src/main/java/com/applovin/reactnative/AppLovinMAXNativeAdView.java
+++ b/android/src/main/java/com/applovin/reactnative/AppLovinMAXNativeAdView.java
@@ -444,7 +444,7 @@ public class AppLovinMAXNativeAdView
         {
             // Renders the ad only after the last asset view is set
             renderNativeAdHandler.removeCallbacksAndMessages( null );
-            renderNativeAdHandler.postDelayed( renderNativeAdTask, 1 );
+            renderNativeAdHandler.postDelayed( renderNativeAdTask, 50 );
         }
     }
 

--- a/example/src/NativeAdViewExample.tsx
+++ b/example/src/NativeAdViewExample.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useState, useEffect, useRef, useCallback } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { StyleSheet, View, Platform } from 'react-native';
 import {
     NativeAdView,
@@ -50,55 +50,6 @@ export const NativeAdViewExample = ({
         }
     }, [aspectRatio]);
 
-    const NativeAdExample = useCallback(() => {
-        return (
-            <NativeAdView
-                adUnitId={adUnitId}
-                placement="myplacement"
-                customData="mycustomdata"
-                ref={nativeAdViewRef}
-                style={styles.nativead}
-                onAdLoaded={(adInfo: AdInfo) => {
-                    if (adInfo?.nativeAd?.mediaContentAspectRatio) {
-                        setAspectRatio(adInfo?.nativeAd?.mediaContentAspectRatio);
-                    }
-                    log('Native ad loaded from ' + adInfo.networkName);
-                    setIsNativeAdLoading(false);
-                }}
-                onAdLoadFailed={(errorInfo: AdLoadFailedInfo) => {
-                    log(
-                        'Native ad failed to load with error code ' +
-                            errorInfo.code +
-                            ' and message: ' +
-                            errorInfo.message
-                    );
-                    setIsNativeAdLoading(false);
-                }}
-                onAdClicked={(adInfo: AdInfo) => {
-                    log('Native ad clicked on ' + adInfo.adUnitId);
-                }}
-                onAdRevenuePaid={(adInfo: AdRevenueInfo) => {
-                    log('Native ad revenue paid: ' + adInfo.revenue);
-                }}
-            >
-                <View style={styles.assetContainer}>
-                    <View style={styles.assetUpperContainer}>
-                        <IconView style={styles.icon} />
-                        <View style={styles.assetTitleContainer}>
-                            <TitleView numberOfLines={1} style={styles.title} />
-                            <AdvertiserView numberOfLines={1} style={styles.advertiser} />
-                            <StarRatingView style={styles.starRatingView} />
-                        </View>
-                        <OptionsView style={styles.optionsView} />
-                    </View>
-                    <BodyView numberOfLines={2} style={styles.body} />
-                    <MediaView style={{ ...styles.mediaView, ...mediaViewSize }} />
-                    <CallToActionView style={styles.callToAction} />
-                </View>
-            </NativeAdView>
-        );
-    }, [adUnitId, log, mediaViewSize]);
-
     return (
         <>
             <AppButton
@@ -110,7 +61,50 @@ export const NativeAdViewExample = ({
             />
             {isNativeAdShowing && (
                 <View style={styles.container}>
-                    <NativeAdExample />
+                    <NativeAdView
+                        adUnitId={adUnitId}
+                        placement="myplacement"
+                        customData="mycustomdata"
+                        ref={nativeAdViewRef}
+                        style={styles.nativead}
+                        onAdLoaded={(adInfo: AdInfo) => {
+                            if (adInfo?.nativeAd?.mediaContentAspectRatio) {
+                                setAspectRatio(adInfo?.nativeAd?.mediaContentAspectRatio);
+                            }
+                            log('Native ad loaded from ' + adInfo.networkName);
+                            setIsNativeAdLoading(false);
+                        }}
+                        onAdLoadFailed={(errorInfo: AdLoadFailedInfo) => {
+                            log(
+                                'Native ad failed to load with error code ' +
+                                    errorInfo.code +
+                                    ' and message: ' +
+                                    errorInfo.message
+                            );
+                            setIsNativeAdLoading(false);
+                        }}
+                        onAdClicked={(adInfo: AdInfo) => {
+                            log('Native ad clicked on ' + adInfo.adUnitId);
+                        }}
+                        onAdRevenuePaid={(adInfo: AdRevenueInfo) => {
+                            log('Native ad revenue paid: ' + adInfo.revenue);
+                        }}
+                    >
+                        <View style={styles.assetContainer}>
+                            <View style={styles.assetUpperContainer}>
+                                <IconView style={styles.icon} />
+                                <View style={styles.assetTitleContainer}>
+                                    <TitleView numberOfLines={1} style={styles.title} />
+                                    <AdvertiserView numberOfLines={1} style={styles.advertiser} />
+                                    <StarRatingView style={styles.starRatingView} />
+                                </View>
+                                <OptionsView style={styles.optionsView} />
+                            </View>
+                            <BodyView numberOfLines={2} style={styles.body} />
+                            <MediaView style={{ ...styles.mediaView, ...mediaViewSize }} />
+                            <CallToActionView style={styles.callToAction} />
+                        </View>
+                    </NativeAdView>
                     <AppButton
                         title={'RELOAD'}
                         enabled={!isNativeAdLoading}


### PR DESCRIPTION
Fix native ads rendering multiple times after updating all the asset views.

- It is too short a time for all the asset views to refresh when the UI is jittering.
- The example recreates `NativeAdView` when started because of the `useCallback` hook.

These will cause the recent ads in `Creative Debugger` to appear more than twice.