### PR TITLE
fix/update_adinfo_to_include_additional_memebers_for_deprecating_adrevenueinfo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Versions
 
 ## x.x.x
+* Update `AdInfo` to include `adFormat`, `networkPlacement`, `revenuePrecision`, and `latencyMills`, deprecating `AdRevenueInfo`.
 * Fix banners and MRECs (`<AdView/>`) not being destroyed when unmounted with the new architecture enabled on iOS.
 * Fix native ads not being destroyed when unmounted on iOS.
 * Fix `adViewId` not correctly set for banners and MRECs (`<AdView/>`) on Android.

--- a/android/src/main/java/com/applovin/reactnative/AppLovinMAXAdViewUiComponent.java
+++ b/android/src/main/java/com/applovin/reactnative/AppLovinMAXAdViewUiComponent.java
@@ -250,10 +250,10 @@ class AppLovinMAXAdViewUiComponent
     {
         if ( containerView != null )
         {
-            WritableMap adRevenueInfo = AppLovinMAXModule.getInstance().getAdRevenueInfo( ad );
-            adRevenueInfo.putInt( "adViewId", hashCode() );
+            WritableMap adInfo = AppLovinMAXModule.getInstance().getAdInfo( ad );
+            adInfo.putInt( "adViewId", hashCode() );
 
-            sendReactNativeCallbackEvent( AppLovinMAXAdEvents.ON_AD_REVENUE_PAID_EVENT, adRevenueInfo );
+            sendReactNativeCallbackEvent( AppLovinMAXAdEvents.ON_AD_REVENUE_PAID_EVENT, adInfo );
         }
     }
 

--- a/android/src/main/java/com/applovin/reactnative/AppLovinMAXModule.java
+++ b/android/src/main/java/com/applovin/reactnative/AppLovinMAXModule.java
@@ -1391,7 +1391,7 @@ public class AppLovinMAXModule
             return;
         }
 
-        sendReactNativeEvent( name, getAdRevenueInfo( ad ) );
+        sendReactNativeEvent( name, getAdInfo( ad ) );
     }
 
     @Override
@@ -2053,11 +2053,16 @@ public class AppLovinMAXModule
     {
         WritableMap adInfo = Arguments.createMap();
         adInfo.putString( "adUnitId", ad.getAdUnitId() );
-        adInfo.putString( "creativeId", AppLovinSdkUtils.isValidString( ad.getCreativeId() ) ? ad.getCreativeId() : "" );
+        adInfo.putString( "adFormat", ad.getFormat().getLabel() );
         adInfo.putString( "networkName", ad.getNetworkName() );
+        adInfo.putString( "networkPlacement", ad.getNetworkPlacement() );
+
+        adInfo.putString( "creativeId", AppLovinSdkUtils.isValidString( ad.getCreativeId() ) ? ad.getCreativeId() : "" );
         adInfo.putString( "placement", AppLovinSdkUtils.isValidString( ad.getPlacement() ) ? ad.getPlacement() : "" );
         adInfo.putDouble( "revenue", ad.getRevenue() );
+        adInfo.putString( "revenuePrecision", ad.getRevenuePrecision() );
         adInfo.putMap( "waterfall", createAdWaterfallInfo( ad.getWaterfall() ) );
+        adInfo.putDouble( "latencyMillis", ad.getRequestLatencyMillis() );
         adInfo.putString( "dspName", AppLovinSdkUtils.isValidString( ad.getDspName() ) ? ad.getDspName() : "" );
 
         WritableMap sizeObject = Arguments.createMap();
@@ -2098,15 +2103,6 @@ public class AppLovinMAXModule
         info.putInt( "mediatedNetworkErrorCode", error.getMediatedNetworkErrorCode() );
         info.putString( "mediatedNetworkErrorMessage", error.getMediatedNetworkErrorMessage() );
         return info;
-    }
-
-    public WritableMap getAdRevenueInfo(final MaxAd ad)
-    {
-        WritableMap adInfo = getAdInfo( ad );
-        adInfo.putString( "networkPlacement", ad.getNetworkPlacement() );
-        adInfo.putString( "revenuePrecision", ad.getRevenuePrecision() );
-        adInfo.putString( "countryCode", sdkConfiguration.getCountryCode() );
-        return adInfo;
     }
 
     private WritableMap getAdUnitInfo(final String adUnitId)

