### PR TITLE
feat/depend_on_Android_SDK_12.6.1_and_iOS_SDK_12.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Versions
 
 ## x.x.x
+* Depend on Android SDK 12.6.1 and iOS SDK 12.6.1.
 * Fix BidMachine media view not clickable on Android.
 ## 7.1.0
 * Replace targeting data APIs with new numeric segments targeting APIs. For migration instructions, please see [here](https://developers.applovin.com/en/react-native/overview/data-and-keyword-passing/#segment-targeting).

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -85,6 +85,6 @@ dependencies {
   //noinspection GradleDynamicVersion
   implementation "com.facebook.react:react-native:0.73.6"
 
-  implementation "com.applovin:applovin-sdk:12.6.0"
+  implementation "com.applovin:applovin-sdk:12.6.1"
 }
 

--- a/react-native-applovin-max.podspec
+++ b/react-native-applovin-max.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
 
   s.source_files = "ios/AppLovinMAX*.{h,m}"
 
-  s.dependency "AppLovinSDK", "12.6.0"
+  s.dependency "AppLovinSDK", "12.6.1"
 
   # Use install_modules_dependencies helper to install the dependencies if React Native version >=0.71.0.
   # See https://github.com/facebook/react-native/blob/febf6b7f33fdb4904669f99d795eba4c0f95d7bf/scripts/cocoapods/new_architecture.rb#L79.


### PR DESCRIPTION
Depends on Android SDK 12.6.1 and iOS SDK 12.6.1, which is the first SDK update after the renewal of the build platform.