### PR TITLE
feat/update_support_site_links

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -59,7 +59,7 @@ body:
     attributes:
       label: "Additional Info"
       description: |
-        - If applicable, include any info to provide further context, such as images, videos, or logs after [enabling verbose logging](https://developers.applovin.com/en/max/react-native/overview/advanced-settings#enable-verbose-logging).
+        - If applicable, include any info to provide further context, such as images, videos, or logs after [enabling verbose logging](https://support.axon.ai/en/max/react-native/overview/advanced-settings#enable-verbose-logging).
         - If you don't want to post media publicly, please submit your file(s) in a [support request](https://support.applovin.com/hc/en-us/requests/new) with subject 'Issue #<ISSUE_NUMBER>: <ISSUE_LINK>' after filing this issue with a note saying you will do so here.
       placeholder: "Tip: Attach files by clicking this area and dragging files in"
     validations:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: true
 contact_links:
   - name: Documentation
-    url: https://developers.applovin.com/en/max/react-native/overview/integration
+    url: https://support.axon.ai/en/max/react-native/overview/integration
     about: Documentation for the AppLovin MAX React Native Module
   - name: Support
-    url: https://developers.applovin.comhttps://developers.applovin.com/en/max/faq/common-questions-from-publishers
+    url: https://support.axon.ai/en/max/faq/common-questions-from-publishers
     about: Answers to common questions and support for AppLovin MAX

--- a/.github/ISSUE_TEMPLATE/crash_anr_report.yaml
+++ b/.github/ISSUE_TEMPLATE/crash_anr_report.yaml
@@ -70,7 +70,7 @@ body:
     attributes:
       label: "Additional Info"
       description: |
-        - If applicable, include any info to provide further context, such as images, videos, or logs after [enabling verbose logging](https://developers.applovin.com/en/max/react-native/overview/advanced-settings#enable-verbose-logging).
+        - If applicable, include any info to provide further context, such as images, videos, or logs after [enabling verbose logging](https://support.axon.ai/en/max/react-native/overview/advanced-settings#enable-verbose-logging).
         - If you don't want to post media publicly, please submit your file(s) in a [support request](https://support.applovin.com/hc/en-us/requests/new) with subject 'Issue #<ISSUE_NUMBER>: <ISSUE_LINK>' after filing this issue with a note saying you will do so here.
       placeholder: "Tip: Attach files by clicking this area and dragging files in"
     validations:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@
 ## 8.0.4
 * Update IconView to support native ad icon image view, primarily for BigoAds native ads.
 ## 8.0.3
-* Remove deprecated Terms Flow API `AppLovinMAX.setConsentFlowEnabled()`. Check out our docs for integrating our latest [MAX Terms and Privacy Policy Consent Flow](https://developers.applovin.com/en/max/react-native/overview/terms-and-privacy-policy-flow/).
+* Remove deprecated Terms Flow API `AppLovinMAX.setConsentFlowEnabled()`. Check out our docs for integrating our latest [MAX Terms and Privacy Policy Consent Flow](https://support.axon.ai/en/max/react-native/overview/terms-and-privacy-policy-flow/).
 ## 8.0.2
 * Crash if plugin version is incompatible with native SDK version.
 ## 8.0.1
@@ -48,17 +48,17 @@
 ## 8.0.0
 * Depend on Android SDK 13.0.0 and iOS SDK 13.0.0.
 * Removed COPPA support.
-* Add constants for MAX Error Codes. For more info, check out our [docs](https://developers.applovin.com/en/max/react-native/overview/error-handling#max-error-codes).
+* Add constants for MAX Error Codes. For more info, check out our [docs](https://support.axon.ai/en/max/react-native/overview/error-handling#max-error-codes).
 ## 7.1.1
 * Depend on Android SDK 12.6.1 and iOS SDK 12.6.1.
 * Fix BidMachine media view not clickable on Android.
 ## 7.1.0
-* Replace targeting data APIs with new numeric segments targeting APIs. For migration instructions, please see [here](https://developers.applovin.com/en/react-native/overview/data-and-keyword-passing/#segment-targeting).
+* Replace targeting data APIs with new numeric segments targeting APIs. For migration instructions, please see [here](https://support.axon.ai/en/max/react-native/overview/data-and-keyword-passing#segment-targeting).
 * Depend on Android SDK 12.6.0 and iOS SDK 12.6.0.
 ## 7.0.1
 * Fix native UI component banners and MRECs (`<AdView/>`) not calling the `onAdLoaded` and `onAdLoadFailed` callbacks on Android. Regression from v7.0.0. (https://github.com/AppLovin/AppLovin-MAX-React-Native/issues/354)
 ## 7.0.0
-* Add APIs for preloading native UI component banners and MRECs. For more info, check out our [docs](https://developers.applovin.com/en/react-native/ad-formats/banner-and-mrec-ads#preloading-native-ui-component).
+* Add APIs for preloading native UI component banners and MRECs. For more info, check out our [docs](https://support.axon.ai/en/max/react-native/ad-formats/banner-and-mrec-ads#ad-preloading).
 * Fix native ads rendering multiple times after updating all the asset views.
 * Improve loading time for `<AdView/>`.
 * Upgrade the build platform to support React Native 0.7x.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 AppLovin MAX React Native Module for Android and iOS.
 
 ## Documentation
-Check out our integration docs [here](https://developers.applovin.com/en/react-native/overview/integration).
+Check out our integration docs [here](https://support.axon.ai/en/max/react-native/overview/integration).
 
 ## Demo Apps
 The `/example` directory contains the demo app. Gradle and CocoaPods automatically pulls in the React Native module for easier debugging.


### PR DESCRIPTION
Update support site links to `support.axon.ai`.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Update all documentation and issue templates to point to the new support site (support.axon.ai) instead of developers.applovin.com, including bug report, crash/anr report templates, config links, changelog, and README.

### Why are these changes being made?
Direct users to the correct support resources and keep references consistent with the relocated documentation. If there were any gaps in template corrections, they are addressed by ensuring all relevant links reflect the new domain.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->