### PR TITLE
ref/add_support_for_amazon_integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Versions
 
 ## x.x.x
+* Make AppLovinMAXAdView public to support Amazon Integration. (https://github.com/AppLovin/AppLovin-MAX-React-Native/issues/407)
 * Enable compatibility with the Interop Layer.
 * Upgrade the React Native version to 0.76.2.
 * Remove obsolete MAX Error Codes - `ErrorCode.FULLSCREEN_AD_ALREADY_LOADING` and `ErrorCode.FULLSCREEN_AD_LOAD_WHILE_SHOWING`.

--- a/android/src/main/java/com/applovin/reactnative/AppLovinMAXAdView.java
+++ b/android/src/main/java/com/applovin/reactnative/AppLovinMAXAdView.java
@@ -18,7 +18,7 @@ import androidx.annotation.Nullable;
 /**
  * Created by Thomas So on September 27 2020
  */
-class AppLovinMAXAdView
+public class AppLovinMAXAdView
     extends ReactViewGroup
 {
     private static final Map<Integer, AppLovinMAXAdViewUiComponent> uiComponentInstances          = new HashMap<>( 2 );


### PR DESCRIPTION
Make AppLovinMAXAdView public to support Amazon Integration (https://github.com/AppLovin/AppLovin-MAX-React-Native/issues/407).

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Make the `AppLovinMAXAdView` class public to facilitate integration with third-party components, such as Amazon.

### Why are these changes being made?

The change is necessary to support integration with Amazon by allowing the `AppLovinMAXAdView` class to be accessed by external components. This improves the flexibility and extensibility of the ad view framework without altering its internal functionalities.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->