### PR TITLE
fix/line_mrec_not_shown_on_android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Versions
 
 ## x.x.x
+* Fix LINE MREC (`<AdView/>`) not shown on Android.
 * Depend on Android SDK 13.2.0 and iOS SDK 13.2.0.
 * Fix a type error from applying text-specific props to `StarRatingView`.
 ## 9.0.0

--- a/android/src/main/java/com/applovin/reactnative/AppLovinMAXAdView.java
+++ b/android/src/main/java/com/applovin/reactnative/AppLovinMAXAdView.java
@@ -241,7 +241,7 @@ public class AppLovinMAXAdView
 
         if ( uiComponent != null )
         {
-            uiComponent.measureAndLayout( 0, 0, getWidth(), getHeight() );
+            postDelayed( () -> uiComponent.measureAndLayout( 0, 0, getWidth(), getHeight() ), 500 );
         }
     }
 

--- a/example/src/NativeBannerExample.tsx
+++ b/example/src/NativeBannerExample.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Platform, StyleSheet } from 'react-native';
+import { Platform, StyleSheet, View } from 'react-native';
 import { AdView, AdFormat } from 'react-native-applovin-max';
 import type { AdInfo, AdLoadFailedInfo, AdViewId } from 'react-native-applovin-max';
 import AppButton from './components/AppButton';
@@ -25,48 +25,54 @@ const NativeBannerExample = ({ adUnitId, adViewId, isInitialized, log, isNativeU
                 }}
             />
             {isNativeUIBannerShowing && (
-                <AdView
-                    adUnitId={adUnitId}
-                    adViewId={adViewId}
-                    adFormat={AdFormat.BANNER}
-                    style={styles.banner}
-                    onAdLoaded={(adInfo: AdInfo) => {
-                        log('Banner ad ( ' + adInfo.adViewId + ' ) loaded from ' + adInfo.networkName);
-                    }}
-                    onAdLoadFailed={(errorInfo: AdLoadFailedInfo) => {
-                        log('Banner ad ( ' + errorInfo.adViewId + ' ) failed to load with error code ' + errorInfo.code + ' and message: ' + errorInfo.message);
-                    }}
-                    onAdClicked={(adInfo: AdInfo) => {
-                        log('Banner ad ( ' + adInfo.adViewId + ' ) clicked');
-                    }}
-                    onAdExpanded={(adInfo: AdInfo) => {
-                        log('Banner ad ( ' + adInfo.adViewId + ' ) expanded');
-                    }}
-                    onAdCollapsed={(adInfo: AdInfo) => {
-                        log('Banner ad ( ' + adInfo.adViewId + ' ) collapsed');
-                    }}
-                    onAdRevenuePaid={(adInfo: AdInfo) => {
-                        log('Banner ad ( ' + adInfo.adViewId + ' ) revenue paid: ' + adInfo.revenue);
-                    }}
-                />
+                <View style={styles.container}>
+                    <AdView
+                        adUnitId={adUnitId}
+                        adViewId={adViewId}
+                        adFormat={AdFormat.BANNER}
+                        style={styles.banner}
+                        onAdLoaded={(adInfo: AdInfo) => {
+                            log('Banner ad ( ' + adInfo.adViewId + ' ) loaded from ' + adInfo.networkName);
+                        }}
+                        onAdLoadFailed={(errorInfo: AdLoadFailedInfo) => {
+                            log('Banner ad ( ' + errorInfo.adViewId + ' ) failed to load with error code ' + errorInfo.code + ' and message: ' + errorInfo.message);
+                        }}
+                        onAdClicked={(adInfo: AdInfo) => {
+                            log('Banner ad ( ' + adInfo.adViewId + ' ) clicked');
+                        }}
+                        onAdExpanded={(adInfo: AdInfo) => {
+                            log('Banner ad ( ' + adInfo.adViewId + ' ) expanded');
+                        }}
+                        onAdCollapsed={(adInfo: AdInfo) => {
+                            log('Banner ad ( ' + adInfo.adViewId + ' ) collapsed');
+                        }}
+                        onAdRevenuePaid={(adInfo: AdInfo) => {
+                            log('Banner ad ( ' + adInfo.adViewId + ' ) revenue paid: ' + adInfo.revenue);
+                        }}
+                    />
+                </View>
             )}
         </>
     );
 };
 
 const styles = StyleSheet.create({
-    banner: {
-        // Set background color for banners to be fully functional
-        backgroundColor: '#000000',
-        position: 'absolute',
+    container: {
         width: '100%',
-        // Automatically sized to 50 on phones and 90 on tablets. When adaptiveBannerEnabled is on,
-        // sized to AppLovinMAX.getAdaptiveBannerHeightForWidth().
-        height: 'auto',
+        position: 'absolute',
         bottom: Platform.select({
             ios: 36, // For bottom safe area
             android: 0,
         }),
+        // Set background color for banners to be fully functional
+        backgroundColor: '#000000',
+    },
+    banner: {
+        alignSelf: 'center',
+        width: 'auto',
+        // Automatically sized to 50 on phones and 90 on tablets. When adaptiveBannerEnabled is on,
+        // sized to AppLovinMAX.getAdaptiveBannerHeightForWidth().
+        height: 'auto',
     },
 });
 

--- a/example/src/NativeMRecExample.tsx
+++ b/example/src/NativeMRecExample.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Platform, StyleSheet } from 'react-native';
+import { Platform, StyleSheet, View } from 'react-native';
 import { AdView, AdFormat } from 'react-native-applovin-max';
 import type { AdInfo, AdLoadFailedInfo, AdViewId } from 'react-native-applovin-max';
 import AppButton from './components/AppButton';
