### PR TITLE
ref/suspend_auto_refresh_for_preloaded_adview_in_background

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Versions
 
 ## x.x.x
+* Update preloaded banners and MRECs (`<AdView/>`) to suspend loading while not visible in background.
 * Add a workaround for the IllegalStateException (ISE) that occurs when remounting a preloaded banner and MREC (`<AdView/>`) using `react-native-screens`.
 ## 8.0.4
 * Update IconView to support native ad icon image view, primarily for BigoAds native ads.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Versions
 
 ## x.x.x
-* Update preloaded banners and MRECs (`<AdView/>`) to suspend loading while not visible in background.
+* Update preloaded banners and MRECs (`<AdView/>`) to suspend auto-refresh while not visible in background.
 * Add a workaround for the IllegalStateException (ISE) that occurs when remounting a preloaded banner and MREC (`<AdView/>`) using `react-native-screens`.
 ## 8.0.4
 * Update IconView to support native ad icon image view, primarily for BigoAds native ads.

--- a/android/src/main/java/com/applovin/reactnative/AppLovinMAXAdView.java
+++ b/android/src/main/java/com/applovin/reactnative/AppLovinMAXAdView.java
@@ -334,6 +334,8 @@ class AppLovinMAXAdView
             if ( uiComponent == preloadedUiComponent )
             {
                 AppLovinMAXModule.d( "Unmounting the preloaded native UI component: " + uiComponent.getAdView() );
+
+                uiComponent.setAutoRefresh( false );
             }
             else
             {

--- a/android/src/main/java/com/applovin/reactnative/AppLovinMAXAdViewUiComponent.java
+++ b/android/src/main/java/com/applovin/reactnative/AppLovinMAXAdViewUiComponent.java
@@ -167,6 +167,10 @@ class AppLovinMAXAdViewUiComponent
         {
             sendReactNativeCallbackEvent( AppLovinMAXAdEvents.ON_AD_LOADED_EVENT, adInfo );
         }
+        else
+        {
+            setAutoRefresh( false );
+        }
     }
 
     @Override

--- a/android/src/main/java/com/applovin/reactnative/AppLovinMAXAdViewUiComponent.java
+++ b/android/src/main/java/com/applovin/reactnative/AppLovinMAXAdViewUiComponent.java
@@ -34,6 +34,7 @@ class AppLovinMAXAdViewUiComponent
         adView = new MaxAdView( adUnitId, adFormat, AppLovinMAXModule.getInstance().getSdk(), context );
         adView.setListener( this );
         adView.setRevenueListener( this );
+        adView.stopAutoRefresh();
 
         adView.setExtraParameter( "adaptive_banner", "true" );
 
@@ -166,10 +167,6 @@ class AppLovinMAXAdViewUiComponent
         if ( containerView != null )
         {
             sendReactNativeCallbackEvent( AppLovinMAXAdEvents.ON_AD_LOADED_EVENT, adInfo );
-        }
-        else
-        {
-            setAutoRefresh( false );
         }
     }
 

--- a/android/src/main/java/com/applovin/reactnative/AppLovinMAXAdViewUiComponent.java
+++ b/android/src/main/java/com/applovin/reactnative/AppLovinMAXAdViewUiComponent.java
@@ -34,12 +34,12 @@ class AppLovinMAXAdViewUiComponent
         adView = new MaxAdView( adUnitId, adFormat, AppLovinMAXModule.getInstance().getSdk(), context );
         adView.setListener( this );
         adView.setRevenueListener( this );
-        adView.stopAutoRefresh();
-
         adView.setExtraParameter( "adaptive_banner", "true" );
 
         // Set this extra parameter to work around a SDK bug that ignores calls to stopAutoRefresh()
         adView.setExtraParameter( "allow_pause_auto_refresh_immediately", "true" );
+
+        adView.stopAutoRefresh();
     }
 
     public MaxAdView getAdView()

--- a/ios/AppLovinMAXAdView.m
+++ b/ios/AppLovinMAXAdView.m
@@ -277,7 +277,11 @@ static NSMutableDictionary<NSString *, AppLovinMAXAdViewUIComponent *> *preloade
             
             AppLovinMAXAdViewUIComponent *preloadedUIComponent = preloadedUIComponentInstances[self.adUnitId];
             
-            if ( self.uiComponent != preloadedUIComponent )
+            if ( self.uiComponent == preloadedUIComponent )
+            {
+                self.uiComponent.autoRefresh = NO;
+            }
+            else
             {
                 [uiComponentInstances removeObjectForKey: self.adUnitId];
                 [self.uiComponent destroy];

--- a/ios/AppLovinMAXAdViewUIComponent.m
+++ b/ios/AppLovinMAXAdViewUIComponent.m
@@ -128,6 +128,10 @@
     {
         self.containerView.onAdLoadedEvent(adInfo);
     }
+    else
+    {
+        self.autoRefresh = NO;
+    }
 }
 
 - (void)didFailToLoadAdForAdUnitIdentifier:(NSString *)adUnitIdentifier withError:(MAError *)error

--- a/ios/AppLovinMAXAdViewUIComponent.m
+++ b/ios/AppLovinMAXAdViewUIComponent.m
@@ -21,6 +21,8 @@
         self.adView = [[MAAdView alloc] initWithAdUnitIdentifier: adUnitIdentifier adFormat: adFormat sdk: [AppLovinMAX shared].sdk];
         self.adView.delegate = self;
         self.adView.revenueDelegate = self;
+
+        [self.adView stopAutoRefresh];
         
         [self.adView setExtraParameterForKey: @"adaptive_banner" value: @"true"];
         
@@ -127,10 +129,6 @@
     if ( self.containerView )
     {
         self.containerView.onAdLoadedEvent(adInfo);
-    }
-    else
-    {
-        self.autoRefresh = NO;
     }
 }
 

--- a/ios/AppLovinMAXAdViewUIComponent.m
+++ b/ios/AppLovinMAXAdViewUIComponent.m
@@ -22,12 +22,12 @@
         self.adView.delegate = self;
         self.adView.revenueDelegate = self;
 
-        [self.adView stopAutoRefresh];
-        
         [self.adView setExtraParameterForKey: @"adaptive_banner" value: @"true"];
         
         // Set this extra parameter to work around a SDK bug that ignores calls to stopAutoRefresh()
         [self.adView setExtraParameterForKey: @"allow_pause_auto_refresh_immediately" value: @"true"];
+
+        [self.adView stopAutoRefresh];
         
         // Set a frame size to suppress an error of zero area for MAAdView
         self.adView.frame = (CGRect) { CGPointZero, adFormat.size };


### PR DESCRIPTION
Update preloaded banners and MRECs to suspend loading while not visible in background.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Update preloaded banners and MRECs (`<AdView/>`) to suspend loading while not visible in the background by setting auto-refresh to false for the preloaded UI component.

### Why are these changes being made?

These changes are being made to optimize ad performance and prevent unnecessary ad loading when the ad views are not visible. This approach ensures efficient resource usage and aligns with best practices for handling background processes in mobile applications.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->