--- a/android/src/main/java/com/applovin/reactnative/AppLovinMAXNativeAdView.java
+++ b/android/src/main/java/com/applovin/reactnative/AppLovinMAXNativeAdView.java
@@ -227,8 +227,8 @@ public class AppLovinMAXNativeAdView
     @Override
     public void onAdRevenuePaid(@NonNull final MaxAd ad)
     {
-        WritableMap adRevenueInfo = AppLovinMAXModule.getInstance().getAdRevenueInfo( ad );
-        reactContext.getJSModule( RCTEventEmitter.class ).receiveEvent( getId(), AppLovinMAXAdEvents.ON_AD_REVENUE_PAID_EVENT, adRevenueInfo );
+        WritableMap adInfo = AppLovinMAXModule.getInstance().getAdInfo( ad );
+        reactContext.getJSModule( RCTEventEmitter.class ).receiveEvent( getId(), AppLovinMAXAdEvents.ON_AD_REVENUE_PAID_EVENT, adInfo );
     }
 
     /// Native Ad Component Methods

--- a/example/src/InterExample.tsx
+++ b/example/src/InterExample.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { useState, useEffect, useRef } from 'react';
 import { InterstitialAd } from 'react-native-applovin-max';
-import type { AdInfo, AdLoadFailedInfo, AdRevenueInfo } from 'react-native-applovin-max';
+import type { AdInfo, AdLoadFailedInfo } from 'react-native-applovin-max';
 import AppButton from './components/AppButton';
 
 const MAX_EXPONENTIAL_RETRY_COUNT = 6;
@@ -68,7 +68,7 @@ const InterExample = ({ adUnitId, isInitialized, log }: Props) => {
             setAdLoadState(AdLoadState.notLoaded);
             log('Interstitial ad hidden');
         });
-        InterstitialAd.addAdRevenuePaidListener((adInfo: AdRevenueInfo) => {
+        InterstitialAd.addAdRevenuePaidListener((adInfo: AdInfo) => {
             log('Interstitial ad revenue paid: ' + adInfo.revenue);
         });
     }, [adUnitId, log]);

--- a/example/src/NativeAdViewExample.tsx
+++ b/example/src/NativeAdViewExample.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { useState, useEffect, useRef } from 'react';
 import { StyleSheet, View, Platform } from 'react-native';
 import { NativeAdView, TitleView, AdvertiserView, BodyView, CallToActionView, IconView, OptionsView, MediaView, StarRatingView } from 'react-native-applovin-max';
