### PR TITLE
ref/add_workaround_for_ise_when_reattaching_preloaded_AdView_with_react_native_screens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Versions
 
+## x.x.x
+* Add a workaround for the IllegalStateException (ISE) that occurs when remounting a preloaded banner and MREC (`<AdView/>`) using `react-native-screens`.
 ## 8.0.4
 * Update IconView to support native ad icon image view, primarily for BigoAds native ads.
 ## 8.0.3

--- a/android/src/main/java/com/applovin/reactnative/AppLovinMAXAdView.java
+++ b/android/src/main/java/com/applovin/reactnative/AppLovinMAXAdView.java
@@ -88,7 +88,7 @@ class AppLovinMAXAdView
             return;
         }
 
-        if ( preloadedUiComponent.hasContainerView() )
+        if ( preloadedUiComponent.isAdViewAttached() )
         {
             promise.reject( new IllegalStateException( "Cannot destroy - currently in use" ) );
             return;
@@ -276,21 +276,22 @@ class AppLovinMAXAdView
                 return;
             }
 
-            AppLovinMAXModule.d( "Attaching a native UI component for " + adUnitId );
-
             uiComponent = preloadedUiComponentInstances.get( adUnitId );
             if ( uiComponent != null )
             {
                 // Attach the preloaded uiComponent if possible, otherwise create a new one for the
                 // same adUnitId
-                if ( !uiComponent.hasContainerView() )
+                if ( !uiComponent.isAdViewAttached() )
                 {
-                    uiComponent.setAdaptiveBannerEnabled( adaptiveBannerEnabled );
+                    AppLovinMAXModule.d( "Attaching the preloaded native UI component for " + adUnitId );
+
                     uiComponent.setAutoRefresh( autoRefresh );
                     uiComponent.attachAdView( AppLovinMAXAdView.this );
                     return;
                 }
             }
+
+            AppLovinMAXModule.d( "Attaching a new native UI component for " + adUnitId );
 
             uiComponent = new AppLovinMAXAdViewUiComponent( adUnitId, adFormat, reactContext );
             uiComponentInstances.put( adUnitId, uiComponent );
