### PR TITLE
fix/media_view_not_clickable_on_bidmachine_native_ads

### DIFF
--- a/android/src/main/java/com/applovin/reactnative/AppLovinMAXNativeAdView.java
+++ b/android/src/main/java/com/applovin/reactnative/AppLovinMAXNativeAdView.java
@@ -380,7 +380,7 @@ public class AppLovinMAXNativeAdView
         }
 
         view.setTag( MEDIA_VIEW_CONTAINER_TAG );
-        clickableViews.add( view );
+        clickableViews.add( mediaView );
 
         view.addOnLayoutChangeListener( this );
 


### PR DESCRIPTION
Fix media view not clickable on BidMachine native ads.   Verified the fix with the following:

- AppLovin
- BidMachine
- Google
- ImMobi
- Line
- Pangle
- Smatto