### PR TITLE
feat/depend_on_Android_SDK_13.2.0_and_iOS_SDK_13.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Versions
 
 ## x.x.x
+* Depend on Android SDK 13.2.0 and iOS SDK 13.2.0.
 * Fix a type error from applying text-specific props to `StarRatingView`.
 ## 9.0.0
 * Add support for Fabric Native Components in `AdView`s and `NativeAdView`s.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -96,6 +96,6 @@ dependencies {
   //noinspection GradleDynamicVersion
   implementation "com.facebook.react:react-native:0.75.4"
 
-  implementation "com.applovin:applovin-sdk:13.1.0"
+  implementation "com.applovin:applovin-sdk:13.2.0"
 }
 

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - AppLovinSDK (13.1.0)
+  - AppLovinSDK (13.2.0)
   - boost (1.84.0)
   - DoubleConversion (1.1.6)
   - FBLazyVector (0.76.2)
@@ -1244,7 +1244,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - Yoga
   - react-native-applovin-max (9.0.0):
-    - AppLovinSDK (= 13.1.0)
+    - AppLovinSDK (= 13.2.0)
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1740,7 +1740,7 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  AppLovinSDK: 539a0178d8bef4d68b2551a93526e0c1bba06cb2
+  AppLovinSDK: 1eb88a82b4feea9f3696ce9cc1e3343c4997ee12
   boost: 1dca942403ed9342f98334bf4c3621f011aa7946
   DoubleConversion: f16ae600a246532c4020132d54af21d0ddb2a385
   FBLazyVector: bc70dcb22ad30ce734a7cce7210791dc737e230f
@@ -1776,7 +1776,7 @@ SPEC CHECKSUMS:
   React-logger: 81d58ca6f1d93fca9a770bda6cc1c4fbfcc99c9c
   React-Mapbuffer: 726951e68f4bb1c2513d322f2548798b2a3d628d
   React-microtasksnativemodule: bc55596cbf40957f5099bc495f1a06f459d0be88
-  react-native-applovin-max: b13bd9cc2bccedf3f33da27919fd1d13e3e97701
+  react-native-applovin-max: 78b2d413cfd33cae32173cc07d236b908b98bad0
   React-nativeconfig: 470fce6d871c02dc5eff250a362d56391b7f52d6
   React-NativeModulesApple: 6297fc3136c1fd42884795c51d7207de6312b606
   React-perflogger: f2c94413cfad44817c96cab33753831e73f0d0dd

--- a/react-native-applovin-max.podspec
+++ b/react-native-applovin-max.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
 
   s.source_files = "ios/AppLovinMAX*.{h,mm}"
 
-  s.dependency "AppLovinSDK", "13.1.0"
+  s.dependency "AppLovinSDK", "13.2.0"
 
   # Use install_modules_dependencies helper to install the dependencies if React Native version >=0.71.0.
   # See https://github.com/facebook/react-native/blob/febf6b7f33fdb4904669f99d795eba4c0f95d7bf/scripts/cocoapods/new_architecture.rb#L79.


### PR DESCRIPTION
Depend on Android SDK 13.2.0 and iOS SDK 13.2.0.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Upgrade dependencies to Android SDK 13.2.0 and iOS SDK 13.2.0.

### Why are these changes being made?

To ensure compatibility with the latest features and improvements provided in Android SDK 13.2.0 and iOS SDK 13.2.0. This update addresses potential compatibility issues and takes advantage of enhancements in the newer SDK versions.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->