### PR TITLE
fix/adview_not_destroyed_with_new_arch_enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Versions
 
+## x.x.x
+* Fix banners and MRECs (<AdView/>) not being destroyed when unmounted with the new architecture enabled on iOS.
 ## 8.1.1
 * Make AppLovinMAXAdView public to support Amazon Integration. (https://github.com/AppLovin/AppLovin-MAX-React-Native/issues/407)
 * Enable compatibility with the Interop Layer.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Versions
 
 ## x.x.x
-* Fix banners and MRECs (<AdView/>) not being destroyed when unmounted with the new architecture enabled on iOS.
+* Fix banners and MRECs (`<AdView/>`) not being destroyed when unmounted with the new architecture enabled on iOS.
 ## 8.1.1
 * Make AppLovinMAXAdView public to support Amazon Integration. (https://github.com/AppLovin/AppLovin-MAX-React-Native/issues/407)
 * Enable compatibility with the Interop Layer.

--- a/ios/AppLovinMAXAdView.m
+++ b/ios/AppLovinMAXAdView.m
@@ -295,7 +295,11 @@ static NSMutableDictionary<NSNumber *, AppLovinMAXAdViewUIComponent *> *preloade
     [super didMoveToWindow];
     
     // This view is unmounted
+#ifdef RCT_NEW_ARCH_ENABLED
+    if ( !self.window )
+#else
     if ( !self.window && !self.superview )
+#endif
     {
         if ( self.uiComponent )
         {

--- a/ios/AppLovinMAXAdView.m
+++ b/ios/AppLovinMAXAdView.m
@@ -295,11 +295,7 @@ static NSMutableDictionary<NSNumber *, AppLovinMAXAdViewUIComponent *> *preloade
     [super didMoveToWindow];
     
     // This view is unmounted
-#ifdef RCT_NEW_ARCH_ENABLED
     if ( !self.window )
-#else
-    if ( !self.window && !self.superview )
-#endif
     {
         if ( self.uiComponent )
         {

--- a/ios/AppLovinMAXAdView.m
+++ b/ios/AppLovinMAXAdView.m
@@ -317,6 +317,8 @@ static NSMutableDictionary<NSNumber *, AppLovinMAXAdViewUIComponent *> *preloade
                 [self.uiComponent destroy];
             }
         }
+        
+        self.uiComponent = nil;
     }
 }
 


### PR DESCRIPTION
Fix AdView not being destroyed when unmounted with the new architecture enabled on iOS.   

When the new architecure is enabled, [the interop libraries](https://github.com/reactwg/react-native-new-architecture/discussions/135) are used to support non-migrated libraries, including our Max library. In the interop libraries, the tree structure appears to have changed, leaving the interop superview intact when the AdView is being destroyed. This causes the AdView to continue refreshing even after it has been unmounted in the app.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI


### What change is being made?

Fix the issue where banners and MRECs (`<AdView/>`) are not destroyed when unmounted with the new architecture enabled on iOS.

### Why are these changes being made?

This change addresses a bug that prevented the proper destruction of ad views in the new architectural setup, which could lead to memory leaks or unexpected behavior. The conditional compilation adjustment ensures that the component behavior aligns correctly with the architecture mode in use.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->