### PR TITLE
fix/marked_nonnull_for_nsnumber_arguments

### DIFF
--- a/ios/AppLovinMAX.m
+++ b/ios/AppLovinMAX.m
@@ -984,7 +984,7 @@ RCT_EXPORT_METHOD(preloadNativeUIComponentAdView:(NSString *)adUnitIdentifier
                                   withPromiseRejecter: reject];
 }
 
-RCT_EXPORT_METHOD(destroyNativeUIComponentAdView:(NSNumber *)adViewId
+RCT_EXPORT_METHOD(destroyNativeUIComponentAdView:(nonnull NSNumber *)adViewId
                                                 :(RCTPromiseResolveBlock)resolve
                                                 :(RCTPromiseRejectBlock)reject)
 {


### PR DESCRIPTION
NSNumber arguments in the React Native method must be `nonnull`.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Mark the `NSNumber` argument as `nonnull` in the `destroyNativeUIComponentAdView` method signature.

### Why are these changes being made?
This change ensures that the `adViewId` parameter is explicitly marked as non-nullable to prevent potential null-pointer exceptions, which enforces safer memory handling and improves code reliability. The addition emphasizes that the method requires a valid `NSNumber` instance and avoids unintended issues during runtime.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->