### PR TITLE
feat/use_max_ad_view_configuration_for_adaptive_banners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Versions
 
+## x.x.x
+* Add optional `isAdaptive` flag to `BannerAd.createAd()` and `preloadNativeUIComponentAdView()` to enable adaptive banners (default: true).
 ## 9.1.0
 * Depend on Android SDK 13.2.0 and iOS SDK 13.2.0.
 * Fix LINE MREC (`<AdView/>`) not shown on Android.

--- a/android/src/main/java/com/applovin/reactnative/AppLovinMAXAdView.java
+++ b/android/src/main/java/com/applovin/reactnative/AppLovinMAXAdView.java
@@ -76,6 +76,7 @@ public class AppLovinMAXAdView
 
     public static void preloadNativeUIComponentAdView(final String adUnitId,
                                                       final MaxAdFormat adFormat,
+                                                      final boolean isAdaptive,
                                                       @Nullable final String placement,
                                                       @Nullable final String customData,
                                                       @Nullable final Map<String, Object> extraParameters,
@@ -83,7 +84,7 @@ public class AppLovinMAXAdView
                                                       final Promise promise,
                                                       final ReactContext context)
     {
-        AppLovinMAXAdViewUiComponent preloadedUiComponent = new AppLovinMAXAdViewUiComponent( adUnitId, adFormat, context );
+        AppLovinMAXAdViewUiComponent preloadedUiComponent = new AppLovinMAXAdViewUiComponent( adUnitId, adFormat, isAdaptive, context );
         preloadedUiComponentInstances.put( preloadedUiComponent.hashCode(), preloadedUiComponent );
 
         preloadedUiComponent.setPlacement( placement );
@@ -189,11 +190,6 @@ public class AppLovinMAXAdView
     public void setAdaptiveBannerEnabled(final boolean enabled)
     {
         adaptiveBannerEnabled = enabled;
-
-        if ( uiComponent != null )
-        {
-            uiComponent.setAdaptiveBannerEnabled( adaptiveBannerEnabled );
-        }
     }
 
     public void setAutoRefreshEnabled(final boolean enabled)
@@ -314,14 +310,13 @@ public class AppLovinMAXAdView
                 {
                     AppLovinMAXModuleImpl.d( "Mounting the preloaded AdView (" + adViewId + ") for Ad Unit ID " + adUnitId );
 
-                    uiComponent.setAdaptiveBannerEnabled( adaptiveBannerEnabled );
                     uiComponent.setAutoRefreshEnabled( autoRefreshEnabled );
                     uiComponent.attachAdView( AppLovinMAXAdView.this );
                     return;
                 }
             }
 
-            uiComponent = new AppLovinMAXAdViewUiComponent( adUnitId, adFormat, reactContext );
+            uiComponent = new AppLovinMAXAdViewUiComponent( adUnitId, adFormat, adaptiveBannerEnabled, reactContext );
             adViewId = uiComponent.hashCode();
             uiComponentInstances.put( adViewId, uiComponent );
 
@@ -331,7 +326,6 @@ public class AppLovinMAXAdView
             uiComponent.setCustomData( customData );
             uiComponent.setExtraParameters( extraParameters );
             uiComponent.setLocalExtraParameters( localExtraParameters );
-            uiComponent.setAdaptiveBannerEnabled( adaptiveBannerEnabled );
             uiComponent.setAutoRefreshEnabled( autoRefreshEnabled );
 
             uiComponent.attachAdView( AppLovinMAXAdView.this );

--- a/android/src/main/java/com/applovin/reactnative/AppLovinMAXAdViewUiComponent.java
+++ b/android/src/main/java/com/applovin/reactnative/AppLovinMAXAdViewUiComponent.java
@@ -7,6 +7,7 @@ import com.applovin.mediation.MaxAdFormat;
 import com.applovin.mediation.MaxAdListener;
 import com.applovin.mediation.MaxAdRevenueListener;
 import com.applovin.mediation.MaxAdViewAdListener;
+import com.applovin.mediation.MaxAdViewConfiguration;
 import com.applovin.mediation.MaxError;
 import com.applovin.mediation.ads.MaxAdView;
 import com.facebook.react.bridge.ReactContext;
@@ -28,15 +29,28 @@ class AppLovinMAXAdViewUiComponent
     @Nullable
     private AppLovinMAXAdView containerView;
 