-import type { AdInfo, AdLoadFailedInfo, AdRevenueInfo, NativeAdViewHandler } from 'react-native-applovin-max';
+import type { AdInfo, AdLoadFailedInfo, NativeAdViewHandler } from 'react-native-applovin-max';
 import AppButton from './components/AppButton';
 
 type Props = {
@@ -65,7 +65,7 @@ export const NativeAdViewExample = ({ adUnitId, isInitialized, log, isNativeAdSh
                         onAdClicked={(adInfo: AdInfo) => {
                             log('Native ad clicked on ' + adInfo.adUnitId);
                         }}
-                        onAdRevenuePaid={(adInfo: AdRevenueInfo) => {
+                        onAdRevenuePaid={(adInfo: AdInfo) => {
                             log('Native ad revenue paid: ' + adInfo.revenue);
                         }}
                     >

--- a/example/src/NativeBannerExample.tsx
+++ b/example/src/NativeBannerExample.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Platform, StyleSheet } from 'react-native';
 import { AdView, AdFormat } from 'react-native-applovin-max';
-import type { AdInfo, AdLoadFailedInfo, AdRevenueInfo, AdViewId } from 'react-native-applovin-max';
+import type { AdInfo, AdLoadFailedInfo, AdViewId } from 'react-native-applovin-max';
 import AppButton from './components/AppButton';
 
 type Props = {
@@ -45,7 +45,7 @@ const NativeBannerExample = ({ adUnitId, adViewId, isInitialized, log, isNativeU
                     onAdCollapsed={(adInfo: AdInfo) => {
                         log('Banner ad ( ' + adInfo.adViewId + ' ) collapsed');
                     }}
-                    onAdRevenuePaid={(adInfo: AdRevenueInfo) => {
+                    onAdRevenuePaid={(adInfo: AdInfo) => {
                         log('Banner ad ( ' + adInfo.adViewId + ' ) revenue paid: ' + adInfo.revenue);
                     }}
                 />

--- a/example/src/NativeMRecExample.tsx
+++ b/example/src/NativeMRecExample.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Platform, StyleSheet } from 'react-native';
 import { AdView, AdFormat } from 'react-native-applovin-max';
-import type { AdInfo, AdLoadFailedInfo, AdRevenueInfo, AdViewId } from 'react-native-applovin-max';
+import type { AdInfo, AdLoadFailedInfo, AdViewId } from 'react-native-applovin-max';
 import AppButton from './components/AppButton';
 
 type Props = {
@@ -45,7 +45,7 @@ const NativeMRecExample = ({ adUnitId, adViewId, isInitialized, log, isNativeUIM
                     onAdCollapsed={(adInfo: AdInfo) => {
                         log('MREC ad ( ' + adInfo.adViewId + ' ) collapsed');
                     }}
-                    onAdRevenuePaid={(adInfo: AdRevenueInfo) => {
+                    onAdRevenuePaid={(adInfo: AdInfo) => {
                         log('MREC ad ( ' + adInfo.adViewId + ' ) revenue paid: ' + adInfo.revenue);
                     }}
                 />

--- a/example/src/ProgrammaticBannerExample.tsx
+++ b/example/src/ProgrammaticBannerExample.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { useState, useEffect } from 'react';
 import { BannerAd, AdViewPosition } from 'react-native-applovin-max';
-import type { AdInfo, AdLoadFailedInfo, AdRevenueInfo } from 'react-native-applovin-max';
+import type { AdInfo, AdLoadFailedInfo } from 'react-native-applovin-max';
 import AppButton from './components/AppButton';
 
 type Props = {
@@ -32,7 +32,7 @@ const ProgrammaticBannerExample = ({ adUnitId, isInitialized, log, isNativeUIBan
         BannerAd.addAdCollapsedEventListener((/* adInfo: AdInfo */) => {
             log('Banner ad collapsed');
         });
-        BannerAd.addAdRevenuePaidListener((adInfo: AdRevenueInfo) => {
+        BannerAd.addAdRevenuePaidListener((adInfo: AdInfo) => {
             log('Banner ad revenue paid: ' + adInfo.revenue);
         });
     }, [log]);

--- a/example/src/ProgrammaticMRecExample.tsx
+++ b/example/src/ProgrammaticMRecExample.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { useState, useEffect } from 'react';
 import { MRecAd, AdViewPosition } from 'react-native-applovin-max';
-import type { AdInfo, AdLoadFailedInfo, AdRevenueInfo } from 'react-native-applovin-max';
+import type { AdInfo, AdLoadFailedInfo } from 'react-native-applovin-max';
 import AppButton from './components/AppButton';
 
 type Props = {
@@ -32,7 +32,7 @@ const ProgrammaticMRecExample = ({ adUnitId, isInitialized, log, isNativeUIMRecS
         MRecAd.addAdCollapsedEventListener((/* adInfo: AdInfo */) => {
             log('MRec ad collapsed');
         });
-        MRecAd.addAdRevenuePaidListener((adInfo: AdRevenueInfo) => {
+        MRecAd.addAdRevenuePaidListener((adInfo: AdInfo) => {
             log('MRec ad revenue paid: ' + adInfo.revenue);
         });
     }, [log]);

--- a/example/src/RewardedExample.tsx
+++ b/example/src/RewardedExample.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { useState, useEffect, useRef } from 'react';
 import { RewardedAd } from 'react-native-applovin-max';
-import type { AdInfo, AdLoadFailedInfo, AdRevenueInfo } from 'react-native-applovin-max';
+import type { AdInfo, AdLoadFailedInfo } from 'react-native-applovin-max';
 import AppButton from './components/AppButton';
 
 const MAX_EXPONENTIAL_RETRY_COUNT = 6;
@@ -71,7 +71,7 @@ const RewardedExample = ({ adUnitId, isInitialized, log }: Props) => {
         RewardedAd.addAdReceivedRewardEventListener((/* adInfo: AdRewardInfo */) => {
             log('Rewarded ad granted reward');
         });
-        RewardedAd.addAdRevenuePaidListener((adInfo: AdRevenueInfo) => {
+        RewardedAd.addAdRevenuePaidListener((adInfo: AdInfo) => {
             log('Rewarded ad revenue paid: ' + adInfo.revenue);
         });
     }, [adUnitId, log]);

--- a/ios/AppLovinMAX.h
+++ b/ios/AppLovinMAX.h
@@ -59,11 +59,6 @@ extern NSString *const ON_NATIVE_UI_COMPONENT_ADVIEW_AD_LOAD_FAILED_EVENT;
  */
 - (NSDictionary<NSString *, id> *)adDisplayFailedInfoForAd:(MAAd *)ad withError:(MAError *)error;
 
-/**
- * Returns a dictionay value of adRevenuInfo for the specified ad.
- */
-- (NSDictionary<NSString *, id> *)adRevenueInfoForAd:(MAAd *)ad;
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ios/AppLovinMAX.m
+++ b/ios/AppLovinMAX.m
@@ -1230,7 +1230,7 @@ RCT_EXPORT_METHOD(destroyNativeUIComponentAdView:(nonnull NSNumber *)adViewId
         return;
     }
     
-    [self sendReactNativeEventWithName: name body: [self adRevenueInfoForAd: ad]];
+    [self sendReactNativeEventWithName: name body: [self adInfoForAd: ad]];
 }
 
 - (void)didCompleteRewardedVideoForAd:(MAAd *)ad
@@ -1856,11 +1856,15 @@ RCT_EXPORT_METHOD(destroyNativeUIComponentAdView:(nonnull NSNumber *)adViewId
 - (NSDictionary<NSString *, id> *)adInfoForAd:(MAAd *)ad
 {
     return @{@"adUnitId" : ad.adUnitIdentifier,
-             @"creativeId" : ad.creativeIdentifier ?: @"",
+             @"adFormat" : ad.format.label,
              @"networkName" : ad.networkName,
+             @"networkPlacement" : ad.networkPlacement,
+             @"creativeId" : ad.creativeIdentifier ?: @"",
              @"placement" : ad.placement ?: @"",
              @"revenue" : @(ad.revenue),
+             @"revenuePrecision" : ad.revenuePrecision,
              @"waterfall": [self createAdWaterfallInfo: ad.waterfall],
+             @"latencyMillis" : @(ad.requestLatency * 1000),
              @"dspName" : ad.DSPName ?: @"",
              @"size" : @{@"width" : @(ad.size.width),
                          @"height" : @(ad.size.height)}
@@ -1889,15 +1893,6 @@ RCT_EXPORT_METHOD(destroyNativeUIComponentAdView:(nonnull NSNumber *)adViewId
                                    @"mediatedNetworkErrorCode" : @(error.mediatedNetworkErrorCode),
                                    @"mediatedNetworkErrorMessage" : error.mediatedNetworkErrorMessage} mutableCopy];
     [body addEntriesFromDictionary: [self adInfoForAd: ad]];
-    return body;
-}
-
-- (NSDictionary<NSString *, id> *)adRevenueInfoForAd:(MAAd *)ad
-{
-    NSMutableDictionary *body = [self adInfoForAd: ad].mutableCopy;
-    body[@"networkPlacement"] = ad.networkPlacement;
-    body[@"revenuePrecision"] = ad.revenuePrecision;
-    body[@"countryCode"] = self.sdk.configuration.countryCode;
     return body;
 }
 

--- a/ios/AppLovinMAXNativeAdView.m
+++ b/ios/AppLovinMAXNativeAdView.m
@@ -402,7 +402,7 @@
 
 - (void)didPayRevenueForAd:(MAAd *)ad
 {
-    self.onAdRevenuePaidEvent([[AppLovinMAX shared] adRevenueInfoForAd: ad]);
+    self.onAdRevenuePaidEvent([[AppLovinMAX shared] adInfoForAd: ad]);
 }
 
 - (void)destroyCurrentAdIfNeeded

--- a/src/AdView.tsx
+++ b/src/AdView.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { useEffect, useState, useRef, useCallback, useImperativeHandle, useReducer, forwardRef } from 'react';
 import { NativeModules, requireNativeComponent, StyleSheet, UIManager, findNodeHandle, useWindowDimensions, View } from 'react-native';
 import type { ViewProps, ViewStyle, StyleProp, NativeMethods, DimensionValue } from 'react-native';
-import type { AdDisplayFailedInfo, AdInfo, AdLoadFailedInfo, AdRevenueInfo } from './types/AdInfo';
+import type { AdDisplayFailedInfo, AdInfo, AdLoadFailedInfo } from './types/AdInfo';
 import type { AdNativeEvent } from './types/AdEvent';
 import type { AdViewProps, AdViewHandler, NativeUIComponentAdViewOptions, AdViewId } from './types/AdViewProps';
 import { addEventListener, removeEventListener } from './EventEmitter';
@@ -64,7 +64,7 @@ type AdViewNativeEvents = {
     onAdClickedEvent(event: AdNativeEvent<AdInfo>): void;
     onAdExpandedEvent(event: AdNativeEvent<AdInfo>): void;
     onAdCollapsedEvent(event: AdNativeEvent<AdInfo>): void;
-    onAdRevenuePaidEvent(event: AdNativeEvent<AdRevenueInfo>): void;
+    onAdRevenuePaidEvent(event: AdNativeEvent<AdInfo>): void;
 };
 
 const AdViewComponent = requireNativeComponent<AdViewProps & ViewProps & AdViewNativeEvents>('AppLovinMAXAdView');
@@ -272,7 +272,7 @@ export const AdView = forwardRef<AdViewHandler, AdViewProps & ViewProps>(functio
     );
 
     const onAdRevenuePaidEvent = useCallback(
-        (event: AdNativeEvent<AdRevenueInfo>) => {
+        (event: AdNativeEvent<AdInfo>) => {
             onAdRevenuePaid?.(event.nativeEvent);
         },
         [onAdRevenuePaid]

--- a/src/AppOpenAd.ts
+++ b/src/AppOpenAd.ts
@@ -1,6 +1,6 @@
 import { NativeModules } from 'react-native';
 import { addEventListener, removeEventListener } from './EventEmitter';
-import type { AdDisplayFailedInfo, AdInfo, AdLoadFailedInfo, AdRevenueInfo } from './types/AdInfo';
+import type { AdDisplayFailedInfo, AdInfo, AdLoadFailedInfo } from './types/AdInfo';
 import type { LocalExtraParameterValue } from './types/AdProps';
 import type { AppOpenAdType } from './types/AppOpenAd';
 
@@ -84,7 +84,7 @@ const removeAdHiddenEventListener = (): void => {
     removeEventListener(ON_APPOPEN_AD_HIDDEN_EVENT);
 };
 
-const addAdRevenuePaidListener = (listener: (adInfo: AdRevenueInfo) => void): void => {
+const addAdRevenuePaidListener = (listener: (adInfo: AdInfo) => void): void => {
     addEventListener(ON_APPOPEN_AD_REVENUE_PAID, listener);
 };
 

--- a/src/BannerAd.ts
+++ b/src/BannerAd.ts
@@ -1,6 +1,6 @@
 import { NativeModules } from 'react-native';
 import { addEventListener, removeEventListener } from './EventEmitter';
-import type { AdInfo, AdLoadFailedInfo, AdRevenueInfo } from './types/AdInfo';
+import type { AdInfo, AdLoadFailedInfo } from './types/AdInfo';
 import type { LocalExtraParameterValue } from './types/AdProps';
 import type { BannerAdType } from './types/BannerAd';
 import type { AdViewPosition } from './AdView';
@@ -101,7 +101,7 @@ const removeAdExpandedEventListener = (): void => {
     removeEventListener(ON_BANNER_AD_EXPANDED_EVENT);
 };
 
-const addAdRevenuePaidListener = (listener: (adInfo: AdRevenueInfo) => void): void => {
+const addAdRevenuePaidListener = (listener: (adInfo: AdInfo) => void): void => {
     addEventListener(ON_BANNER_AD_REVENUE_PAID, listener);
 };
 

--- a/src/InterstitialAd.ts
+++ b/src/InterstitialAd.ts
@@ -1,6 +1,6 @@
 import { NativeModules } from 'react-native';
 import { addEventListener, removeEventListener } from './EventEmitter';
-import type { AdDisplayFailedInfo, AdInfo, AdLoadFailedInfo, AdRevenueInfo } from './types/AdInfo';
+import type { AdDisplayFailedInfo, AdInfo, AdLoadFailedInfo } from './types/AdInfo';
 import type { LocalExtraParameterValue } from './types/AdProps';
 import type { InterstitialAdType } from './types/InterstitialAd';
 
@@ -84,7 +84,7 @@ const removeAdHiddenEventListener = (): void => {
     removeEventListener(ON_INTERSTITIAL_HIDDEN_EVENT);
 };
 
-const addAdRevenuePaidListener = (listener: (adInfo: AdRevenueInfo) => void): void => {
+const addAdRevenuePaidListener = (listener: (adInfo: AdInfo) => void): void => {
     addEventListener(ON_INTERSTITIAL_AD_REVENUE_PAID, listener);
 };
 

--- a/src/MRecAd.ts
+++ b/src/MRecAd.ts
@@ -1,6 +1,6 @@
 import { NativeModules } from 'react-native';
 import { addEventListener, removeEventListener } from './EventEmitter';
-import type { AdInfo, AdLoadFailedInfo, AdRevenueInfo } from './types/AdInfo';
+import type { AdInfo, AdLoadFailedInfo } from './types/AdInfo';
 import type { LocalExtraParameterValue } from './types/AdProps';
 import type { MRecAdType } from './types/MRecAd';
 import type { AdViewPosition } from './AdView';
@@ -94,7 +94,7 @@ const removeAdExpandedEventListener = (): void => {
     removeEventListener(ON_MREC_AD_EXPANDED_EVENT);
 };
 
-const addAdRevenuePaidListener = (listener: (adInfo: AdRevenueInfo) => void): void => {
+const addAdRevenuePaidListener = (listener: (adInfo: AdInfo) => void): void => {
     addEventListener(ON_MREC_AD_REVENUE_PAID, listener);
 };
 

--- a/src/RewardedAd.ts
+++ b/src/RewardedAd.ts
@@ -1,6 +1,6 @@
 import { NativeModules } from 'react-native';
 import { addEventListener, removeEventListener } from './EventEmitter';
-import type { AdDisplayFailedInfo, AdInfo, AdLoadFailedInfo, AdRevenueInfo, AdRewardInfo } from './types/AdInfo';
+import type { AdDisplayFailedInfo, AdInfo, AdLoadFailedInfo, AdRewardInfo } from './types/AdInfo';
 import type { LocalExtraParameterValue } from './types/AdProps';
 import type { RewardedAdType } from './types/RewardedAd';
 
@@ -85,7 +85,7 @@ const removeAdHiddenEventListener = (): void => {
     removeEventListener(ON_REWARDED_AD_HIDDEN_EVENT);
 };
 
-const addAdRevenuePaidListener = (listener: (adInfo: AdRevenueInfo) => void): void => {
+const addAdRevenuePaidListener = (listener: (adInfo: AdInfo) => void): void => {
     addEventListener(ON_REWARDED_AD_REVENUE_PAID, listener);
 };
 

--- a/src/nativeAd/NativeAdView.tsx
+++ b/src/nativeAd/NativeAdView.tsx
@@ -3,7 +3,7 @@ import { forwardRef, useContext, useImperativeHandle, useRef, useState, useEffec
 import { NativeModules, requireNativeComponent, UIManager, findNodeHandle, View } from 'react-native';
 import type { ViewProps } from 'react-native';
 import { NativeAdViewContext, NativeAdViewProvider } from './NativeAdViewProvider';
-import type { AdInfo, AdLoadFailedInfo, AdRevenueInfo } from '../types/AdInfo';
+import type { AdInfo, AdLoadFailedInfo } from '../types/AdInfo';
 import type { AdNativeEvent } from '../types/AdEvent';
 import type { NativeAd } from '../types/NativeAd';
 import type { NativeAdViewHandler, NativeAdViewProps } from '../types/NativeAdViewProps';
@@ -15,7 +15,7 @@ type NativeAdViewNativeEvents = {
     onAdLoadedEvent(event: { nativeEvent: { nativeAd: NativeAd; adInfo: AdInfo } }): void;
     onAdLoadFailedEvent(event: AdNativeEvent<AdLoadFailedInfo>): void;
     onAdClickedEvent(event: AdNativeEvent<AdInfo>): void;
-    onAdRevenuePaidEvent(event: AdNativeEvent<AdRevenueInfo>): void;
+    onAdRevenuePaidEvent(event: AdNativeEvent<AdInfo>): void;
 };
 
 const NativeAdViewComponent = requireNativeComponent<NativeAdViewProps & ViewProps & NativeAdViewNativeEvents>('AppLovinMAXNativeAdView');
@@ -140,7 +140,7 @@ const NativeAdViewImpl = forwardRef<NativeAdViewHandler, NativeAdViewProps & Vie
     );
 
     const onAdRevenuePaidEvent = useCallback(
-        (event: AdNativeEvent<AdRevenueInfo>) => {
+        (event: AdNativeEvent<AdInfo>) => {
             onAdRevenuePaid?.(event.nativeEvent);
         },
         [onAdRevenuePaid]

--- a/src/types/AdEvent.ts
+++ b/src/types/AdEvent.ts
@@ -1,6 +1,6 @@
-import type { AdInfo, AdLoadFailedInfo, AdDisplayFailedInfo, AdRevenueInfo, AdRewardInfo } from './AdInfo';
+import type { AdInfo, AdLoadFailedInfo, AdDisplayFailedInfo, AdRewardInfo } from './AdInfo';
 
-export type AdEventObject = AdInfo | AdLoadFailedInfo | AdDisplayFailedInfo | AdRevenueInfo | AdRewardInfo;
+export type AdEventObject = AdInfo | AdLoadFailedInfo | AdDisplayFailedInfo | AdRewardInfo;
 
 /**
  * Defines a generic event listener for the pragrammatic methods to receive an event from the native

--- a/src/types/AdInfo.ts
+++ b/src/types/AdInfo.ts
@@ -11,6 +11,11 @@ export type AdInfo = {
     adUnitId: string;
 
     /**
+     * The format of this ad.
+     */
+    adFormat: string;
+
+    /**
      * The unique ID of the native UI component AdView.
      */
     adViewId?: AdViewId;
@@ -31,6 +36,11 @@ export type AdInfo = {
     networkName: string;
 
     /**
+     * The ad network placement for which this ad was loaded.
+     */
+    networkPlacement: string;
+
+    /**
      * The placement name that you assign when you integrate each ad format, for granular reporting
      * in postbacks.
      */
@@ -43,9 +53,26 @@ export type AdInfo = {
     revenue: number;
 
     /**
+     * The precision of the revenue value for this ad.
+     *
+     * Possible values are:
+     * - "publisher_defined" - If the revenue is the price assigned to the line item by the publisher.
+     * - "exact" - If the revenue is the resulting price of a real-time auction.
+     * - "estimated" - If the revenue is the price obtained by auto-CPM.
+     * - "undefined" - If we do not have permission from the ad network to share impression-level data.
+     * - "" - An empty string, if revenue and precision are not valid (for example, in test mode).
+     */
+    revenuePrecision: string;
+
+    /**
      * The DSP network that provides the loaded ad when the ad is served through AppLovin Exchange.
      */
     dspName?: string | null;
+
+    /**
+     * The latency of the mediation ad load request in milliseconds.
+     */
+    latencyMillis: number;
 
     /**
      * The underlying waterfall of ad responses.
@@ -149,33 +176,6 @@ export type AdRewardInfo = AdInfo & {
      * The rewarded amount.
      */
     rewardAmount: string;
-};
-
-/**
- * Represents revenue given to the publisher.
- */
-export type AdRevenueInfo = AdInfo & {
-    /**
-     * The ad network placement for which this ad was loaded.
-     */
-    networkPlacement: string;
-
-    /**
-     * The precision of the revenue value for this ad.
-     *
-     * Possible values are:
-     * - "publisher_defined" - If the revenue is the price assigned to the line item by the publisher.
-     * - "exact" - If the revenue is the resulting price of a real-time auction.
-     * - "estimated" - If the revenue is the price obtained by auto-CPM.
-     * - "undefined" - If we do not have permission from the ad network to share impression-level data.
-     * - "" - An empty string, if revenue and precision are not valid (for example, in test mode).
-     */
-    revenuePrecision: string;
-
-    /**
-     * The current country code where the ad was shown.
-     */
-    countryCode: string;
 };
 
 /**

--- a/src/types/AdProps.ts
+++ b/src/types/AdProps.ts
@@ -1,4 +1,4 @@
-import type { AdDisplayFailedInfo, AdInfo, AdLoadFailedInfo, AdRevenueInfo } from './AdInfo';
+import type { AdDisplayFailedInfo, AdInfo, AdLoadFailedInfo } from './AdInfo';
 
 /**
  * Local extra parameters can be of type: string, number, boolean, array, map, and null.
@@ -60,5 +60,5 @@ export type AdProps = {
     /**
      * A callback fuction that {@link AdView} or {@link NativeAdView} fires when it pays ad revenue to the publisher.
      */
-    onAdRevenuePaid?: (adInfo: AdRevenueInfo) => void;
+    onAdRevenuePaid?: (adInfo: AdInfo) => void;
 };

--- a/src/types/FullscreenAd.ts
+++ b/src/types/FullscreenAd.ts
@@ -1,5 +1,5 @@
 import type { AdEventListener } from './AdEvent';
-import type { AdInfo, AdLoadFailedInfo, AdRevenueInfo, AdDisplayFailedInfo } from './AdInfo';
+import type { AdInfo, AdLoadFailedInfo, AdDisplayFailedInfo } from './AdInfo';
 import type { LocalExtraParameterValue } from './AdProps';
 
 /**
@@ -126,15 +126,15 @@ export type FullscreenAdType = {
     removeAdHiddenEventListener(): void;
 
     /**
-     * Adds the specified event listener to receive {@link AdRevenueInfo} when a full-screen ad
+     * Adds the specified event listener to receive {@link AdInfo} when a full-screen ad
      * pays ad revenue to the publisher.
      *
      * @param listener Listener to be notified.
      */
-    addAdRevenuePaidListener(listener: AdEventListener<AdRevenueInfo>): void;
+    addAdRevenuePaidListener(listener: AdEventListener<AdInfo>): void;
 
     /**
-     * Removes the event listener to receive {@link AdRevenueInfo} when a full-screen ad pays
+     * Removes the event listener to receive {@link AdInfo} when a full-screen ad pays
      * ad revenue to the publisher.
      */
     removeAdRevenuePaidListener(): void;

--- a/src/types/ViewAd.ts
+++ b/src/types/ViewAd.ts
@@ -1,5 +1,5 @@
 import type { AdEventListener } from './AdEvent';
-import type { AdInfo, AdLoadFailedInfo, AdRevenueInfo } from './AdInfo';
+import type { AdInfo, AdLoadFailedInfo } from './AdInfo';
 import type { LocalExtraParameterValue } from './AdProps';
 import type { AdViewPosition } from '../AdView';
 
@@ -147,15 +147,15 @@ export type ViewAdType = {
     removeAdExpandedEventListener(): void;
 
     /**
-     * Adds the specified event listener to receive {@link AdRevenueInfo} when a view-base ad pays
+     * Adds the specified event listener to receive {@link AdInfo} when a view-base ad pays
      * ad revenue to the publisher.
      *
      * @param listener Listener to be notified.
      */
-    addAdRevenuePaidListener(listener: AdEventListener<AdRevenueInfo>): void;
+    addAdRevenuePaidListener(listener: AdEventListener<AdInfo>): void;
 
     /**
-     * Removes the event listener to receive {@link AdRevenueInfo} when when a view-base ad pays ad
+     * Removes the event listener to receive {@link AdInfo} when when a view-base ad pays ad
      * revenue to the publisher.
      */
     removeAdRevenuePaidListener(): void;


### PR DESCRIPTION
Update `AdInfo` to include `adFormat`, `networkPlacement`, `revenuePrecision`, and `latencyMills`, deprecating `AdRevenueInfo`.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Update `AdInfo` to include `adFormat`, `networkPlacement`, `revenuePrecision`, and `latencyMillis`, and deprecate `AdRevenueInfo`.

### Why are these changes being made?

These changes streamline the ad information structure by consolidating necessary fields into `AdInfo` and removing the now redundant `AdRevenueInfo`. This simplification improves the maintainability and clarity of the codebase while ensuring all necessary ad details are captured in a single structure.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->