@@ -326,14 +327,18 @@ class AppLovinMAXAdView
     {
         if ( uiComponent != null )
         {
-            AppLovinMAXModule.d( "Unmounting the native UI component: " + uiComponent.getAdView() );
-
             uiComponent.detachAdView();
 
             AppLovinMAXAdViewUiComponent preloadedUiComponent = preloadedUiComponentInstances.get( adUnitId );
 
-            if ( uiComponent != preloadedUiComponent )
+            if ( uiComponent == preloadedUiComponent )
             {
+                AppLovinMAXModule.d( "Unmounting the preloaded native UI component: " + uiComponent.getAdView() );
+            }
+            else
+            {
+                AppLovinMAXModule.d( "Destroying the native UI component: " + uiComponent.getAdView() );
+
                 uiComponentInstances.remove( adUnitId );
                 uiComponent.destroy();
             }

--- a/android/src/main/java/com/applovin/reactnative/AppLovinMAXAdView.java
+++ b/android/src/main/java/com/applovin/reactnative/AppLovinMAXAdView.java
@@ -88,7 +88,7 @@ class AppLovinMAXAdView
             return;
         }
 
-        if ( preloadedUiComponent.isAdViewAttached() )
+        if ( preloadedUiComponent.hasContainerView() )
         {
             promise.reject( new IllegalStateException( "Cannot destroy - currently in use" ) );
             return;
@@ -281,9 +281,9 @@ class AppLovinMAXAdView
             {
                 // Attach the preloaded uiComponent if possible, otherwise create a new one for the
                 // same adUnitId
-                if ( !uiComponent.isAdViewAttached() )
+                if ( !( uiComponent.hasContainerView() || uiComponent.isAdViewNotRemoved() ) )
                 {
-                    AppLovinMAXModule.d( "Attaching the preloaded native UI component for " + adUnitId );
+                    AppLovinMAXModule.d( "Mounting the preloaded native UI component for " + adUnitId );
 
                     uiComponent.setAutoRefresh( autoRefresh );
                     uiComponent.attachAdView( AppLovinMAXAdView.this );
@@ -291,7 +291,7 @@ class AppLovinMAXAdView
                 }
             }
 
-            AppLovinMAXModule.d( "Attaching a new native UI component for " + adUnitId );
+            AppLovinMAXModule.d( "Mounting a new native UI component for " + adUnitId );
 
             uiComponent = new AppLovinMAXAdViewUiComponent( adUnitId, adFormat, reactContext );
             uiComponentInstances.put( adUnitId, uiComponent );
@@ -337,7 +337,7 @@ class AppLovinMAXAdView
             }
             else
             {
-                AppLovinMAXModule.d( "Destroying the native UI component: " + uiComponent.getAdView() );
+                AppLovinMAXModule.d( "Unmounting the native UI component to destroy: " + uiComponent.getAdView() );
 
                 uiComponentInstances.remove( adUnitId );
                 uiComponent.destroy();

--- a/android/src/main/java/com/applovin/reactnative/AppLovinMAXAdView.java
+++ b/android/src/main/java/com/applovin/reactnative/AppLovinMAXAdView.java
@@ -281,7 +281,7 @@ class AppLovinMAXAdView
             {
                 // Attach the preloaded uiComponent if possible, otherwise create a new one for the
                 // same adUnitId
-                if ( !( uiComponent.hasContainerView() || uiComponent.isAdViewNotRemoved() ) )
+                if ( !( uiComponent.hasContainerView() || uiComponent.isAdViewAttached() ) )
                 {
                     AppLovinMAXModule.d( "Mounting the preloaded native UI component for " + adUnitId );
 

--- a/android/src/main/java/com/applovin/reactnative/AppLovinMAXAdViewUiComponent.java
+++ b/android/src/main/java/com/applovin/reactnative/AppLovinMAXAdViewUiComponent.java
@@ -102,14 +102,14 @@ class AppLovinMAXAdViewUiComponent
     // being removed from containerView when attached to react-native-screens views. This happens
     // because react-native-screens replaces the default UI manager with its own, which includes
     // caching for screen navigation.
-    public boolean isAdViewNotRemoved()
+    public boolean isAdViewAttached()
     {
         return containerView == null && adView.getParent() != null;
     }
 
     public void attachAdView(AppLovinMAXAdView view)
     {
-        if ( isAdViewNotRemoved() )
+        if ( isAdViewAttached() )
         {
             AppLovinMAXModule.e( "Cannot attach AdView because it already has an existing parent: " + adView );
             return;

--- a/android/src/main/java/com/applovin/reactnative/AppLovinMAXAdViewUiComponent.java
+++ b/android/src/main/java/com/applovin/reactnative/AppLovinMAXAdViewUiComponent.java
@@ -93,23 +93,30 @@ class AppLovinMAXAdViewUiComponent
         }
     }
 
-    public boolean isAdViewAttached()
+    public boolean hasContainerView()
     {
-        return containerView != null || adView.getParent() != null;
+        return containerView != null;
+    }
+
+    // AdView should have no parent when containerView is null, but it retains a parent even after
+    // being removed from containerView when attached to react-native-screens views. This happens
+    // because react-native-screens replaces the default UI manager with its own, which includes
+    // caching for screen navigation.
+    public boolean isAdViewNotRemoved()
+    {
+        return containerView == null && adView.getParent() != null;
     }
 
     public void attachAdView(AppLovinMAXAdView view)
     {
-        containerView = view;
+        if ( isAdViewNotRemoved() )
+        {
+            AppLovinMAXModule.e( "Cannot attach AdView because it already has an existing parent: " + adView );
+            return;
+        }
 
-        if ( adView.getParent() == null )
-        {
-            containerView.addView( adView );
-        }
-        else
-        {
-            AppLovinMAXModule.e( "Cannot attach AdView due to an existing parent: " + adView );
-        }
+        containerView = view;
+        containerView.addView( adView );
     }
 
     public void detachAdView()

--- a/android/src/main/java/com/applovin/reactnative/AppLovinMAXAdViewUiComponent.java
+++ b/android/src/main/java/com/applovin/reactnative/AppLovinMAXAdViewUiComponent.java
@@ -93,15 +93,23 @@ class AppLovinMAXAdViewUiComponent
         }
     }
 
-    public boolean hasContainerView()
+    public boolean isAdViewAttached()
     {
-        return containerView != null;
+        return containerView != null || adView.getParent() != null;
     }
 
     public void attachAdView(AppLovinMAXAdView view)
     {
         containerView = view;
-        containerView.addView( adView );
+
+        if ( adView.getParent() == null )
+        {
+            containerView.addView( adView );
+        }
+        else
+        {
+            AppLovinMAXModule.e( "Cannot attach AdView due to an existing parent: " + adView );
+        }
     }
 
     public void detachAdView()


### PR DESCRIPTION
Add a workaround for the IllegalStateException (ISE) that occurs when remounting a preloaded banner and MREC (`<AdView/>`) using `react-native-screens`.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Add a workaround to handle the IllegalStateException that occurs when remounting a preloaded AdView, specifically a banner and MREC, using `react-native-screens`.

### Why are these changes being made?
The change addresses an issue where an IllegalStateException is thrown when a preloaded AdView is remounted, which disrupts user experience on the application. The new implementation enhances stability by ensuring that the ad view is not reattached if it is already attached to a parent view, thus preventing the exception from occurring.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->