### PR TITLE
feat/crash_if_plugin_version_is_incompatible_with_native_sdk_version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Versions
 
+## x.x.x
+* Crash if plugin version is incompatible with native SDK version.
 ## 8.0.1
 * Fix CTA not clickable in native ads on Android.
 ## 8.0.0

--- a/android/src/main/java/com/applovin/reactnative/AppLovinMAXModule.java
+++ b/android/src/main/java/com/applovin/reactnative/AppLovinMAXModule.java
@@ -2402,7 +2402,9 @@ public class AppLovinMAXModule
         return constants;
     }
 
-    // Version String
+    //
+    // Version Utils
+    //
 
     private boolean isInclusiveVersion(final String version, @Nullable final String minVersion, @Nullable final String maxVersion)
     {

--- a/android/src/main/java/com/applovin/reactnative/AppLovinMAXModule.java
+++ b/android/src/main/java/com/applovin/reactnative/AppLovinMAXModule.java
@@ -2408,10 +2408,11 @@ public class AppLovinMAXModule
     {
         if ( TextUtils.isEmpty( version ) ) return true;
 
+        int versionCode = toVersionCode( version );
+
         // if version is less than the minimum version
         if ( !TextUtils.isEmpty( minVersion ) )
         {
-            int versionCode = toVersionCode( version );
             int minVersionCode = toVersionCode( minVersion );
 
             if ( versionCode < minVersionCode ) return false;
@@ -2420,7 +2421,6 @@ public class AppLovinMAXModule
         // if version is greater than the maximum version
         if ( !TextUtils.isEmpty( maxVersion ) )
         {
-            int versionCode = toVersionCode( version );
             int maxVersionCode = toVersionCode( maxVersion );
 
             if ( versionCode > maxVersionCode ) return false;

--- a/android/src/main/java/com/applovin/reactnative/AppLovinMAXModule.java
+++ b/android/src/main/java/com/applovin/reactnative/AppLovinMAXModule.java
@@ -96,12 +96,12 @@ public class AppLovinMAXModule
 
     private static final Point DEFAULT_AD_VIEW_OFFSET = new Point( 0, 0 );
 
-    private static final Map<String, String> ALCompatibleNativeSDKVersions = new HashMap<>();
+    private static final Map<String, String> ALCompatibleNativeSdkVersions = new HashMap<>();
 
     static
     {
-        ALCompatibleNativeSDKVersions.put( "8.0.1", "13.0.0" );
-        ALCompatibleNativeSDKVersions.put( "8.0.0", "13.0.0" );
+        ALCompatibleNativeSdkVersions.put( "8.0.1", "13.0.0" );
+        ALCompatibleNativeSdkVersions.put( "8.0.0", "13.0.0" );
     }
 
     public static  AppLovinMAXModule instance;
@@ -151,7 +151,7 @@ public class AppLovinMAXModule
         super( reactContext );
 
         // Check that plugin version is compatible with native SDK version
-        String minCompatibleNativeSdkVersion = ALCompatibleNativeSDKVersions.get( PLUGIN_VERSION );
+        String minCompatibleNativeSdkVersion = ALCompatibleNativeSdkVersions.get( PLUGIN_VERSION );
         boolean isCompatible = isInclusiveVersion( AppLovinSdk.VERSION, minCompatibleNativeSdkVersion, null );
         if ( !isCompatible )
         {


### PR DESCRIPTION
This is an attempt to resolve issues where underlying SDK is updated in the `Podfile` or `build.gradle` files due to not hardcoding to a specific version. This issue is easier to slip by on Android and result in issues such as this: https://github.com/AppLovin/AppLovin-MAX-React-Native/issues/371.

@alhiwatan - can you take a look and port to Android? Also, I wonder if it makes sense to add this crash to our doc's FAQ and update the error message to point to it so developers know exactly what's going on and how to resolve.