-    public AppLovinMAXAdViewUiComponent(final String adUnitId, final MaxAdFormat adFormat, final ReactContext context)
+    public AppLovinMAXAdViewUiComponent(final String adUnitId, final MaxAdFormat adFormat, final boolean isAdaptive, final ReactContext context)
     {
         reactContext = context;
         surfaceId = UIManagerHelper.getSurfaceId( context );
 
-        adView = new MaxAdView( adUnitId, adFormat, AppLovinMAXModuleImpl.getInstance().getSdk(), context );
+        MaxAdViewConfiguration.Builder builder = MaxAdViewConfiguration.builder();
+
+        if ( adFormat.isBannerOrLeaderAd() )
+        {
+            if ( isAdaptive )
+            {
+                builder.setAdaptiveType( MaxAdViewConfiguration.AdaptiveType.ANCHORED );
+            }
+            else
+            {
+                builder.setAdaptiveType( MaxAdViewConfiguration.AdaptiveType.NONE );
+            }
+        }
+
+        adView = new MaxAdView( adUnitId, adFormat, builder.build() );
         adView.setListener( this );
         adView.setRevenueListener( this );
-        adView.setExtraParameter( "adaptive_banner", "true" );
 
         // Set this extra parameter to work around a SDK bug that ignores calls to stopAutoRefresh()
         adView.setExtraParameter( "allow_pause_auto_refresh_immediately", "true" );
@@ -62,11 +76,6 @@ class AppLovinMAXAdViewUiComponent
     public void setCustomData(@Nullable final String value)
     {
         adView.setCustomData( value );
-    }
-
-    public void setAdaptiveBannerEnabled(final boolean enabled)
-    {
-        adView.setExtraParameter( "adaptive_banner", Boolean.toString( enabled ) );
     }
 
     public void setAutoRefreshEnabled(final boolean enabled)

--- a/android/src/main/java/com/applovin/reactnative/AppLovinMAXModuleImpl.java
+++ b/android/src/main/java/com/applovin/reactnative/AppLovinMAXModuleImpl.java
@@ -1583,7 +1583,7 @@ public class AppLovinMAXModuleImpl
             }
             else if ( "adaptive_banner".equalsIgnoreCase( key ) )
             {
-                e( "Setting adaptive banners via extra parameters is discouraged. Please use the `BannerAd.createAd(adUnitId: string, position: AdViewPosition, xOffset: number, yOffset: number, isAdaptive: boolean)` API for proper adaptive banner configuration." );
+                e( "Setting adaptive banners via extra parameters is deprecated and will be removed in a future plugin version. Please use the BannerAd.createAd(adUnitId: string, position: AdViewPosition, xOffset: number, yOffset: number, isAdaptive: boolean) API to properly configure adaptive banners." );
 
                 boolean useAdaptiveBannerAdSize = Boolean.parseBoolean( value );
                 if ( useAdaptiveBannerAdSize )

--- a/android/src/newarch/com/applovin/reactnative/AppLovinMAXModule.java
+++ b/android/src/newarch/com/applovin/reactnative/AppLovinMAXModule.java
@@ -175,15 +175,15 @@ public class AppLovinMAXModule
     }
 
     @Override
-    public void createBanner(final String adUnitId, final String position)
+    public void createBanner(final String adUnitId, final String position, final boolean isAdaptive)
     {
-        impl.createBanner( adUnitId, position );
+        impl.createBanner( adUnitId, position, isAdaptive );
     }
 
     @Override
-    public void createBannerWithOffsets(final String adUnitId, final String position, final double xOffset, final double yOffset)
+    public void createBannerWithOffsets(final String adUnitId, final String position, final double xOffset, final double yOffset, final boolean isAdaptive)
     {
-        impl.createBannerWithOffsets( adUnitId, position, (float) xOffset, (float) yOffset );
+        impl.createBannerWithOffsets( adUnitId, position, (float) xOffset, (float) yOffset, isAdaptive );
     }
 
     @Override
@@ -427,9 +427,9 @@ public class AppLovinMAXModule
     }
 
     @Override
-    public void preloadNativeUIComponentAdView(final String adUnitId, final String adFormat, @Nullable final String placement, @Nullable final String customData, @Nullable final ReadableMap extraParameters, @Nullable final ReadableMap localExtraParameters, final Promise promise)
+    public void preloadNativeUIComponentAdView(final String adUnitId, final String adFormat, final boolean isAdaptive, @Nullable final String placement, @Nullable final String customData, @Nullable final ReadableMap extraParameters, @Nullable final ReadableMap localExtraParameters, final Promise promise)
     {
-        impl.preloadNativeUIComponentAdView( adUnitId, adFormat, placement, customData, extraParameters, localExtraParameters, promise );
+        impl.preloadNativeUIComponentAdView( adUnitId, adFormat, isAdaptive, placement, customData, extraParameters, localExtraParameters, promise );
     }
 
     @Override

