### PR TITLE
fix/nativeadview_not_destroyed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Versions
 
+## x.x.x
+* Fix native ads not being destroyed when unmounted on iOS.
 ## 8.1.1
 * Make AppLovinMAXAdView public to support Amazon Integration. (https://github.com/AppLovin/AppLovin-MAX-React-Native/issues/407)
 * Enable compatibility with the Interop Layer.

--- a/ios/AppLovinMAXNativeAdView.m
+++ b/ios/AppLovinMAXNativeAdView.m
@@ -85,7 +85,7 @@
 {
     [super didMoveToWindow];
     
-    if ( !self.window && !self.superview )
+    if ( !self.window )
     {
         [self destroyCurrentAdIfNeeded];
     }


### PR DESCRIPTION
Fix native ads not being destroyed when unmounted on iOS.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Fix the issue of native ads not being destroyed on iOS when the native ad view is unmounted by modifying the condition within the `didMoveToWindow` method.

### Why are these changes being made?
The existing condition incorrectly checked for both the absence of a window and superview, leading to native ads not being destroyed correctly upon unmounting, which could cause potential memory leaks and unexpected behaviors in apps. Removing the superview condition ensures proper cleanup of native ads.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->