### PR TITLE
fix/revenue_not_correctly_set_for_adview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Versions
 
 ## x.x.x
+* Fix `AdRewardInfo` not correctly set for banners and MRECs (`<AdView/>`) on iOS.
 * Fix banners and MRECs (`<AdView/>`) not being destroyed when unmounted with the new architecture enabled on iOS.
 * Fix native ads not being destroyed when unmounted on iOS.
 * Fix `adViewId` not correctly set for banners and MRECs (`<AdView/>`) on Android.

--- a/ios/AppLovinMAXAdViewUIComponent.m
+++ b/ios/AppLovinMAXAdViewUIComponent.m
@@ -210,7 +210,7 @@
     if ( self.containerView )
     {
         NSMutableDictionary *body = [@{@"adViewId": @(self.hash)} mutableCopy];
-        [body addEntriesFromDictionary: [[AppLovinMAX shared] adInfoForAd: ad]];
+        [body addEntriesFromDictionary: [[AppLovinMAX shared] adRevenueInfoForAd: ad]];
         
         self.containerView.onAdRevenuePaidEvent(body);
     }


### PR DESCRIPTION
Fix AdRewardInfo not correctly set for AdView on iOS.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Fix the issue where `AdRewardInfo` was not correctly set for banner and MREC ads (`<AdView/>`) on iOS by updating the method to retrieve ad revenue info.

### Why are these changes being made?

The change addresses a bug that caused incorrect revenue data to be associated with ads on iOS. By updating the method to use `adRevenueInfoForAd` instead of `adInfoForAd`, the fix ensures that revenue information is accurately captured and shared.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->