--- a/android/src/oldarch/com/applovin/reactnative/AppLovinMAXModule.java
+++ b/android/src/oldarch/com/applovin/reactnative/AppLovinMAXModule.java
@@ -175,15 +175,15 @@ public class AppLovinMAXModule
     }
 
     @ReactMethod
-    public void createBanner(final String adUnitId, final String position)
+    public void createBanner(final String adUnitId, final String position, final boolean isAdaptive)
     {
-        impl.createBanner( adUnitId, position );
+        impl.createBanner( adUnitId, position, isAdaptive );
     }
 
     @ReactMethod
-    public void createBannerWithOffsets(final String adUnitId, final String position, final double xOffset, final double yOffset)
+    public void createBannerWithOffsets(final String adUnitId, final String position, final double xOffset, final double yOffset, final boolean isAdaptive)
     {
-        impl.createBannerWithOffsets( adUnitId, position, (float) xOffset, (float) yOffset );
+        impl.createBannerWithOffsets( adUnitId, position, (float) xOffset, (float) yOffset, isAdaptive );
     }
 
     @ReactMethod
@@ -427,9 +427,9 @@ public class AppLovinMAXModule
     }
 
     @ReactMethod
-    public void preloadNativeUIComponentAdView(final String adUnitId, final String adFormat, @Nullable final String placement, @Nullable final String customData, @Nullable final ReadableMap extraParameters, @Nullable final ReadableMap localExtraParameters, final Promise promise)
+    public void preloadNativeUIComponentAdView(final String adUnitId, final String adFormat, final boolean isAdaptive, @Nullable final String placement, @Nullable final String customData, @Nullable final ReadableMap extraParameters, @Nullable final ReadableMap localExtraParameters, final Promise promise)
     {
-        impl.preloadNativeUIComponentAdView( adUnitId, adFormat, placement, customData, extraParameters, localExtraParameters, promise );
+        impl.preloadNativeUIComponentAdView( adUnitId, adFormat, isAdaptive, placement, customData, extraParameters, localExtraParameters, promise );
     }
 
     @ReactMethod

--- a/ios/AppLovinMAX.mm
+++ b/ios/AppLovinMAX.mm
@@ -1395,7 +1395,7 @@ RCT_EXPORT_METHOD(destroyNativeUIComponentAdView:(double)adViewId
         }
         else if ( [@"adaptive_banner" isEqualToString: key] )
         {
-            [self log: @"Setting adaptive banners via extra parameters is discouraged. Please use the `BannerAd.createAd(adUnitId: string, position: AdViewPosition, xOffset: number, yOffset: number, isAdaptive: boolean)` API for proper adaptive banner configuration."];
+            [self log: @"Setting adaptive banners via extra parameters is deprecated and will be removed in a future plugin version. Please use the BannerAd.createAd(adUnitId: string, position: AdViewPosition, xOffset: number, yOffset: number, isAdaptive: boolean) API to properly configure adaptive banners."];
             
             BOOL shouldUseAdaptiveBanner = [NSNumber al_numberWithString: value].boolValue;
             if ( shouldUseAdaptiveBanner )
@@ -1569,12 +1569,12 @@ RCT_EXPORT_METHOD(destroyNativeUIComponentAdView:(double)adViewId
                 else
                 {
                     builder.adaptiveType = MAAdViewAdaptiveTypeNone;
-                    [self.disabledAdaptiveBannerAdUnitIdentifiers addObject:adUnitIdentifier];
+                    [self.disabledAdaptiveBannerAdUnitIdentifiers addObject: adUnitIdentifier];
                 }
             }
         }];
 
-        result = [[MAAdView alloc] initWithAdUnitIdentifier:adUnitIdentifier adFormat:adFormat configuration:config];
+        result = [[MAAdView alloc] initWithAdUnitIdentifier: adUnitIdentifier adFormat: adFormat configuration: config];
         result.delegate = self;
         result.revenueDelegate = self;
         result.userInteractionEnabled = NO;