@@ -25,44 +25,50 @@ const NativeMRecExample = ({ adUnitId, adViewId, isInitialized, log, isNativeUIM
                 }}
             />
             {isNativeUIMRecShowing && (
-                <AdView
-                    adUnitId={adUnitId}
-                    adFormat={AdFormat.MREC}
-                    adViewId={adViewId}
-                    style={styles.mrec}
-                    onAdLoaded={(adInfo: AdInfo) => {
-                        log('MREC ad ( ' + adInfo.adViewId + ' ) loaded from ' + adInfo.networkName);
-                    }}
-                    onAdLoadFailed={(errorInfo: AdLoadFailedInfo) => {
-                        log('MREC ad ( ' + errorInfo.adViewId + ' ) failed to load with error code ' + errorInfo.code + ' and message: ' + errorInfo.message);
-                    }}
-                    onAdClicked={(adInfo: AdInfo) => {
-                        log('MREC ad ( ' + adInfo.adViewId + ' ) clicked');
-                    }}
-                    onAdExpanded={(adInfo: AdInfo) => {
-                        log('MREC ad ( ' + adInfo.adViewId + ' ) expanded');
-                    }}
-                    onAdCollapsed={(adInfo: AdInfo) => {
-                        log('MREC ad ( ' + adInfo.adViewId + ' ) collapsed');
-                    }}
-                    onAdRevenuePaid={(adInfo: AdInfo) => {
-                        log('MREC ad ( ' + adInfo.adViewId + ' ) revenue paid: ' + adInfo.revenue);
-                    }}
-                />
+                <View style={styles.container}>
+                    <AdView
+                        adUnitId={adUnitId}
+                        adFormat={AdFormat.MREC}
+                        adViewId={adViewId}
+                        style={styles.mrec}
+                        onAdLoaded={(adInfo: AdInfo) => {
+                            log('MREC ad ( ' + adInfo.adViewId + ' ) loaded from ' + adInfo.networkName);
+                        }}
+                        onAdLoadFailed={(errorInfo: AdLoadFailedInfo) => {
+                            log('MREC ad ( ' + errorInfo.adViewId + ' ) failed to load with error code ' + errorInfo.code + ' and message: ' + errorInfo.message);
+                        }}
+                        onAdClicked={(adInfo: AdInfo) => {
+                            log('MREC ad ( ' + adInfo.adViewId + ' ) clicked');
+                        }}
+                        onAdExpanded={(adInfo: AdInfo) => {
+                            log('MREC ad ( ' + adInfo.adViewId + ' ) expanded');
+                        }}
+                        onAdCollapsed={(adInfo: AdInfo) => {
+                            log('MREC ad ( ' + adInfo.adViewId + ' ) collapsed');
+                        }}
+                        onAdRevenuePaid={(adInfo: AdInfo) => {
+                            log('MREC ad ( ' + adInfo.adViewId + ' ) revenue paid: ' + adInfo.revenue);
+                        }}
+                    />
+                </View>
             )}
         </>
     );
 };
 
 const styles = StyleSheet.create({
-    mrec: {
-        position: 'absolute',
+    container: {
         width: '100%',
-        height: 'auto',
+        position: 'absolute',
         bottom: Platform.select({
             ios: 36, // For bottom safe area
             android: 0,
         }),
+    },
+    mrec: {
+        alignSelf: 'center',
+        width: 'auto',
+        height: 'auto',
     },
 });
 

--- a/example/src/ScrolledAdViewExample.tsx
+++ b/example/src/ScrolledAdViewExample.tsx
@@ -157,7 +157,8 @@ const styles = StyleSheet.create({
         fontSize: 20,
     },
     adview: {
-        width: '100%',
+        alignSelf: 'center',
+        width: 'auto',
         height: 'auto',
     },
     placeholder: {


### PR DESCRIPTION
Fix LINE MREC not shown on Android.  Used the same trick for `NativeAdView`.

Also, update the example for better handling of `Adview` when placing it in the bottom of the screen.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Wrap AdView components in Android `<View>` containers and alter measurement logic to fix the issue where LINE MREC ads are not shown.

### Why are these changes being made?
These changes are made to address a bug on Android where LINE MREC ads are not displaying correctly. Encapsulating AdView components within `<View>` allows for improved layout handling, ensuring the ads are positioned and displayed properly. Additionally, using `postDelayed` for measurement ensures the layout is computed after any view measurement, aligning with the rendering lifecycle of React Native.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->