### PR TITLE
ref/support_interop_layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## Versions
 
 ## x.x.x
-* Upgrade the React Native version to 0.75.4.
+* Enable compatibility with the Interop Layer.
+* Upgrade the React Native version to 0.76.2.
 * Remove obsolete MAX Error Codes - `ErrorCode.FULLSCREEN_AD_ALREADY_LOADING` and `ErrorCode.FULLSCREEN_AD_LOAD_WHILE_SHOWING`.
 ## 8.1.0
 * Enhance banner and MREC (`<AdView/>`) preloading to support preloading multiple `<AdView/>` instances.

--- a/example/Gemfile
+++ b/example/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 # You may use http://rbenv.org/ or https://rvm.io/ to install and use this version
 ruby ">= 2.6.10"
 
-# Cocoapods 1.15 introduced a bug which break the build. We will remove the upper
-# bound in the template on Cocoapods with next React Native release.
-gem 'cocoapods', '>= 1.13', '< 1.15'
-gem 'activesupport', '>= 6.1.7.5', '< 7.1.0'
+# Exclude problematic versions of cocoapods and activesupport that causes build failures.
+gem 'cocoapods', '>= 1.13', '!= 1.15.0', '!= 1.15.1'
+gem 'activesupport', '>= 6.1.7.5', '!= 7.1.0'
+gem 'xcodeproj', '< 1.26.0'

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         minSdkVersion = 24
         compileSdkVersion = 34
         targetSdkVersion = 34
-        ndkVersion = "25.1.8937393"
+        ndkVersion = "26.1.10909125"
         kotlinVersion = "1.8.0"
     }
     repositories {

--- a/example/ios/AppLovinMAXExample/AppDelegate.mm
+++ b/example/ios/AppLovinMAXExample/AppDelegate.mm
@@ -16,10 +16,10 @@
 
 - (NSURL *)sourceURLForBridge:(RCTBridge *)bridge
 {
-  return [self getBundleURL];
+  return [self bundleURL];
 }
 
-- (NSURL *)getBundleURL
+- (NSURL *)bundleURL
 {
 #if DEBUG
   return [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index"];

--- a/react-native-applovin-max.podspec
+++ b/react-native-applovin-max.podspec
@@ -1,7 +1,6 @@
 require "json"
 
 package = JSON.parse(File.read(File.join(__dir__, "package.json")))
-folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -Wno-comma -Wno-shorten-64-to-32'
 
 Pod::Spec.new do |s|
   s.name         = "react-native-applovin-max"
@@ -23,10 +22,12 @@ Pod::Spec.new do |s|
   if respond_to?(:install_modules_dependencies, true)
     install_modules_dependencies(s)
   else
-  s.dependency "React-Core"
+    s.dependency "React-Core"
 
   # Don't install the dependencies when we run `pod install` in the old architecture.
   if ENV['RCT_NEW_ARCH_ENABLED'] == '1' then
+    folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -Wno-comma -Wno-shorten-64-to-32'
+
     s.compiler_flags = folly_compiler_flags + " -DRCT_NEW_ARCH_ENABLED=1"
     s.pod_target_xcconfig    = {
         "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost\"",

--- a/src/AppLovinMAX.ts
+++ b/src/AppLovinMAX.ts
@@ -115,10 +115,15 @@ type NativeAppLovinMAXType = Omit<AppLovinMAXType, 'initialize' | 'getSegments'>
 
 const nativeMethods: NativeAppLovinMAXType = NativeAppLovinMAX;
 
-export const AppLovinMAX: AppLovinMAXType = {
-    ...nativeMethods,
-    initialize,
-    getSegments,
-};
+export const AppLovinMAX: AppLovinMAXType = Object.create(nativeMethods, {
+    initialize: {
+        value: initialize,
+        enumerable: true,
+    },
+    getSegments: {
+        value: getSegments,
+        enumerable: true,
+    },
+});
 
 export default AppLovinMAX;

--- a/src/nativeAd/NativeAdView.tsx
+++ b/src/nativeAd/NativeAdView.tsx
@@ -95,13 +95,12 @@ const NativeAdViewImpl = forwardRef<NativeAdViewHandler, NativeAdViewProps & Vie
 
     // Load a new ad
     const loadAd = useCallback(() => {
-        if (nativeAdViewRef.current) {
-            UIManager.dispatchViewManagerCommand(
-                findNodeHandle(nativeAdViewRef.current),
-                // @ts-ignore: Issue in RN ts defs
-                UIManager.getViewManagerConfig('AppLovinMAXNativeAdView').Commands.loadAd,
-                undefined
-            );
+        const nativeAdView = nativeAdViewRef.current;
+        if (nativeAdView) {
+            const viewManagerConfig = UIManager.getViewManagerConfig('AppLovinMAXNativeAdView');
+            if (viewManagerConfig?.Commands && typeof viewManagerConfig.Commands.loadAd === 'number') {
+                UIManager.dispatchViewManagerCommand(findNodeHandle(nativeAdView), viewManagerConfig.Commands.loadAd, []);
+            }
         }
     }, []);
 


### PR DESCRIPTION
Enable compatibility with the [Interop Layer](https://github.com/reactwg/react-native-new-architecture/discussions/135).

This is the first step for enabling the new architecture.   The details are documented:

"[Make your library compatible with the New Architecture](https://github.com/reactwg/react-native-new-architecture/blob/main/docs/enable-libraries.md)"

Now, our plugin can be compiled with the new arhchitecture enabled and run on the Interop Layer.   Both Android and iOS works good, but iOS has some glitch.  As it is documented in the Interop Layer, there seems some limitations.

The next step is to support the new architecture natively.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Enable compatibility with the Interop Layer, upgrade React Native to version 0.76.2, update gem dependencies to exclude problematic versions, update NDK version in Android build, rename a function in iOS AppDelegate, and refactor `AppLovinMAX` and `NativeAdView` implementations.

### Why are these changes being made?

The changes are made to maintain compatibility with the Interop Layer which improves interoperability, ensure stability by using specific versions of dependencies that avoid known issues, keep the framework up-to-date with the latest React Native version for better features and support, and to enhance code clarity and maintainability through function renaming and refactoring. These updates collectively aim to improve the project's robustness and functionality.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->