### PR TITLE
fix/adviewid_not_correctly_set_for_adview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Versions
 
+## x.x.x
+* Fix `adViewId` not correctly set for banners and MRECs (`<AdView/>`) on Android.
 ## 8.1.1
 * Make AppLovinMAXAdView public to support Amazon Integration. (https://github.com/AppLovin/AppLovin-MAX-React-Native/issues/407)
 * Enable compatibility with the Interop Layer.

--- a/android/src/main/java/com/applovin/reactnative/AppLovinMAXAdViewManager.java
+++ b/android/src/main/java/com/applovin/reactnative/AppLovinMAXAdViewManager.java
@@ -84,7 +84,7 @@ class AppLovinMAXAdViewManager
     }
 
     @ReactProp(name = "adViewId")
-    public void setAdFormat(final AppLovinMAXAdView view, final int adViewId)
+    public void setAdViewId(final AppLovinMAXAdView view, final int adViewId)
     {
         view.setAdViewId( adViewId );
     }


### PR DESCRIPTION
Fix adViewId not correctly set for AdView on Android.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Correct the method name from `setAdFormat` to `setAdViewId` to properly assign `adViewId` for `<AdView/>` components on Android.

### Why are these changes being made?

The previous implementation incorrectly named the method responsible for setting the `adViewId`, causing the id to not be set for banner and MREC ads. This fix ensures that `adViewId` is properly assigned, resolving ad view issues on the Android platform.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->