--- a/ios/AppLovinMAX.mm
+++ b/ios/AppLovinMAX.mm
@@ -485,7 +485,7 @@ RCT_EXPORT_METHOD(trackEvent:(NSString *)event :(NSDictionary<NSString *, id> *)
 
 #pragma mark - Banners
 
-RCT_EXPORT_METHOD(createBanner:(NSString *)adUnitIdentifier position:(NSString *)bannerPosition)
+RCT_EXPORT_METHOD(createBanner:(NSString *)adUnitIdentifier position:(NSString *)bannerPosition isAdaptive:(BOOL)isAdaptive)
 {
     if ( !self.sdk )
     {
@@ -493,11 +493,11 @@ RCT_EXPORT_METHOD(createBanner:(NSString *)adUnitIdentifier position:(NSString *
         return;
     }
     
-    [self createAdViewWithAdUnitIdentifier: adUnitIdentifier adFormat: DEVICE_SPECIFIC_ADVIEW_AD_FORMAT atPosition: bannerPosition withOffset: CGPointZero];
+    [self createAdViewWithAdUnitIdentifier: adUnitIdentifier adFormat: DEVICE_SPECIFIC_ADVIEW_AD_FORMAT atPosition: bannerPosition withOffset: CGPointZero isAdaptive: isAdaptive];
 }
 
 // NOTE: No function overloading in JS so we need new method signature
-RCT_EXPORT_METHOD(createBannerWithOffsets:(NSString *)adUnitIdentifier position:(NSString *)bannerPosition xOffset:(double)xOffset yOffset:(double)yOffset)
+RCT_EXPORT_METHOD(createBannerWithOffsets:(NSString *)adUnitIdentifier position:(NSString *)bannerPosition xOffset:(double)xOffset yOffset:(double)yOffset isAdaptive:(BOOL)isAdaptive)
 {
     if ( !self.sdk )
     {
@@ -505,7 +505,7 @@ RCT_EXPORT_METHOD(createBannerWithOffsets:(NSString *)adUnitIdentifier position:
         return;
     }
     
-    [self createAdViewWithAdUnitIdentifier: adUnitIdentifier adFormat: DEVICE_SPECIFIC_ADVIEW_AD_FORMAT atPosition: bannerPosition withOffset: CGPointMake(xOffset, yOffset)];
+    [self createAdViewWithAdUnitIdentifier: adUnitIdentifier adFormat: DEVICE_SPECIFIC_ADVIEW_AD_FORMAT atPosition: bannerPosition withOffset: CGPointMake(xOffset, yOffset) isAdaptive: isAdaptive];
 }
 
 RCT_EXPORT_METHOD(setBannerBackgroundColor:(NSString *)adUnitIdentifier hexColorCode:(NSString *)hexColorCode)
@@ -664,7 +664,7 @@ RCT_EXPORT_METHOD(createMRec:(NSString *)adUnitIdentifier position:(NSString *)m
         return;
     }
     
-    [self createAdViewWithAdUnitIdentifier: adUnitIdentifier adFormat: MAAdFormat.mrec atPosition: mrecPosition withOffset: CGPointZero];
+    [self createAdViewWithAdUnitIdentifier: adUnitIdentifier adFormat: MAAdFormat.mrec atPosition: mrecPosition withOffset: CGPointZero isAdaptive: NO];
 }
 
 RCT_EXPORT_METHOD(setMRecPlacement:(NSString *)adUnitIdentifier placement:(nullable NSString *)placement)
@@ -956,6 +956,7 @@ RCT_EXPORT_METHOD(setAppOpenAdLocalExtraParameter:(NSString *)adUnitIdentifier p
 
 RCT_EXPORT_METHOD(preloadNativeUIComponentAdView:(NSString *)adUnitIdentifier
                   adFormat:(NSString *)adFormatStr
+                  isAdaptive:(BOOL)isAdaptive
                   placement:(nullable NSString *)placement
                   customData:(nullable NSString *)customData
                   extraParameters:(nullable NSDictionary<NSString *, id> *)extraParameterDict
@@ -981,6 +982,7 @@ RCT_EXPORT_METHOD(preloadNativeUIComponentAdView:(NSString *)adUnitIdentifier
     
     [AppLovinMAXAdView preloadNativeUIComponentAdView: adUnitIdentifier
                                              adFormat: adFormat
+                                           isAdaptive: isAdaptive
                                             placement: placement
                                            customData: customData
                                       extraParameters: extraParameterDict
@@ -1268,14 +1270,14 @@ RCT_EXPORT_METHOD(destroyNativeUIComponentAdView:(double)adViewId
 
 #pragma mark - Internal Methods
 
-- (void)createAdViewWithAdUnitIdentifier:(NSString *)adUnitIdentifier adFormat:(MAAdFormat *)adFormat atPosition:(NSString *)adViewPosition withOffset:(CGPoint)offset
+- (void)createAdViewWithAdUnitIdentifier:(NSString *)adUnitIdentifier adFormat:(MAAdFormat *)adFormat atPosition:(NSString *)adViewPosition withOffset:(CGPoint)offset isAdaptive:(BOOL)isAdaptive
 {
     dispatch_async(dispatch_get_main_queue(), ^{
         
         [self log: @"Creating %@ with ad unit identifier \"%@\", position: \"%@\", and offset: %@", adFormat, adUnitIdentifier, adViewPosition, NSStringFromCGPoint(offset)];
         
         // Retrieve ad view from the map
-        MAAdView *adView = [self retrieveAdViewForAdUnitIdentifier: adUnitIdentifier adFormat: adFormat atPosition: adViewPosition withOffset: offset];
+        MAAdView *adView = [self retrieveAdViewForAdUnitIdentifier: adUnitIdentifier adFormat: adFormat atPosition: adViewPosition withOffset: offset isAdaptive: isAdaptive];
         adView.hidden = YES;
         self.safeAreaBackground.hidden = YES;
         
@@ -1323,7 +1325,7 @@ RCT_EXPORT_METHOD(destroyNativeUIComponentAdView:(double)adViewId
         
         [self log: @"Setting placement \"%@\" for \"%@\" with ad unit identifier \"%@\"", placement, adFormat, adUnitIdentifier];
         
-        MAAdView *adView = [self retrieveAdViewForAdUnitIdentifier: adUnitIdentifier adFormat: adFormat atPosition: @"" withOffset: CGPointZero];
+        MAAdView *adView = [self retrieveAdViewForAdUnitIdentifier: adUnitIdentifier adFormat: adFormat atPosition: @"" withOffset: CGPointZero isAdaptive: YES];
         adView.placement = placement;
     });
 }
@@ -1334,7 +1336,7 @@ RCT_EXPORT_METHOD(destroyNativeUIComponentAdView:(double)adViewId
         
         [self log: @"Setting custom data \"%@\" for \"%@\" with ad unit identifier \"%@\"", customData, adFormat, adUnitIdentifier];
         
-        MAAdView *adView = [self retrieveAdViewForAdUnitIdentifier: adUnitIdentifier adFormat: adFormat atPosition: @"" withOffset: CGPointZero];
+        MAAdView *adView = [self retrieveAdViewForAdUnitIdentifier: adUnitIdentifier adFormat: adFormat atPosition: @"" withOffset: CGPointZero isAdaptive: YES];
         adView.customData = customData;
     });
 }
@@ -1393,6 +1395,8 @@ RCT_EXPORT_METHOD(destroyNativeUIComponentAdView:(double)adViewId
         }
         else if ( [@"adaptive_banner" isEqualToString: key] )
         {
+            [self log: @"Setting adaptive banners via extra parameters is discouraged. Please use the `BannerAd.createAd(adUnitId: string, position: AdViewPosition, xOffset: number, yOffset: number, isAdaptive: boolean)` API for proper adaptive banner configuration."];
+            
             BOOL shouldUseAdaptiveBanner = [NSNumber al_numberWithString: value].boolValue;
             if ( shouldUseAdaptiveBanner )
             {
@@ -1545,15 +1549,32 @@ RCT_EXPORT_METHOD(destroyNativeUIComponentAdView:(double)adViewId
 
 - (MAAdView *)retrieveAdViewForAdUnitIdentifier:(NSString *)adUnitIdentifier adFormat:(MAAdFormat *)adFormat
 {
-    return [self retrieveAdViewForAdUnitIdentifier: adUnitIdentifier adFormat: adFormat atPosition: nil withOffset: CGPointZero];
+    return [self retrieveAdViewForAdUnitIdentifier: adUnitIdentifier adFormat: adFormat atPosition: nil withOffset: CGPointZero isAdaptive: YES];
 }
 
-- (MAAdView *)retrieveAdViewForAdUnitIdentifier:(NSString *)adUnitIdentifier adFormat:(MAAdFormat *)adFormat atPosition:(NSString *)adViewPosition withOffset:(CGPoint)offset
+- (MAAdView *)retrieveAdViewForAdUnitIdentifier:(NSString *)adUnitIdentifier adFormat:(MAAdFormat *)adFormat atPosition:(NSString *)adViewPosition withOffset:(CGPoint)offset isAdaptive:(BOOL)isAdaptive
 {
     MAAdView *result = self.adViews[adUnitIdentifier];
     if ( !result && adViewPosition )
     {
-        result = [[MAAdView alloc] initWithAdUnitIdentifier: adUnitIdentifier adFormat: adFormat sdk: self.sdk];
+        MAAdViewConfiguration *config = [MAAdViewConfiguration configurationWithBuilderBlock:^(MAAdViewConfigurationBuilder *builder) {
+
+            // Set adaptive type only for banner ads. If adaptive is enabled, use ANCHORED; otherwise, fall back to NONE.
+            if ( [adFormat isBannerOrLeaderAd] )
+            {
+                if ( isAdaptive )
+                {
+                    builder.adaptiveType = MAAdViewAdaptiveTypeAnchored;
+                }
+                else
+                {
+                    builder.adaptiveType = MAAdViewAdaptiveTypeNone;
+                    [self.disabledAdaptiveBannerAdUnitIdentifiers addObject:adUnitIdentifier];
+                }
+            }
+        }];
+
+        result = [[MAAdView alloc] initWithAdUnitIdentifier:adUnitIdentifier adFormat:adFormat configuration:config];
         result.delegate = self;
         result.revenueDelegate = self;
         result.userInteractionEnabled = NO;

--- a/ios/AppLovinMAXAdView.h
+++ b/ios/AppLovinMAXAdView.h
@@ -32,6 +32,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (void)preloadNativeUIComponentAdView:(NSString *)adUnitIdentifier 
                               adFormat:(MAAdFormat *)adFormat
+                            isAdaptive:(BOOL)isAdaptive
                              placement:(nullable NSString *)placement
                             customData:(nullable NSString *)customData
                        extraParameters:(nullable NSDictionary<NSString *, id> *)extraParameters

--- a/ios/AppLovinMAXAdView.mm
+++ b/ios/AppLovinMAXAdView.mm
@@ -87,6 +87,7 @@ static NSMutableDictionary<NSNumber *, AppLovinMAXAdViewUIComponent *> *preloade
 
 + (void)preloadNativeUIComponentAdView:(NSString *)adUnitIdentifier
                               adFormat:(MAAdFormat *)adFormat
+                            isAdaptive:(BOOL)isAdaptive
                              placement:(nullable NSString *)placement
                             customData:(nullable NSString *)customData
                        extraParameters:(nullable NSDictionary<NSString *, id> *)extraParameters
@@ -94,7 +95,7 @@ static NSMutableDictionary<NSNumber *, AppLovinMAXAdViewUIComponent *> *preloade
                    withPromiseResolver:(RCTPromiseResolveBlock)resolve
                    withPromiseRejecter:(RCTPromiseRejectBlock)reject
 {
-    AppLovinMAXAdViewUIComponent *preloadedUIComponent = [[AppLovinMAXAdViewUIComponent alloc] initWithAdUnitIdentifier: adUnitIdentifier adFormat: adFormat];
+    AppLovinMAXAdViewUIComponent *preloadedUIComponent = [[AppLovinMAXAdViewUIComponent alloc] initWithAdUnitIdentifier: adUnitIdentifier adFormat: adFormat isAdaptive: isAdaptive];
     preloadedUIComponentInstances[@(preloadedUIComponent.hash)] = preloadedUIComponent;
     
     preloadedUIComponent.placement = placement;
@@ -548,11 +549,6 @@ static NSMutableDictionary<NSNumber *, AppLovinMAXAdViewUIComponent *> *preloade
 - (void)setAdaptiveBannerEnabled:(BOOL)adaptiveBannerEnabled
 {
     _adaptiveBannerEnabled = adaptiveBannerEnabled;
-    
-    if ( self.uiComponent )
-    {
-        self.uiComponent.adaptiveBannerEnabled = adaptiveBannerEnabled;
-    }
 }
 
 - (void)setAutoRefresh:(BOOL)autoRefresh
@@ -640,14 +636,13 @@ static NSMutableDictionary<NSNumber *, AppLovinMAXAdViewUIComponent *> *preloade
             {
                 [[AppLovinMAX shared] log: @"Mounting the preloaded AdView (%@) for Ad Unit ID %@", self.adViewId, self.adUnitId];
                 
-                self.uiComponent.adaptiveBannerEnabled = [self isAdaptiveBannerEnabled];
                 self.uiComponent.autoRefreshEnabled = [self isAutoRefreshEnabled];
                 [self.uiComponent attachAdView: self];
                 return;
             }
         }
         
-        self.uiComponent = [[AppLovinMAXAdViewUIComponent alloc] initWithAdUnitIdentifier: adUnitId adFormat: adFormat];
+        self.uiComponent = [[AppLovinMAXAdViewUIComponent alloc] initWithAdUnitIdentifier: adUnitId adFormat: adFormat isAdaptive: [self isAdaptiveBannerEnabled]];
         self.adViewId = @(self.uiComponent.hash);
         uiComponentInstances[self.adViewId] = self.uiComponent;
         
@@ -677,7 +672,6 @@ static NSMutableDictionary<NSNumber *, AppLovinMAXAdViewUIComponent *> *preloade
         self.uiComponent.customData = self.customData;
         self.uiComponent.extraParameters = flattenedExtraParameters;
         self.uiComponent.localExtraParameters = flattenedLocalExtraParameters;
-        self.uiComponent.adaptiveBannerEnabled = [self isAdaptiveBannerEnabled];
         self.uiComponent.autoRefreshEnabled = [self isAutoRefreshEnabled];
         
         [self.uiComponent attachAdView: self];

--- a/ios/AppLovinMAXAdViewUIComponent.h
+++ b/ios/AppLovinMAXAdViewUIComponent.h
@@ -14,7 +14,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSString *customData;
 @property (nonatomic, copy, nullable) NSDictionary<NSString *, id> *extraParameters;
 @property (nonatomic, copy, nullable) NSDictionary<NSString *, id> *localExtraParameters;
-@property (nonatomic, assign, getter=isAdaptiveBannerEnabled) BOOL adaptiveBannerEnabled;
 @property (nonatomic, assign, getter=isAutoRefreshEnabled) BOOL autoRefreshEnabled;
 
 - (void)loadAd;
@@ -22,7 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)detachAdView;
 - (void)destroy;
 
-- (instancetype)initWithAdUnitIdentifier:(NSString *)adUnitIdentifier adFormat:(MAAdFormat *)adFormat;
+- (instancetype)initWithAdUnitIdentifier:(NSString *)adUnitIdentifier adFormat:(MAAdFormat *)adFormat isAdaptive:(BOOL)isAdaptive;
 
 @end
 

--- a/ios/AppLovinMAXAdViewUIComponent.mm
+++ b/ios/AppLovinMAXAdViewUIComponent.mm
@@ -13,17 +13,30 @@
 
 @implementation AppLovinMAXAdViewUIComponent
 
-- (instancetype)initWithAdUnitIdentifier:(NSString *)adUnitIdentifier adFormat:(MAAdFormat *)adFormat
+- (instancetype)initWithAdUnitIdentifier:(NSString *)adUnitIdentifier adFormat:(MAAdFormat *)adFormat isAdaptive:(BOOL)isAdaptive
 {
     self = [super init];
     if ( self )
     {
-        self.adView = [[MAAdView alloc] initWithAdUnitIdentifier: adUnitIdentifier adFormat: adFormat sdk: [AppLovinMAX shared].sdk];
+        MAAdViewConfiguration *config = [MAAdViewConfiguration configurationWithBuilderBlock:^(MAAdViewConfigurationBuilder *builder) {
+
+            if ( [adFormat isBannerOrLeaderAd] )
+            {
+                if ( isAdaptive )
+                {
+                    builder.adaptiveType = MAAdViewAdaptiveTypeAnchored;
+                }
+                else
+                {
+                    builder.adaptiveType = MAAdViewAdaptiveTypeNone;
+                }
+            }
+        }];
+
+        self.adView = [[MAAdView alloc] initWithAdUnitIdentifier: adUnitIdentifier adFormat: adFormat configuration: config];
         self.adView.delegate = self;
         self.adView.revenueDelegate = self;
-        
-        [self.adView setExtraParameterForKey: @"adaptive_banner" value: @"true"];
-        
+                
         // Set this extra parameter to work around a SDK bug that ignores calls to stopAutoRefresh()
         [self.adView setExtraParameterForKey: @"allow_pause_auto_refresh_immediately" value: @"true"];
         
@@ -48,11 +61,6 @@
 - (void)setCustomData:(nullable NSString *)customData
 {
     self.adView.customData = customData;
-}
-
-- (void)setAdaptiveBannerEnabled:(BOOL)adaptiveBannerEnabled
-{
-    [self.adView setExtraParameterForKey: @"adaptive_banner" value: adaptiveBannerEnabled ? @"true" : @"false"];
 }
 
 - (void)setAutoRefreshEnabled:(BOOL)autoRefresh

--- a/src/AdView.tsx
+++ b/src/AdView.tsx
@@ -239,8 +239,8 @@ export const AdView = forwardRef<AdViewHandler, AdViewProps & ViewProps>(functio
  * @throws An error if the preload request fails.
  */
 export const preloadNativeUIComponentAdView = async (adUnitId: string, adFormat: AdFormat, options: NativeUIComponentAdViewOptions = {}): Promise<AdViewId> => {
-    const { placement = null, customData = null, extraParameters = {}, localExtraParameters = {} } = options;
-    return AppLovinMAX.preloadNativeUIComponentAdView(adUnitId, adFormat, placement, customData, extraParameters, localExtraParameters);
+    const { isAdaptive = true, placement = null, customData = null, extraParameters = {}, localExtraParameters = {} } = options;
+    return AppLovinMAX.preloadNativeUIComponentAdView(adUnitId, adFormat, isAdaptive, placement, customData, extraParameters, localExtraParameters);
 };
 
 /**

--- a/src/BannerAd.ts
+++ b/src/BannerAd.ts
@@ -14,9 +14,8 @@ const {
     ON_BANNER_AD_REVENUE_PAID,
 } = AppLovinMAX.getConstants();
 
-const createAd = (adUnitId: string, position: AdViewPosition, xOffset: number = 0, yOffset: number = 0): void => {
-    AppLovinMAX.createBannerWithOffsets(adUnitId, position, xOffset, yOffset);
-    AppLovinMAX.setBannerExtraParameter(adUnitId, 'adaptive_banner', 'true');
+const createAd = (adUnitId: string, position: AdViewPosition, xOffset: number = 0, yOffset: number = 0, isAdaptive: boolean = true): void => {
+    AppLovinMAX.createBannerWithOffsets(adUnitId, position, xOffset, yOffset, isAdaptive);
 };
 
 const destroyAd = (adUnitId: string): void => {

--- a/src/specs/NativeAppLovinMAXModule.ts
+++ b/src/specs/NativeAppLovinMAXModule.ts
@@ -136,8 +136,8 @@ export interface Spec extends TurboModule {
     // Banner Ads
     // ─────────────────────────────────────────────────────────
 
-    createBanner(adUnitId: string, position: string): void;
-    createBannerWithOffsets(adUnitId: string, position: string, xOffset: number, yOffset: number): void;
+    createBanner(adUnitId: string, position: string, isAdaptive: boolean): void;
+    createBannerWithOffsets(adUnitId: string, position: string, xOffset: number, yOffset: number, isAdaptive: boolean): void;
     setBannerBackgroundColor(adUnitId: string, hexColorCode: string): void;
     setBannerPlacement(adUnitId: string, placement: string | null): void;
     setBannerCustomData(adUnitId: string, customData: string | null): void;
@@ -206,6 +206,7 @@ export interface Spec extends TurboModule {
     preloadNativeUIComponentAdView(
         adUnitId: string,
         adFormat: string,
+        isAdaptive: boolean,
         placement?: string | null,
         customData?: string | null,
         extraParameters?: UnsafeObject | null,

--- a/src/types/AdViewProps.ts
+++ b/src/types/AdViewProps.ts
@@ -73,6 +73,11 @@ export type AdViewProps = AdProps & {
  */
 export type NativeUIComponentAdViewOptions = {
     /**
+     * Whether adaptive banner sizing is enabled. Defaults to `true`.
+     */
+    isAdaptive?: boolean;
+
+    /**
      * The placement name used for analytics and reporting.
      */
     placement?: string | null;

--- a/src/types/BannerAd.ts
+++ b/src/types/BannerAd.ts
@@ -13,8 +13,9 @@ export type BannerAdType = ViewAdType & {
      * @param position - The position of the banner on screen.
      * @param xOffset - Optional horizontal offset from the left (default: 0).
      * @param yOffset - Optional vertical offset from the top (default: 0).
+     * @param isAdaptive - Optional flag to enable adaptive banners (default: true).
      */
-    createAd(adUnitId: string, position: AdViewPosition, xOffset?: number, yOffset?: number): void;
+    createAd(adUnitId: string, position: AdViewPosition, xOffset?: number, yOffset?: number, isAdaptive?: boolean): void;
 
     /**
      * Sets the background color of the banner.


### PR DESCRIPTION
Use MAX AdView configuration for adaptive banners.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add an optional `isAdaptive` flag to the `BannerAd.createAd()` and `preloadNativeUIComponentAdView()` methods to enable adaptive banner functionality, with adaptive banners enabled by default.

### Why are these changes being made?

This change introduces flexibility in configuring adaptive banners, allowing developers to choose whether or not to enable adaptive sizing for their ad views, optimizing display according to their needs. The inclusion of an `isAdaptive` flag and restructuring the configuration ensures integration simplicity and addresses previous limitations related to setting adaptive banners via extra parameters.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->