### PR TITLE
Fix native ad loading twice on Android with new architecture

### DIFF
--- a/android/src/main/java/com/applovin/reactnative/AppLovinMAXNativeAdView.java
+++ b/android/src/main/java/com/applovin/reactnative/AppLovinMAXNativeAdView.java
@@ -96,6 +96,13 @@ public class AppLovinMAXNativeAdView
     {
         if ( TextUtils.isEmpty( value ) ) return;
 
+        // Guard against re-triggering ad load when adUnitId prop is re-applied without changing value.
+        // In the new architecture, Fabric may call prop setters on every render cycle even when values
+        // haven't changed (unlike old arch where @ReactProp only fires on actual value changes).
+        // Without this check, a style/layout update on the parent causes setAdUnitId to reset
+        // isAdUnitIdSet = true, and the next onAfterUpdateTransaction triggers a second loadAd().
+        if ( value.equals( adUnitId ) ) return;
+
         adUnitId = value;
 
         isAdUnitIdSet.set( true );


### PR DESCRIPTION
## Summary

Fixes #441

In the **new architecture (Fabric)**, prop setters can be called on every render cycle even when values haven't changed — unlike the old architecture where `@ReactProp` only fires on actual value changes.

**Root cause:** When a parent component re-renders after the ad loads (e.g. `style={{opacity: hasAd ? 1 : 0}}` toggled in `onAdLoaded`), Fabric re-applies all props to the native view including `adUnitId`. This resets `isAdUnitIdSet = true`, and the next `onAfterUpdateTransaction` triggers a second `loadAd()` — causing `onAdLoaded` to fire twice and two different ads to appear in sequence.

**Why iOS doesn't have this problem:** The iOS new arch path in `updateProps:` already guards against this:
```objc
if ( oldViewProps.adUnitId != newViewProps.adUnitId )
{
    [self setAdUnitId: RCTNSStringFromString(newViewProps.adUnitId)];
}
```

**Fix:** Mirror the same guard on Android — early return in `setAdUnitId` when the value equals the already-set `adUnitId`:
```java
if ( value.equals( adUnitId ) ) return;
```

## Test plan

- [ ] Enable new architecture (`newArchEnabled=true` in `gradle.properties`)
- [ ] Load a native ad
- [ ] In `onAdLoaded`, update a style prop on the `NativeAdView` (e.g. toggle opacity from 0 to 1)
- [ ] Confirm `onAdLoaded` fires only **once** and no second ad load occurs
- [ ] Confirm behavior is unchanged with `newArchEnabled=false`